### PR TITLE
Fixing Regex validation for mobile phone numbers (UK only).

### DIFF
--- a/app/controllers/contact-details.ts
+++ b/app/controllers/contact-details.ts
@@ -17,8 +17,6 @@ function getContactDetails(req: Request, res: Response, next: NextFunction) {
 function postContactDetails(updateAppealService: UpdateAppealService) {
   return async (req: Request, res: Response, next: NextFunction) => {
     try {
-      const validation = contactDetailsValidation(req.body);
-
       const selections = req.body['selections'] || [];
 
       let email = null;
@@ -33,11 +31,14 @@ function postContactDetails(updateAppealService: UpdateAppealService) {
         }
       }
       if (selections.includes('text-message')) {
+        req.body['text-message-value'] = req.body['text-message-value'].replace(/\s/g, '');
         phone = req.body['text-message-value'];
         if (phone) {
           wantsSms = true;
         }
       }
+
+      const validation = contactDetailsValidation(req.body);
 
       const contactDetails = { email, wantsEmail, phone, wantsSms };
 

--- a/app/utils/fields-validations.ts
+++ b/app/utils/fields-validations.ts
@@ -1,7 +1,7 @@
 import Joi from '@hapi/joi';
 import moment from 'moment';
 import i18n from '../../locale/en.json';
-import { postcodeRegex } from './regular-expressions';
+import { mobilePhoneRegex, postcodeRegex } from './regular-expressions';
 
 /**
  * Uses Joi schema validation to validate and object and returns:
@@ -127,7 +127,6 @@ function appellantNamesValidation(obj: object) {
 }
 
 function contactDetailsValidation(obj: object) {
-  const phonePattern = new RegExp('^(?:0|\\+?44)(?:\\d\\s?){9,10}$');
   const schema = Joi.object({
     'selections': Joi.alternatives()
       .try(
@@ -160,15 +159,14 @@ function contactDetailsValidation(obj: object) {
           Joi.string().valid('text-message')).required(),
       then: Joi.string()
         .optional()
-        .regex(phonePattern)
+        .regex(mobilePhoneRegex)
         .messages({
           'string.empty': i18n.validationErrors.phoneEmpty,
           'string.pattern.base': i18n.validationErrors.phoneFormat
         }),
       otherwise: Joi.strip()
     })
-  })
-    .unknown();
+  }).unknown();
 
   return validate(obj, schema);
 }
@@ -227,11 +225,10 @@ function emailValidation(obj: object): null | ValidationErrors {
  * @return ValidationError object if there are issues, null if no issues found
  */
 function phoneValidation(obj: object): null | ValidationErrors {
-  const phonePattern = new RegExp('^(?:0|\\+?44)(?:\\d\\s?){9,10}$');
   const schema = Joi.object({
     'text-message-value': Joi.string()
       .required()
-      .regex(phonePattern)
+      .regex(mobilePhoneRegex)
       .messages({
         'string.empty': i18n.validationErrors.phoneEmpty,
         'string.pattern.base': i18n.validationErrors.phoneFormat

--- a/app/utils/fields-validations.ts
+++ b/app/utils/fields-validations.ts
@@ -224,7 +224,7 @@ function emailValidation(obj: object): null | ValidationErrors {
  * 'string.pattern.base': if phone number does not match format
  * @return ValidationError object if there are issues, null if no issues found
  */
-function phoneValidation(obj: object): null | ValidationErrors {
+function mobilePhoneValidation(obj: object): null | ValidationErrors {
   const schema = Joi.object({
     'text-message-value': Joi.string()
       .required()
@@ -297,7 +297,7 @@ export {
   postcodeValidation,
   nationalityValidation,
   emailValidation,
-  phoneValidation,
+  mobilePhoneValidation,
   textAreaValidation,
   statementOfTruthValidation,
   addressValidation,

--- a/app/utils/regular-expressions.ts
+++ b/app/utils/regular-expressions.ts
@@ -1,5 +1,7 @@
-const postcodeRegex = /([Gg][Ii][Rr] 0[Aa]{2})|((([A-Za-z][0-9]{1,2})|(([A-Za-z][A-Ha-hJ-Yj-y][0-9]{1,2})|(([A-Za-z][0-9][A-Za-z])|([A-Za-z][A-Ha-hJ-Yj-y][0-9][A-Za-z]?))))\s?[0-9][A-Za-z]{2})/;
+const postcodeRegex = new RegExp(/([Gg][Ii][Rr] 0[Aa]{2})|((([A-Za-z][0-9]{1,2})|(([A-Za-z][A-Ha-hJ-Yj-y][0-9]{1,2})|(([A-Za-z][0-9][A-Za-z])|([A-Za-z][A-Ha-hJ-Yj-y][0-9][A-Za-z]?))))\s?[0-9][A-Za-z]{2})/);
+const mobilePhoneRegex = new RegExp('^(?:07|\\+?447)(?:\\d\\s?){9}$');
 
 export {
-  postcodeRegex
+  postcodeRegex,
+  mobilePhoneRegex
 };

--- a/test/unit/utils/fields-validations.test.ts
+++ b/test/unit/utils/fields-validations.test.ts
@@ -3,7 +3,7 @@ import {
   dateValidation,
   emailValidation,
   homeOfficeNumberValidation,
-  phoneValidation,
+  mobilePhoneValidation,
   statementOfTruthValidation,
   textAreaValidation
 } from '../../../app/utils/fields-validations';
@@ -181,41 +181,61 @@ describe('fields-validations', () => {
     });
   });
 
-  describe('phoneValidation', () => {
-    it('should validate a landline phone number', () => {
+  describe('mobilePhoneValidation', () => {
+    it('should fail validation with landline phone number', () => {
       const object = { 'text-message-value': '01632960001' };
-      const validationResult = phoneValidation(object);
-      expect(validationResult).to.equal(null);
-    });
-
-    it('should validate a mobile phone number', () => {
-      const object = { 'text-message-value': '07700900982' };
-      const validationResult = phoneValidation(object);
-      expect(validationResult).to.equal(null);
-    });
-
-    it('should validate a phone number with prefix', () => {
-      const object = { 'text-message-value': '+448081570192' };
-      const validationResult = phoneValidation(object);
-      expect(validationResult).to.equal(null);
-    });
-
-    it('should fail phone validation and return "string.empty" type', () => {
-      const object = { 'text-message-value': '' };
-      const validationResult = phoneValidation(object);
+      const validationResult = mobilePhoneValidation(object);
       const expectedResponse = {
         'text-message-value': {
-          'key': 'text-message-value',
-          'text': 'Enter a phone number',
-          'href': '#text-message-value'
+          href: '#text-message-value',
+          key: 'text-message-value',
+          text: 'Enter a telephone number, like 01632 960 002, 07700 900 982 or +44 808 157 0192'
         }
       };
       expect(validationResult).to.deep.equal(expectedResponse);
     });
+  });
 
-    it('should fail phone validation and return "string.format" type', () => {
-      const object = { 'text-message-value': '1234567890' };
-      const validationResult = phoneValidation(object);
+  describe('mobile phone number cases', () => {
+    it('should validate a mobile phone number', () => {
+      const object = { 'text-message-value': '07700900982' };
+      const validationResult = mobilePhoneValidation(object);
+      expect(validationResult).to.equal(null);
+    });
+
+    it('should validate a mobile phone number with spaces', () => {
+      const object = { 'text-message-value': '07700 900 982' };
+      const validationResult = mobilePhoneValidation(object);
+      expect(validationResult).to.equal(null);
+    });
+
+    it('should fail validation if not a valid UK mobile phone number', () => {
+      const object = { 'text-message-value': '09700000000' };
+      const validationResult = mobilePhoneValidation(object);
+
+      const expectedResponse = {
+        'text-message-value': {
+          href: '#text-message-value',
+          key: 'text-message-value',
+          text: 'Enter a telephone number, like 01632 960 002, 07700 900 982 or +44 808 157 0192'
+        }
+      };
+
+      expect(validationResult).to.deep.equal(expectedResponse);
+    });
+  });
+
+  describe('mobile phone number with prefix cases', () => {
+
+    it('should validate a valid mobile phone number with prefix', () => {
+      const object = { 'text-message-value': '+447123456789' };
+      const validationResult = mobilePhoneValidation(object);
+      expect(validationResult).to.equal(null);
+    });
+
+    it('should fail validation with a phone number with prefix', () => {
+      const object = { 'text-message-value': '+448081570192' };
+      const validationResult = mobilePhoneValidation(object);
       const expectedResponse = {
         'text-message-value': {
           'key': 'text-message-value',
@@ -227,51 +247,77 @@ describe('fields-validations', () => {
     });
   });
 
-  describe('textAreaValidation', () => {
-    it('should validate', () => {
-      const text: string = 'Some text here.';
-      const key: string = 'aKey';
-      const validations = textAreaValidation(text, key);
-
-      expect(validations).to.equal(null);
-    });
-
-    it('should fail validation', () => {
-      const text: string = '';
-      const key: string = 'aKey';
-      const validations = textAreaValidation(text, key);
-
-      expect(validations).to.deep.equal(
-        {
-          [key]: {
-            href: '#aKey',
-            key: 'aKey',
-            text: i18n.validationErrors.required
-          }
-        }
-      );
-    });
+  it('should fail phone validation and return "string.empty" type', () => {
+    const object = { 'text-message-value': '' };
+    const validationResult = mobilePhoneValidation(object);
+    const expectedResponse = {
+      'text-message-value': {
+        'key': 'text-message-value',
+        'text': 'Enter a phone number',
+        'href': '#text-message-value'
+      }
+    };
+    expect(validationResult).to.deep.equal(expectedResponse);
   });
 
-  describe('statementOfTruthValidation', () => {
-    it('should validate if statement present', () => {
-      const object = { 'statement': 'acceptance' };
-      const validationResult = statementOfTruthValidation(object);
-      expect(validationResult).to.equal(null);
-    });
-
-    it('should fail validation and return "any.required" type', () => {
-      const object = {};
-      const validationResult = statementOfTruthValidation(object);
-      const expectedResponse = {
-        statement: {
-          href: '#statement',
-          key: 'statement',
-          text: 'Select if you believe the information you have given is true.'
-        }
-      };
-      expect(validationResult).to.deep.equal(expectedResponse);
-    });
-
+  it('should fail phone validation and return "string.format" type', () => {
+    const object = { 'text-message-value': '1234567890' };
+    const validationResult = mobilePhoneValidation(object);
+    const expectedResponse = {
+      'text-message-value': {
+        'key': 'text-message-value',
+        'text': 'Enter a telephone number, like 01632 960 002, 07700 900 982 or +44 808 157 0192',
+        'href': '#text-message-value'
+      }
+    };
+    expect(validationResult).to.deep.equal(expectedResponse);
   });
+});
+
+describe('textAreaValidation', () => {
+  it('should validate', () => {
+    const text: string = 'Some text here.';
+    const key: string = 'aKey';
+    const validations = textAreaValidation(text, key);
+
+    expect(validations).to.equal(null);
+  });
+
+  it('should fail validation', () => {
+    const text: string = '';
+    const key: string = 'aKey';
+    const validations = textAreaValidation(text, key);
+
+    expect(validations).to.deep.equal(
+      {
+        [key]: {
+          href: '#aKey',
+          key: 'aKey',
+          text: i18n.validationErrors.required
+        }
+      }
+    );
+  });
+});
+
+describe('statementOfTruthValidation', () => {
+  it('should validate if statement present', () => {
+    const object = { 'statement': 'acceptance' };
+    const validationResult = statementOfTruthValidation(object);
+    expect(validationResult).to.equal(null);
+  });
+
+  it('should fail validation and return "any.required" type', () => {
+    const object = {};
+    const validationResult = statementOfTruthValidation(object);
+    const expectedResponse = {
+      statement: {
+        href: '#statement',
+        key: 'statement',
+        text: 'Select if you believe the information you have given is true.'
+      }
+    };
+    expect(validationResult).to.deep.equal(expectedResponse);
+  });
+
 });


### PR DESCRIPTION
### Change description ###

Removing whitespaces before validation on mobileNumbers.
Fixing Regex validation for mobile phone numbers (UK only).

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ x] No
```
