### PR TITLE
RIA-1963 &  RIA-1965 : ContactDetails & Appeal Submission to CCD

### DIFF
--- a/app/controllers/contact-details.ts
+++ b/app/controllers/contact-details.ts
@@ -1,50 +1,69 @@
 import { NextFunction, Request, Response, Router } from 'express';
 import { paths } from '../paths';
+import { Events } from '../service/ccd-service';
+import UpdateAppealService from '../service/update-appeal-service';
 import { contactDetailsValidation } from '../utils/fields-validations';
 
 function getContactDetails(req: Request, res: Response, next: NextFunction) {
   try {
     const { application } = req.session.appeal;
-    const { email, phone } = application && application.contactDetails || null;
-    return res.render('appeal-application/contact-details.njk', { email, phone });
+    const contactDetails = application && application.contactDetails || null;
+    return res.render('appeal-application/contact-details.njk', { contactDetails });
   } catch (error) {
     next(error);
   }
 }
 
-function postContactDetails(req: Request, res: Response, next: NextFunction) {
-  try {
-    const validation = contactDetailsValidation(req.body);
-    const { email, phone } = req.session.appeal.application.contactDetails || null;
+function postContactDetails(updateAppealService: UpdateAppealService) {
+  return async (req: Request, res: Response, next: NextFunction) => {
+    try {
+      const validation = contactDetailsValidation(req.body);
 
-    if (validation) {
-      return res.render('appeal-application/contact-details.njk', {
-        email,
-        phone,
-        errors: validation,
-        errorList: Object.values(validation)
-      });
+      const selections = req.body['selections'] || [];
 
+      let email = null;
+      let wantsEmail = false;
+      let phone = null;
+      let wantsSms = false;
+
+      if (selections.includes('email')) {
+        email = req.body['email-value'];
+        if (email) {
+          wantsEmail = true;
+        }
+      }
+      if (selections.includes('text-message')) {
+        phone = req.body['text-message-value'];
+        if (phone) {
+          wantsSms = true;
+        }
+      }
+
+      const contactDetails = { email, wantsEmail, phone, wantsSms };
+
+      if (validation) {
+        return res.render('appeal-application/contact-details.njk', {
+          contactDetails,
+          errors: validation,
+          errorList: Object.values(validation)
+        });
+      }
+
+      req.session.appeal.application.contactDetails = contactDetails;
+      await updateAppealService.submitEvent(Events.EDIT_APPEAL, req);
+
+      return res.redirect(paths.taskList);
+    } catch
+      (error) {
+      next(error);
     }
-    // TODO: Saving data in session for now should save to CCD once implementation is finished
-    // as both buttons save-and-continue and save-for-later do the same thing we store the data and re-direct to task list
-
-    req.session.appeal.application.contactDetails = {
-      ...req.session.appeal.application.contactDetails,
-      email: req.body['email-value'],
-      phone: req.body['text-message-value']
-    };
-    return res.redirect(paths.taskList);
-  } catch
-    (error) {
-    next(error);
-  }
+  };
 }
 
-function setupContactDetailsController(): Router {
+function setupContactDetailsController(updateAppealService: UpdateAppealService): Router {
   const router = Router();
   router.get(paths.contactDetails, getContactDetails);
-  router.post(paths.contactDetails, postContactDetails);
+  router.post(paths.contactDetails, postContactDetails(updateAppealService));
   return router;
 }
 

--- a/app/controllers/home-office-details.ts
+++ b/app/controllers/home-office-details.ts
@@ -3,6 +3,7 @@ import moment from 'moment';
 import multer from 'multer';
 import i18n from '../../locale/en.json';
 import { paths } from '../paths';
+import { Events } from '../service/ccd-service';
 import UpdateAppealService from '../service/update-appeal-service';
 import { dateLetterSentValidation, homeOfficeNumberValidation, textAreaValidation } from '../utils/fields-validations';
 
@@ -27,7 +28,7 @@ function postHomeOfficeDetails(updateAppealService: UpdateAppealService) {
           }
         );
       }
-      await updateAppealService.updateAppeal(req);
+      await updateAppealService.submitEvent(Events.EDIT_APPEAL, req);
       req.session.appeal.application.homeOfficeRefNumber = req.body.homeOfficeRefNumber;
       return res.redirect(paths.homeOffice.letterSent);
     } catch (e) {
@@ -73,7 +74,7 @@ function postDateLetterSent(updateAppealService: UpdateAppealService) {
         year
       };
 
-      await updateAppealService.updateAppeal(req);
+      await updateAppealService.submitEvent(Events.EDIT_APPEAL, req);
 
       if (diffInDays <= 14) {
         req.session.appeal.application.isAppealLate = false;

--- a/app/controllers/personal-details.ts
+++ b/app/controllers/personal-details.ts
@@ -3,6 +3,7 @@ import { NextFunction, Request, Response, Router } from 'express';
 import * as _ from 'lodash';
 import { countryList } from '../data/country-list';
 import { paths } from '../paths';
+import { Events } from '../service/ccd-service';
 import UpdateAppealService from '../service/update-appeal-service';
 import { getAddress } from '../utils/address-utils';
 import {
@@ -50,7 +51,7 @@ function postDateOfBirth(updateAppealService: UpdateAppealService) {
         }
       };
 
-      await updateAppealService.updateAppeal(req);
+      await updateAppealService.submitEvent(Events.EDIT_APPEAL, req);
 
       return res.redirect(paths.personalDetails.nationality);
     } catch (e) {
@@ -89,7 +90,7 @@ function postNamePage(updateAppealService: UpdateAppealService) {
         givenNames: req.body.givenNames
       };
 
-      await updateAppealService.updateAppeal(req);
+      await updateAppealService.submitEvent(Events.EDIT_APPEAL, req);
 
       return res.redirect(paths.personalDetails.dob);
     } catch (e) {
@@ -262,7 +263,7 @@ function postManualEnterAddressPage(updateAppealService: UpdateAppealService) {
         });
       }
 
