### PR TITLE
Fix pr environment

### DIFF
--- a/charts/ia-aip-frontend/requirements.yaml
+++ b/charts/ia-aip-frontend/requirements.yaml
@@ -5,3 +5,8 @@ dependencies:
   - name: redis
     version: "5.1.2"
     repository: "@stable"
+  - name: idam-pr
+    version: ~2.1.0
+    repository: '@hmctspublic'
+    tags:
+      - idam-pr

--- a/charts/ia-aip-frontend/values.preview.template.yaml
+++ b/charts/ia-aip-frontend/values.preview.template.yaml
@@ -1,3 +1,9 @@
+tags:
+  - idam-pr
+idam-pr:
+  redirect_uris:
+    IAC:
+    - https://${SERVICE_FQDN}/redirectUrl
 nodejs:
   environment:
     NODE_ENV: preview


### PR DESCRIPTION
When the pr environment deploys the URL changes each time. As the
redirect URL sent to idam is checked against a whitelist this needs to
be added to the whitelist for each PR environment.