### PR TITLE
Allow users to go directly to the enter address page from postcode

### DIFF
--- a/app/utils/address-utils.ts
+++ b/app/utils/address-utils.ts
@@ -25,14 +25,24 @@ function getLine2(osAddress: Address): string {
   return [ osAddress.doubleDependentLocality, osAddress.dependentLocality ].filter(Boolean).join(', ');
 }
 
-function getAddress(osAddress: Address) {
-  return {
-    line1: getLine1(osAddress),
-    line2: getLine2(osAddress),
-    city: osAddress.postTown,
-    postcode: osAddress.postcode,
-    county: ''
-  };
+function getAddress(osAddress: Address, selectedPostcode: string) {
+  if (osAddress) {
+    return {
+      line1: getLine1(osAddress),
+      line2: getLine2(osAddress),
+      city: osAddress.postTown,
+      postcode: osAddress.postcode,
+      county: ''
+    };
+  } else {
+    return {
+      line1: '',
+      line2: '',
+      city: '',
+      postcode: selectedPostcode ? selectedPostcode : '',
+      county: ''
+    };
+  }
 }
 
 export {

--- a/locale/en.json
+++ b/locale/en.json
@@ -87,7 +87,8 @@
     "enterPostcode": {
       "heading": "What is your address?",
       "title": "Address",
-      "hint": "Enter a UK postcode"
+      "hint": "Enter a UK postcode",
+      "manualAddressLink": "I want to enter my address manually"
     },
     "enterAddress": {
       "heading": "What is your address?",

--- a/test/unit/controllers/enter-address.test.ts
+++ b/test/unit/controllers/enter-address.test.ts
@@ -1,7 +1,7 @@
 import { Address, Point } from '@hmcts/os-places-client';
-
 const express = require('express');
 import { NextFunction, Request, Response } from 'express';
+import * as _ from 'lodash';
 import {
   getManualEnterAddressPage,
   postManualEnterAddressPage,
@@ -70,6 +70,7 @@ describe('Personal Details Controller', function () {
     it('should render appeal-application/personal-details/enter-address.njk', function () {
       // @ts-ignore
       req.session.appeal.application.addressLookup = {
+        postcode: 'selectedPostcode',
         selected: 'udprn',
         result: {
           addresses: [
@@ -85,7 +86,32 @@ describe('Personal Details Controller', function () {
           city: 'postTown',
           county: '',
           postcode: 'postcode'
-        }
+        },
+        selectedPostcode: 'selectedPostcode'
+      });
+    });
+
+    it('should render appeal-application/personal-details/enter-address.njk with address from CCD if page loaded without postcode lookup', function () {
+      // @ts-ignore
+      req.session.appeal.application.addressLookup = {
+      };
+      _.set(req.session.appeal.application, 'personalDetails.address', {
+        line1: 'subBuildingName buildingName',
+        line2: '2 dependentThoroughfareName, thoroughfareName, doubleDependentLocality, dependentLocality',
+        city: 'postTown',
+        county: '',
+        postcode: 'postcode'
+      });
+      getManualEnterAddressPage(req as Request, res as Response, next);
+      expect(res.render).to.have.been.calledOnce.calledWith('appeal-application/personal-details/enter-address.njk', {
+        address: {
+          line1: 'subBuildingName buildingName',
+          line2: '2 dependentThoroughfareName, thoroughfareName, doubleDependentLocality, dependentLocality',
+          city: 'postTown',
+          county: '',
+          postcode: 'postcode'
+        },
+        selectedPostcode: 'postcode'
       });
     });
 

--- a/test/unit/controllers/enter-postcode.test.ts
+++ b/test/unit/controllers/enter-postcode.test.ts
@@ -66,6 +66,14 @@ describe('Personal Details Controller', function() {
       getEnterPostcodePage(req as Request, res as Response, next);
       expect(res.render).to.have.been.calledOnce.calledWith('appeal-application/personal-details/enter-postcode.njk');
     });
+
+    it('should reset postcode lookup', function () {
+      req.session.appeal.application.addressLookup = {
+        postcode: 'somePostcode'
+      };
+      getEnterPostcodePage(req as Request, res as Response, next);
+      expect(req.session.appeal.application.addressLookup).to.eql({});
+    });
   });
 
   describe('postEnterPostcodePage', () => {

--- a/test/unit/controllers/nationatily-page.test.ts
+++ b/test/unit/controllers/nationatily-page.test.ts
@@ -1,5 +1,6 @@
 const express = require('express');
 import { NextFunction, Request, Response } from 'express';
+import * as _ from 'lodash';
 import { getNationalityPage, postNationalityPage, setupPersonalDetailsController } from '../../../app/controllers/personal-details';
 import { countryList } from '../../../app/data/country-list';
 import { paths } from '../../../app/paths';
@@ -41,6 +42,7 @@ describe('Nationality details Controller', function() {
 
     res = {
       render: sandbox.stub(),
+      redirect: sandbox.spy(),
       send: sandbox.stub()
     } as Partial<Response>;
 
@@ -134,6 +136,23 @@ describe('Nationality details Controller', function() {
           nationalitiesOptions,
           statelessNationality: 'stateless'
         });
+    });
+  });
+
+  describe('should redirect to the correct page', () => {
+    it('redirects to enter postcode page if no address has been set', () => {
+      req.body.nationality = 'Taiwan';
+      postNationalityPage(req as Request, res as Response, next);
+
+      expect(res.redirect).to.have.been.calledWith(paths.personalDetails.enterPostcode);
+    });
+
+    it('redirects to enter address page if address has been set', () => {
+      req.body.nationality = 'Taiwan';
+      _.set(req.session.appeal.application, 'personalDetails.address.line1', 'addressLine1');
+      postNationalityPage(req as Request, res as Response, next);
+
+      expect(res.redirect).to.have.been.calledWith(paths.personalDetails.enterAddress);
     });
   });
 });

--- a/test/unit/utils/address-utils.test.ts
+++ b/test/unit/utils/address-utils.test.ts
@@ -74,13 +74,39 @@ describe('address-utils', () => {
   describe('getAddress', () => {
     it('gets full address', () => {
       const osAddress = new Address('1', 'organisationName', 'departmentName', 'poBoxNumber', 'buildingName', 'subBuildingName', 2, 'thoroughfareName', 'dependentThoroughfareName', 'dependentLocality', 'doubleDependentLocality', 'postTown', 'postcode', 'postcodeType', 'formattedAddress', new Point('type', [1, 2]), 'udprn');
-      const address = getAddress(osAddress);
+      const address = getAddress(osAddress, 'selectedPostcode');
 
       expect(address).to.deep.eq({
         line1: 'subBuildingName buildingName',
         line2: '2 dependentThoroughfareName, thoroughfareName, doubleDependentLocality, dependentLocality',
         city: 'postTown',
         postcode: 'postcode',
+        county: ''
+      });
+    });
+
+    it('gets empty address', () => {
+      const osAddress = null;
+      const address = getAddress(osAddress, 'selectedPostcode');
+
+      expect(address).to.deep.eq({
+        line1: '',
+        line2: '',
+        city: '',
+        postcode: 'selectedPostcode',
+        county: ''
+      });
+    });
+
+    it('gets empty address with empty postcode', () => {
+      const osAddress = null;
+      const address = getAddress(osAddress, undefined);
+
+      expect(address).to.deep.eq({
+        line1: '',
+        line2: '',
+        city: '',
+        postcode: '',
         county: ''
       });
     });

--- a/views/appeal-application/personal-details/enter-address.njk
+++ b/views/appeal-application/personal-details/enter-address.njk
@@ -14,10 +14,12 @@
         }}
     {% endif %}
     <h1 class="govuk-fieldset__legend--xl">{{ i18n.pages.enterAddress.heading}}</h1>
-    <h3>{{ i18n.pages.enterAddress.inputs.postcode }}</h3>
-    <span><b>{{ address.postcode }}</b> &emsp;  <a  class="govuk-link app-contact-panel__link"  href="/personal-details/enter-postcode">Change</a></span>
-    </br>
-    </br>
+    {% if selectedPostcode %}
+        <h3>{{ i18n.pages.enterAddress.inputs.postcode }}</h3>
+        <span><b>{{ selectedPostcode }}</b> &emsp;  <a  class="govuk-link app-contact-panel__link"  href="/personal-details/enter-postcode">Change</a></span>
+        </br>
+        </br>
+    {% endif %}
     <form action="/personal-details/enter-address" method="post">
     {% call govukFieldset({
 

--- a/views/appeal-application/personal-details/enter-postcode.njk
+++ b/views/appeal-application/personal-details/enter-postcode.njk
@@ -33,6 +33,10 @@
             classes: "govuk-!-margin-right-1"
         }) }}
     </form>
+    <p>
+        <a href="/personal-details/enter-address">{{ i18n.pages.enterPostcode.manualAddressLink }}</a>
+    </p>
+
     {{ contactUs() }}
 {% endblock  %}
 


### PR DESCRIPTION
lookup if they want tio enter their address manually.
Also if you have saved the address already go directly to the enter
address page rather than postcode lookup.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