-      await updateAppealService.updateAppeal(req);
+      await updateAppealService.submitEvent(Events.EDIT_APPEAL, req);
 
       req.session.appeal.application.personalDetails = {
         ...req.session.appeal.application.personalDetails,

--- a/app/controllers/type-of-appeal.ts
+++ b/app/controllers/type-of-appeal.ts
@@ -1,6 +1,7 @@
 import { NextFunction,Request, Response, Router } from 'express';
 import { appealTypes } from '../data/appeal-types';
 import { paths } from '../paths';
+import { Events } from '../service/ccd-service';
 import UpdateAppealService from '../service/update-appeal-service';
 import { typeOfAppealValidation } from '../utils/fields-validations';
 
@@ -30,7 +31,7 @@ function postTypeOfAppeal(updateAppealService: UpdateAppealService) {
           errorList: Object.values(validation)
         });
       }
-      await updateAppealService.updateAppeal(req);
+      await updateAppealService.submitEvent(Events.EDIT_APPEAL, req);
       req.session.appeal.application.appealType = req.body['appealType'];
       return res.redirect(paths.taskList);
     } catch (error) {

--- a/app/data/appeal-types.ts
+++ b/app/data/appeal-types.ts
@@ -1,5 +1,6 @@
 import i18n from '../../locale/en.json';
-const appealTypes: AppealType[] = [...Object.values(i18n.appealTypes)];
+
+const appealTypes: AppealType[] = [ ...Object.values(i18n.appealTypes) ];
 
 export {
   appealTypes

--- a/app/routes.ts
+++ b/app/routes.ts
@@ -32,9 +32,9 @@ const taskListController = setupTaskListController();
 const homeOfficeDetailsController = setupHomeOfficeDetailsController(updateAppealService);
 const typeOfAppealController = setupTypeOfAppealController(updateAppealService);
 const personalDetailsController = setupPersonalDetailsController({ updateAppealService, osPlacesClient });
-const contactDetailsController = setupContactDetailsController();
+const contactDetailsController = setupContactDetailsController(updateAppealService);
+const checkAndSendController = setupCheckAndSendController(updateAppealService);
 const confirmationController = setConfirmationController();
-const checkAndSendController = setupCheckAndSendController();
 // not protected by idam
 router.use(healthController);
 router.use(startController);

--- a/app/utils/tasks-utils.ts
+++ b/app/utils/tasks-utils.ts
@@ -20,15 +20,17 @@ function appealApplicationStatus(appeal: Appeal) {
   const line1: boolean = !!_.get(appeal.application, 'personalDetails.address.line1');
   const personalDetails: Task = {
     saved: givenNames || familyName || dob || nationality || postcode || line1,
-    completed: givenNames && familyName && dob && nationality && postcode && line1,
+    completed: givenNames && familyName && dob && nationality,
     active: homeOfficeDetails.completed
   };
 
   const email: boolean = !!_.get(appeal.application, 'contactDetails.email');
+  const wantsEmail: boolean = !!_.get(appeal.application, 'contactDetails.wantsEmail');
   const phone: boolean = !!_.get(appeal.application, 'contactDetails.phone');
+  const wantsSms: boolean = !!_.get(appeal.application, 'contactDetails.wantsSms');
   const contactDetails: Task = {
-    saved: email || phone,
-    completed: email || phone,
+    saved: email && wantsEmail || phone && wantsSms,
+    completed: email && wantsEmail || phone && wantsSms,
     active: personalDetails.completed
   };
 

--- a/locale/en.json
+++ b/locale/en.json
@@ -166,7 +166,7 @@
     "futureDate": "The date is in the future, please re-enter the date.",
     "acceptanceStatement": "Select if you believe the information you have given is true.",
     "contactDetails": {
-      "selectOneOption": "Please let us know how you want us to communicate with you."
+      "selectOneOption": "Select at least one of the contact options"
     },
     "givenNames": "Enter your given name or names",
     "familyName": "Enter your family name or names",

--- a/test/unit/controllers/enter-address.test.ts
+++ b/test/unit/controllers/enter-address.test.ts
@@ -49,7 +49,7 @@ describe('Personal Details Controller', function () {
 
     next = sandbox.stub() as NextFunction;
 
-    updateAppealService = { updateAppeal: sandbox.stub() } as Partial<UpdateAppealService>;
+    updateAppealService = { submitEvent: sandbox.stub() } as Partial<UpdateAppealService>;
   });
 
   afterEach(() => {

--- a/test/unit/controllers/enter-date.test.ts
+++ b/test/unit/controllers/enter-date.test.ts
@@ -46,7 +46,7 @@ describe('Personal Details Controller', function () {
 
     next = sandbox.stub() as NextFunction;
 
-    updateAppealService = { updateAppeal: sandbox.stub() } as Partial<UpdateAppealService>;
+    updateAppealService = { submitEvent: sandbox.stub() } as Partial<UpdateAppealService>;
   });
 
   afterEach(() => {

--- a/test/unit/controllers/enter-postcode.test.ts
+++ b/test/unit/controllers/enter-postcode.test.ts
@@ -44,7 +44,7 @@ describe('Personal Details Controller', function() {
 
     next = sandbox.stub() as NextFunction;
 
-    updateAppealService = { updateAppeal: sandbox.stub() } as Partial<UpdateAppealService>;
+    updateAppealService = { submitEvent: sandbox.stub() } as Partial<UpdateAppealService>;
   });
 
   afterEach(() => {

--- a/test/unit/controllers/get-name-page.test.ts
+++ b/test/unit/controllers/get-name-page.test.ts
@@ -44,7 +44,7 @@ describe('Personal Details Controller', function () {
       redirect: sandbox.spy()
     } as Partial<Response>;
 
-    updateAppealService = { updateAppeal: sandbox.stub() } as Partial<UpdateAppealService>;
+    updateAppealService = { submitEvent: sandbox.stub() } as Partial<UpdateAppealService>;
 
     next = sandbox.stub() as NextFunction;
   });

--- a/test/unit/controllers/home-office-details.test.ts
+++ b/test/unit/controllers/home-office-details.test.ts
@@ -59,7 +59,7 @@ describe('Home Office Details Controller', function () {
 
     next = sandbox.stub() as NextFunction;
 
-    updateAppealService = { updateAppeal: sandbox.stub() };
+    updateAppealService = { submitEvent: sandbox.stub() };
   });
 
   afterEach(() => {

--- a/test/unit/controllers/nationatily-page.test.ts
+++ b/test/unit/controllers/nationatily-page.test.ts
@@ -46,7 +46,7 @@ describe('Nationality details Controller', function() {
 
     next = sandbox.stub() as NextFunction;
 
-    updateAppealService = { updateAppeal: sandbox.stub() } as Partial<UpdateAppealService>;
+    updateAppealService = { submitEvent: sandbox.stub() } as Partial<UpdateAppealService>;
   });
 
   afterEach(() => {

--- a/test/unit/controllers/postcode-lookup.test.ts
+++ b/test/unit/controllers/postcode-lookup.test.ts
@@ -54,7 +54,7 @@ describe('Personal Details Controller', function () {
 
     next = sandbox.stub() as NextFunction;
 
-    updateAppealService = { updateAppeal: sandbox.stub() } as Partial<UpdateAppealService>;
+    updateAppealService = { submitEvent: sandbox.stub() } as Partial<UpdateAppealService>;
     lookupByPostcodeStub = sandbox.stub(osPlacesClient, 'lookupByPostcode');
   });
 

--- a/test/unit/controllers/type-of-appeal.test.ts
+++ b/test/unit/controllers/type-of-appeal.test.ts
@@ -39,7 +39,7 @@ describe('Type of appeal Controller', () => {
       } as any
     } as Partial<Request>;
 
-    updateAppealService = { updateAppeal: sandbox.stub() };
+    updateAppealService = { submitEvent: sandbox.stub() };
 
     res = {
       render: sandbox.stub(),

--- a/test/unit/mockData/mock-appeal.ts
+++ b/test/unit/mockData/mock-appeal.ts
@@ -29,7 +29,9 @@ export function createDummyAppealApplication(): Appeal {
       },
       contactDetails: {
         email: 'pedro.jimenez@example.net',
-        phone: '07123456789'
+        wantsEmail: true,
+        phone: '07123456789',
+        wantsSms: false
       },
       addressLookup: {}
     },

--- a/test/unit/service/ccd-service.test.ts
+++ b/test/unit/service/ccd-service.test.ts
@@ -1,5 +1,5 @@
 import rp from 'request-promise';
-import { CcdService } from '../../../app/service/ccd-service';
+import { CcdService, Events } from '../../../app/service/ccd-service';
 import { SecurityHeaders } from '../../../app/service/getHeaders';
 import { expect, sinon } from '../../utils/testUtils';
 
@@ -93,26 +93,26 @@ describe('idam-service', () => {
     const expectedResult = { } as any;
 
     it('updates case', async () => {
-      const startUpdateCaseStub = sinon.stub(ccdService, 'startUpdateCase');
+      const startUpdateCaseStub = sinon.stub(ccdService, 'startUpdateAppeal');
       startUpdateCaseStub.resolves({
         event_id: 'eventId',
         token: 'token'
       });
 
-      const submitUpdateCaseStub = sinon.stub(ccdService, 'submitUpdateCase');
+      const submitUpdateCaseStub = sinon.stub(ccdService, 'submitUpdateAppeal');
       const caseData = { journeyType: 'AIP' };
       submitUpdateCaseStub.withArgs(userId, caseId, headers, {
         event: {
           id: 'eventId',
-          summary: 'Update case AIP',
-          description: 'Update case AIP'
+          summary: Events.EDIT_APPEAL.summary,
+          description: Events.EDIT_APPEAL.description
         },
         data: caseData,
         event_token: 'token',
         ignore_warning: true
       }).resolves(expectedResult);
 
-      const caseDetails = await ccdService.updateCase(userId, {
+      const caseDetails = await ccdService.updateAppeal(Events.EDIT_APPEAL, userId, {
         id: caseId,
         case_data: caseData
       }, headers);
@@ -155,14 +155,20 @@ describe('idam-service', () => {
       expect(createCase).eq(expectedResultGet);
     });
 
-    it('startUpdateCase', () => {
-      const updateCase = ccdService.startUpdateCase(userId, caseId, headers);
+    it('startUpdateCase with "editAppeal"', () => {
+      const updateCase = ccdService.startUpdateAppeal(userId, caseId, Events.EDIT_APPEAL.id, headers);
+
+      expect(updateCase).eq(expectedResultGet);
+    });
+
+    it('startUpdateCase with "submitAppeal', () => {
+      const updateCase = ccdService.startUpdateAppeal(userId, caseId, Events.SUBMIT_APPEAL.id, headers);
 
       expect(updateCase).eq(expectedResultGet);
     });
 
     it('submitUpdateCase', () => {
-      const submitCreateCase = ccdService.submitUpdateCase(userId, caseId,headers, {} as any);
+      const submitCreateCase = ccdService.submitUpdateAppeal(userId, caseId,headers, {} as any);
 
       expect(submitCreateCase).eq(expectedResultPost);
     });

--- a/test/unit/utils/task-utils.test.ts
+++ b/test/unit/utils/task-utils.test.ts
@@ -115,7 +115,8 @@ describe('getStatus', () => {
   it('should update status contactDetails as completed and mark active next task', () => {
     appeal.application.contactDetails = {
       ...appeal.application.contactDetails,
-      phone: '07769118762'
+      phone: '07769118762',
+      wantsSms: true
     };
     status.contactDetails = {
       ...status.contactDetails,
@@ -130,18 +131,21 @@ describe('getStatus', () => {
     appeal.application.contactDetails = {
       ...appeal.application.contactDetails,
       phone: undefined,
-      email: 'email@test.com'
+      wantsSms: false,
+      email: 'email@test.com',
+      wantsEmail: true
     };
     status.contactDetails = {
       ...status.contactDetails,
       completed: true,
       saved: true
     };
+    status.typeOfAppeal.active = true;
     expect(appealApplicationStatus(appeal)).to.deep.eq(status);
   });
 
   it('should update status typeOfAppeal as completed', () => {
-    appeal.application.appealType = ['type'];
+    appeal.application.appealType = ['protection'];
     status.typeOfAppeal = {
       ...status.typeOfAppeal,
       completed: true,

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -67,7 +67,9 @@ interface AppealApplication {
   };
   contactDetails: {
     email?: string;
+    wantsEmail?: boolean;
     phone?: string;
+    wantsSms?: boolean;
   };
   tasks?: {
     [key: string]: Task;

--- a/views/appeal-application/contact-details.njk
+++ b/views/appeal-application/contact-details.njk
@@ -1,4 +1,4 @@
-{% set pageTitleName = i18n.pages.appealType.header %}
+{% set pageTitleName = i18n.pages.contactDetails.header %}
 {% extends "layout.njk" %}
 {% from "govuk/components/checkboxes/macro.njk" import govukCheckboxes %}
 {% from "govuk/components/input/macro.njk" import govukInput %}
@@ -30,7 +30,7 @@
       id: "email-value",
       name: "email-value",
       type: "email",
-      value: email,
+      value: contactDetails.email,
       classes: "govuk-!-width-one-third",
       label: {
         text: i18n.fields.emailAddress
@@ -49,7 +49,7 @@
         id: "text-message-value",
         name: "text-message-value",
         type: "tel",
-        value: phone,
+        value: contactDetails.phone,
         classes: "govuk-!-width-one-third",
         label: {
           text: i18n.fields.mobilePhone
@@ -81,7 +81,7 @@
               conditional: {
                   html: emailHtml
               },
-              checked: true if email
+              checked: true if contactDetails.wantsEmail or errors['email-value']
             },
             {
               value: "text-message",
@@ -89,7 +89,7 @@
               conditional: {
                 html: textHtml
               },
-              checked: true if phone
+              checked: true if contactDetails.wantsSms or errors['text-message-value']
             }
           ],
           errorMessage: {


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/RIA-1963
https://tools.hmcts.net/jira/browse/RIA-1965
https://tools.hmcts.net/jira/browse/RIA-2165

### Change description ###

Adds Backwards mapping from ccd for contactDetails  and appealType
**RIA-1963:**
Makes contact details validation more intelligent to allow certain cases in the checkboxes and inputs.
Adds ability to:
- Save contact details using the new format with subscribers
- Submit the appeal to ccd using the correct event

Other:
Reworked contact details page and contact details object structure to introduce two new booleans used to trigger conditional expressions and error messages, populated from the checkboxes.

**RIA-1965:**
Adds ability to:
- Triggers a Submit event to submit the appeal.

**RIA-2165:**
Adds ability to:
- Submit the appeal to ccd using the correct event

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x ] No
```
