### PR TITLE
Fix: Type of appeal display

### DIFF
--- a/app/controllers/check-and-send.ts
+++ b/app/controllers/check-and-send.ts
@@ -1,5 +1,6 @@
 import { NextFunction, Request, Response, Router } from 'express';
 import moment from 'moment';
+import i18n from '../../locale/en.json';
 import { paths } from '../paths';
 import { Events } from '../service/ccd-service';
 import UpdateAppealService from '../service/update-appeal-service';
@@ -7,6 +8,13 @@ import { statementOfTruthValidation } from '../utils/fields-validations';
 import { addSummaryRow, Delimiter } from '../utils/summary-list';
 
 function createSummaryRowsFrom(appealApplication: AppealApplication) {
+  let appealTypes: string[] = !Array.isArray(appealApplication.appealType)
+    ? [ appealApplication.appealType ] : appealApplication.appealType;
+
+  const appealTypeNames: string[] = appealTypes.map(appealType => {
+    return i18n.appealTypes[appealType].name;
+  });
+
   return [
     addSummaryRow('homeOfficeRefNumber', [ appealApplication.homeOfficeRefNumber ], paths.homeOffice.details),
     addSummaryRow('dateLetterSent',
@@ -27,7 +35,7 @@ function createSummaryRowsFrom(appealApplication: AppealApplication) {
       [ appealApplication.contactDetails.email, appealApplication.contactDetails.phone, ...Object.values(appealApplication.personalDetails.address) ],
       paths.contactDetails),
     addSummaryRow('appealType',
-      [ appealApplication.appealType ],
+      [ appealTypeNames ],
       paths.typeOfAppeal)
   ];
 }

--- a/locale/en.json
+++ b/locale/en.json
@@ -256,8 +256,8 @@
       "title": "<b>European Economic Area (EEA)</b> (You are, or a family member is, an EEA/Swiss national)",
       "examples": "You might be, or have been, a family member or carer of an EEA/Swiss national, or have lived in another EEA country with a British family member, and want to either come to or stay in the UK."
     },
-    "revocation": {
-      "value": "revocation",
+    "revocationOfProtection": {
+      "value": "revocationOfProtection",
       "name": "Revocation of Protection Status",
       "title": "<b>Revocation of Protection Status</b> (Your protection status was taken away)",
       "examples": "Your protection status might have been taken away if it is believed you no longer need it, you didn’t tell the truth in your claim or you have committed a serious crime."

--- a/test/unit/mockData/mock-appeal.ts
+++ b/test/unit/mockData/mock-appeal.ts
@@ -7,7 +7,7 @@ export function createDummyAppealApplication(): Appeal {
         month: 7,
         year: 2019
       },
-      appealType: 'Protection',
+      appealType: 'protection',
       isAppealLate: false,
       personalDetails: {
         givenNames: 'Pedro',


### PR DESCRIPTION
### Change description ###

Fix: Check and send page showing values rather than the name of the a…ppeal type.
Renaming revocation to the correct value.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x ] No
```
