### PR TITLE
Set redirect url based on the request url not hard coded to localhost

### DIFF
--- a/app/controllers/idam.ts
+++ b/app/controllers/idam.ts
@@ -1,6 +1,7 @@
 import idamExpressMiddleware from '@hmcts/div-idam-express-middleware';
 import config from 'config';
 import { Router } from 'express';
+import { getRedirectUrl } from '../utils/url-utils';
 
 function setupIdamController(): Router {
   const idamArgs = {
@@ -18,7 +19,11 @@ function setupIdamController(): Router {
     res.redirect('/');
   });
   router.use(idamExpressMiddleware.userDetails(idamArgs));
-  router.use('/login', idamExpressMiddleware.authenticate(idamArgs));
+  router.use('/login', (req, res, next) => {
+    const loginIdamArgs = idamArgs;
+    loginIdamArgs.redirectUri = getRedirectUrl(req);
+    return idamExpressMiddleware.authenticate(idamArgs)(req, res, next);
+  });
   router.get('/start', (req, res) => {
     res.end(`<p>This will be the start page </p><a href='/login'>Login</a>`);
   });

--- a/app/utils/url-utils.ts
+++ b/app/utils/url-utils.ts
@@ -1,0 +1,13 @@
+import config from 'config';
+import { Request } from 'express';
+
+const appPort = config.get('node.port');
+
+function getUrl(protocol: string, host: string, path: string): string {
+  const portString = (host === 'localhost') ? ':' + appPort : '';
+  return protocol + '://' + host + portString + path;
+}
+
+export function getRedirectUrl(req: Request): string {
+  return getUrl(req.protocol, req.hostname, '/redirectUrl');
+}

--- a/test/unit/utils/url-utils.test.ts
+++ b/test/unit/utils/url-utils.test.ts
@@ -1,0 +1,28 @@
+import { Request } from 'express';
+import { getRedirectUrl } from '../../../app/utils/url-utils';
+
+import { expect } from '../../utils/testUtils';
+
+describe('creates url', () => {
+  it('not for localhost', () => {
+    const req = {
+      protocol: 'http',
+      hostname: 'example.com'
+    } as Partial<Request>;
+
+    const redirectUrl = getRedirectUrl(req as Request);
+
+    expect(redirectUrl).eq('http://example.com/redirectUrl');
+  });
+
+  it('for localhost', () => {
+    const req = {
+      protocol: 'http',
+      hostname: 'localhost'
+    } as Partial<Request>;
+
+    const redirectUrl = getRedirectUrl(req as Request);
+
+    expect(redirectUrl).eq('http://localhost:3000/redirectUrl');
+  });
+});


### PR DESCRIPTION
When you were redirect back from idam on any environment other than localhost the redirect was not working. This was because it was hardcoded to https://localhost:3000/redirectUrl. It needs to be built from the protocol and host in the request to allow for all the different urls we use in an environment.