### PR TITLE
RIA-2281 & RIA-2282: Change link in CYA page and Re-design of summary rows

### DIFF
--- a/app/controllers/check-and-send.ts
+++ b/app/controllers/check-and-send.ts
@@ -16,28 +16,33 @@ function createSummaryRowsFrom(appealApplication: AppealApplication) {
     return i18n.appealTypes[appealType].name;
   });
   const country = countryList.find(country => country.value === appealApplication.personalDetails.nationality);
+  const editParameter = '?edit';
   return [
-    addSummaryRow('homeOfficeRefNumber', [ appealApplication.homeOfficeRefNumber ], paths.homeOffice.details),
+    addSummaryRow('homeOfficeRefNumber',
+      [ appealApplication.homeOfficeRefNumber ],
+      paths.homeOffice.details + editParameter),
     addSummaryRow('dateLetterSent',
       [ appealApplication.dateLetterSent.day, moment.months(appealApplication.dateLetterSent.month - 1), appealApplication.dateLetterSent.year ],
-      paths.homeOffice.letterSent,
-      Delimiter.SPACE
+      paths.homeOffice.letterSent + editParameter, Delimiter.SPACE
     ),
     addSummaryRow('name',
       [ appealApplication.personalDetails.givenNames, appealApplication.personalDetails.familyName ],
-      paths.personalDetails.name, Delimiter.SPACE),
+      paths.personalDetails.name + editParameter, Delimiter.SPACE),
     addSummaryRow('dob',
       [ appealApplication.personalDetails.dob.day, moment.months(appealApplication.personalDetails.dob.month - 1), appealApplication.personalDetails.dob.year ],
-      paths.personalDetails.dob, Delimiter.SPACE),
+      paths.personalDetails.dob + editParameter, Delimiter.SPACE),
     addSummaryRow('nationality',
       [ country.name ],
-      paths.personalDetails.nationality),
+      paths.personalDetails.nationality + editParameter),
+    addSummaryRow('addressDetails',
+      [ ...Object.values(appealApplication.personalDetails.address) ],
+      paths.personalDetails.enterAddress + editParameter),
     addSummaryRow('contactDetails',
-      [ appealApplication.contactDetails.email, appealApplication.contactDetails.phone, ...Object.values(appealApplication.personalDetails.address) ],
-      paths.contactDetails),
+      [ appealApplication.contactDetails.email, appealApplication.contactDetails.phone ],
+      paths.contactDetails + editParameter),
     addSummaryRow('appealType',
       [ appealTypeNames ],
-      paths.typeOfAppeal)
+      paths.typeOfAppeal + editParameter)
   ];
 }
 

--- a/app/controllers/contact-details.ts
+++ b/app/controllers/contact-details.ts
@@ -8,7 +8,7 @@ import { getConditionalRedirectUrl } from '../utils/url-utils';
 
 function getContactDetails(req: Request, res: Response, next: NextFunction) {
   try {
-    req.session.isEdit = _.has(req.query, 'edit');
+    req.session.appeal.application.isEdit = _.has(req.query, 'edit');
     const { application } = req.session.appeal;
     const contactDetails = application && application.contactDetails || null;
     return res.render('appeal-application/contact-details.njk', { contactDetails });

--- a/app/controllers/contact-details.ts
+++ b/app/controllers/contact-details.ts
@@ -1,11 +1,14 @@
 import { NextFunction, Request, Response, Router } from 'express';
+import _ from 'lodash';
 import { paths } from '../paths';
 import { Events } from '../service/ccd-service';
 import UpdateAppealService from '../service/update-appeal-service';
 import { contactDetailsValidation } from '../utils/fields-validations';
+import { getConditionalRedirectUrl } from '../utils/url-utils';
 
 function getContactDetails(req: Request, res: Response, next: NextFunction) {
   try {
+    req.session.isEdit = _.has(req.query, 'edit');
     const { application } = req.session.appeal;
     const contactDetails = application && application.contactDetails || null;
     return res.render('appeal-application/contact-details.njk', { contactDetails });
@@ -52,8 +55,8 @@ function postContactDetails(updateAppealService: UpdateAppealService) {
 
       req.session.appeal.application.contactDetails = contactDetails;
       await updateAppealService.submitEvent(Events.EDIT_APPEAL, req);
+      return getConditionalRedirectUrl(req, res, paths.taskList);
 
-      return res.redirect(paths.taskList);
     } catch
       (error) {
       next(error);

--- a/app/controllers/home-office-details.ts
+++ b/app/controllers/home-office-details.ts
@@ -10,7 +10,7 @@ import { getConditionalRedirectUrl } from '../utils/url-utils';
 
 function getHomeOfficeDetails(req: Request, res: Response, next: NextFunction) {
   try {
-    req.session.isEdit = _.has(req.query, 'edit');
+    req.session.appeal.application.isEdit = _.has(req.query, 'edit');
 
     const { homeOfficeRefNumber } = req.session.appeal.application || null;
     res.render('appeal-application/home-office/details.njk', { homeOfficeRefNumber });
@@ -43,7 +43,7 @@ function postHomeOfficeDetails(updateAppealService: UpdateAppealService) {
 
 function getDateLetterSent(req: Request, res: Response, next: NextFunction) {
   try {
-    req.session.isEdit = _.has(req.query, 'edit');
+    req.session.appeal.application.isEdit = _.has(req.query, 'edit');
 
     const { dateLetterSent } = req.session.appeal.application;
     res.render('appeal-application/home-office/letter-sent.njk', { dateLetterSent });

--- a/app/controllers/personal-details.ts
+++ b/app/controllers/personal-details.ts
@@ -19,7 +19,7 @@ import { getConditionalRedirectUrl } from '../utils/url-utils';
 
 function getDateOfBirthPage(req: Request, res: Response, next: NextFunction) {
   try {
-    req.session.isEdit = _.has(req.query, 'edit');
+    req.session.appeal.application.isEdit = _.has(req.query, 'edit');
 
     const { application } = req.session.appeal;
     const dob = application.personalDetails && application.personalDetails.dob || null;
@@ -60,7 +60,7 @@ function postDateOfBirth(updateAppealService: UpdateAppealService) {
 
 function getNamePage(req: Request, res: Response, next: NextFunction) {
   try {
-    req.session.isEdit = _.has(req.query, 'edit');
+    req.session.appeal.application.isEdit = _.has(req.query, 'edit');
     const personalDetails = req.session.appeal.application.personalDetails;
     return res.render('appeal-application/personal-details/name.njk', { personalDetails });
   } catch (e) {
@@ -99,7 +99,7 @@ function postNamePage(updateAppealService: UpdateAppealService) {
 
 function getNationalityPage(req: Request, res: Response, next: NextFunction) {
   try {
-    req.session.isEdit = _.has(req.query, 'edit');
+    req.session.appeal.application.isEdit = _.has(req.query, 'edit');
 
     const { application } = req.session.appeal;
     const nationality = application.personalDetails && application.personalDetails.nationality || null;
@@ -239,7 +239,7 @@ function findAddress(udprn: string, addresses: Address[]): Address {
 
 function getManualEnterAddressPage(req: Request, res: Response, next: NextFunction) {
   try {
-    req.session.isEdit = _.has(req.query, 'edit');
+    req.session.appeal.application.isEdit = _.has(req.query, 'edit');
 
     let model;
     if (_.has(req.session.appeal.application, 'addressLookup.selected')) {

--- a/app/controllers/type-of-appeal.ts
+++ b/app/controllers/type-of-appeal.ts
@@ -9,7 +9,7 @@ import { getConditionalRedirectUrl } from '../utils/url-utils';
 
 function getTypeOfAppeal(req: Request, res: Response, next: NextFunction) {
   try {
-    req.session.isEdit = _.has(req.query, 'edit');
+    req.session.appeal.application.isEdit = _.has(req.query, 'edit');
 
     const appealType = req.session.appeal.application && req.session.appeal.application.appealType || [];
     const types = appealTypes.map(type => {

--- a/app/utils/url-utils.ts
+++ b/app/utils/url-utils.ts
@@ -1,5 +1,6 @@
 import config from 'config';
-import { Request } from 'express';
+import { Request, Response } from 'express';
+import { paths } from '../paths';
 
 const appPort = config.get('node.port');
 
@@ -10,4 +11,18 @@ function getUrl(protocol: string, host: string, path: string): string {
 
 export function getIdamRedirectUrl(req: Request): string {
   return getUrl('https', req.hostname, '/redirectUrl');
+}
+
+/**
+ * Helps to workout where to redirect the user if it is an edit also resets the isEdit flag each time.
+ * @param req the request
+ * @param res the response
+ * @param redirectUrl the page to be redirected if action is not an edit
+ */
+export function getConditionalRedirectUrl(req: Request, res: Response, redirectUrl: string) {
+  if (req.session.isEdit === true) {
+    req.session.isEdit = false;
+    return res.redirect(paths.checkAndSend);
+  }
+  return res.redirect(redirectUrl);
 }

--- a/app/utils/url-utils.ts
+++ b/app/utils/url-utils.ts
@@ -20,8 +20,8 @@ export function getIdamRedirectUrl(req: Request): string {
  * @param redirectUrl the page to be redirected if action is not an edit
  */
 export function getConditionalRedirectUrl(req: Request, res: Response, redirectUrl: string) {
-  if (req.session.isEdit === true) {
-    req.session.isEdit = false;
+  if (req.session.appeal.application.isEdit === true) {
+    req.session.appeal.application.isEdit = false;
     return res.redirect(paths.checkAndSend);
   }
   return res.redirect(redirectUrl);

--- a/locale/en.json
+++ b/locale/en.json
@@ -219,11 +219,12 @@
     "email": "Email",
     "emailAddress": "Enter email address",
     "homeOfficeRefNumber": "Home Office reference number",
-    "dateLetterSent": "Date letter Sent",
+    "dateLetterSent": "Date letter sent",
     "name": "Name",
     "dob": "Date of birth",
     "nationality": "Nationality",
     "contactDetails": "Contact details",
+    "addressDetails": "Address",
     "appealType": "Appeal type"
   },
   "components": {

--- a/test/unit/controllers/check-and-send.test.ts
+++ b/test/unit/controllers/check-and-send.test.ts
@@ -14,33 +14,39 @@ const express = require('express');
 
 function getMockedSummaryRows() {
   return [ {
-    actions: { items: [ { href: '/home-office/details', text: 'Change' } ] },
+    actions: { items: [ { href: '/home-office/details?edit', text: 'Change' } ] },
     key: { text: 'Home Office reference number' },
     value: { html: 'A1234567' }
   }, {
-    actions: { items: [ { href: '/home-office/letter-sent', text: 'Change' } ] },
-    key: { text: 'Date letter Sent' },
+    actions: { items: [ { href: '/home-office/letter-sent?edit', text: 'Change' } ] },
+    key: { text: 'Date letter sent' },
     value: { html: '1 July 2019' }
   }, {
-    actions: { items: [ { href: '/personal-details/name', text: 'Change' } ] },
+    actions: { items: [ { href: '/personal-details/name?edit', text: 'Change' } ] },
     key: { text: 'Name' },
     value: { html: 'Pedro Jimenez' }
   }, {
-    actions: { items: [ { href: '/personal-details/date-of-birth', text: 'Change' } ] },
+    actions: { items: [ { href: '/personal-details/date-of-birth?edit', text: 'Change' } ] },
     key: { text: 'Date of birth' },
     value: { html: '10 October 1980' }
   }, {
-    actions: { items: [ { href: '/personal-details/nationality', text: 'Change' } ] },
+    actions: { items: [ { href: '/personal-details/nationality?edit', text: 'Change' } ] },
     key: { text: 'Nationality' },
     value: { html: 'Austria' }
   }, {
-    actions: { items: [ { href: '/contact-details', text: 'Change' } ] },
-    key: { text: 'Contact details' },
+    actions: { items: [ { href: '/personal-details/enter-address?edit', text: 'Change' } ] },
+    key: { text: 'Address' },
     value: {
-      html: 'pedro.jimenez@example.net<br>07123456789<br>60 Beautiful Street<br>Flat 2<br>London<br>W1W 7RT<br>London'
+      html: '60 Beautiful Street<br>Flat 2<br>London<br>W1W 7RT<br>London'
     }
   }, {
-    actions: { items: [ { href: '/type-of-appeal', text: 'Change' } ] },
+    actions: { items: [ { href: '/contact-details?edit', text: 'Change' } ] },
+    key: { text: 'Contact details' },
+    value: {
+      html: 'pedro.jimenez@example.net<br>07123456789'
+    }
+  }, {
+    actions: { items: [ { href: '/type-of-appeal?edit', text: 'Change' } ] },
     key: { text: 'Appeal type' },
     value: { html: 'Protection' }
   } ];

--- a/test/unit/controllers/contact-details.test.ts
+++ b/test/unit/controllers/contact-details.test.ts
@@ -77,7 +77,7 @@ describe('Contact details Controller', () => {
     it('when called with edit param getContactDetail should render type-of-appeal.njk and update session', () => {
       req.query = { 'edit': '' };
       getContactDetails(req as Request, res as Response, next);
-      expect(req.session.isEdit).to.have.eq(true);
+      expect(req.session.appeal.application.isEdit).to.have.eq(true);
       expect(res.render).to.have.been.calledOnce.calledWith('appeal-application/contact-details.njk');
     });
 
@@ -230,7 +230,7 @@ describe('Contact details Controller', () => {
         expect(res.redirect).to.have.been.calledWith(paths.taskList);
       });
       it('when in edit mode should validate email and redirect to check-and-send.njk and reset isEdit flag', async () => {
-        req.session.isEdit = true;
+        req.session.appeal.application.isEdit = true;
 
         req.body = {
           selections: [ 'email' ],
@@ -247,7 +247,7 @@ describe('Contact details Controller', () => {
         await postContactDetails(updateAppealService as UpdateAppealService)(req as Request, res as Response, next);
         expect(req.session.appeal.application.contactDetails).to.deep.equal(contactDetailsExpectation);
         expect(res.redirect).to.have.been.calledWith(paths.checkAndSend);
-        expect(req.session.isEdit).to.have.eq(false);
+        expect(req.session.appeal.application.isEdit).to.have.eq(false);
       });
     });
 
@@ -330,7 +330,7 @@ describe('Contact details Controller', () => {
     });
 
     it('when in edit mode should validate phone number and redirect to check-and-send.njk and reset isEdit', async () => {
-      req.session.isEdit = true;
+      req.session.appeal.application.isEdit = true;
 
       req.body = {
         selections: [ 'text-message' ],
@@ -347,7 +347,7 @@ describe('Contact details Controller', () => {
       await postContactDetails(updateAppealService as UpdateAppealService)(req as Request, res as Response, next);
       expect(req.session.appeal.application.contactDetails).to.deep.equal(contactDetailsExpectation);
       expect(res.redirect).to.have.been.calledWith(paths.checkAndSend);
-      expect(req.session.isEdit).to.have.eq(false);
+      expect(req.session.appeal.application.isEdit).to.have.eq(false);
     });
   });
 });

--- a/test/unit/controllers/contact-details.test.ts
+++ b/test/unit/controllers/contact-details.test.ts
@@ -74,6 +74,13 @@ describe('Contact details Controller', () => {
       expect(res.render).to.have.been.calledOnce.calledWith('appeal-application/contact-details.njk');
     });
 
+    it('when called with edit param getContactDetail should render type-of-appeal.njk and update session', () => {
+      req.query = { 'edit': '' };
+      getContactDetails(req as Request, res as Response, next);
+      expect(req.session.isEdit).to.have.eq(true);
+      expect(res.render).to.have.been.calledOnce.calledWith('appeal-application/contact-details.njk');
+    });
+
     it('getContactDetails should catch an exception and call next()', () => {
       const error = new Error('the error');
       res.render = sandbox.stub().throws(error);
@@ -222,6 +229,26 @@ describe('Contact details Controller', () => {
         expect(req.session.appeal.application.contactDetails).to.deep.equal(contactDetailsExpectation);
         expect(res.redirect).to.have.been.calledWith(paths.taskList);
       });
+      it('when in edit mode should validate email and redirect to check-and-send.njk and reset isEdit flag', async () => {
+        req.session.isEdit = true;
+
+        req.body = {
+          selections: [ 'email' ],
+          'email-value': 'valid@example.net'
+        };
+
+        const contactDetailsExpectation = {
+          email: 'valid@example.net',
+          phone: null,
+          wantsEmail: true,
+          wantsSms: false
+        };
+
+        await postContactDetails(updateAppealService as UpdateAppealService)(req as Request, res as Response, next);
+        expect(req.session.appeal.application.contactDetails).to.deep.equal(contactDetailsExpectation);
+        expect(res.redirect).to.have.been.calledWith(paths.checkAndSend);
+        expect(req.session.isEdit).to.have.eq(false);
+      });
     });
 
     describe('text message cases', () => {
@@ -302,5 +329,25 @@ describe('Contact details Controller', () => {
       });
     });
 
+    it('when in edit mode should validate phone number and redirect to check-and-send.njk and reset isEdit', async () => {
+      req.session.isEdit = true;
+
+      req.body = {
+        selections: [ 'text-message' ],
+        'text-message-value': '07123456789'
+      };
+
+      const contactDetailsExpectation = {
+        email: null,
+        phone: '07123456789',
+        wantsEmail: false,
+        wantsSms: true
+      };
+
+      await postContactDetails(updateAppealService as UpdateAppealService)(req as Request, res as Response, next);
+      expect(req.session.appeal.application.contactDetails).to.deep.equal(contactDetailsExpectation);
+      expect(res.redirect).to.have.been.calledWith(paths.checkAndSend);
+      expect(req.session.isEdit).to.have.eq(false);
+    });
   });
 });

--- a/test/unit/controllers/enter-address.test.ts
+++ b/test/unit/controllers/enter-address.test.ts
@@ -1,5 +1,4 @@
 import { Address, Point } from '@hmcts/os-places-client';
-const express = require('express');
 import { NextFunction, Request, Response } from 'express';
 import * as _ from 'lodash';
 import {
@@ -11,6 +10,8 @@ import { paths } from '../../../app/paths';
 import UpdateAppealService from '../../../app/service/update-appeal-service';
 import Logger from '../../../app/utils/logger';
 import { expect, sinon } from '../../utils/testUtils';
+
+const express = require('express');
 
 describe('Personal Details Controller', function () {
   let sandbox: sinon.SinonSandbox;
@@ -74,7 +75,7 @@ describe('Personal Details Controller', function () {
         selected: 'udprn',
         result: {
           addresses: [
-            new Address('123', 'organisationName', 'departmentName', 'poBoxNumber', 'buildingName', 'subBuildingName', 2, 'thoroughfareName', 'dependentThoroughfareName', 'dependentLocality', 'doubleDependentLocality', 'postTown', 'postcode', 'postcodeType', 'formattedAddress', new Point('type', [1, 2]), 'udprn')
+            new Address('123', 'organisationName', 'departmentName', 'poBoxNumber', 'buildingName', 'subBuildingName', 2, 'thoroughfareName', 'dependentThoroughfareName', 'dependentLocality', 'doubleDependentLocality', 'postTown', 'postcode', 'postcodeType', 'formattedAddress', new Point('type', [ 1, 2 ]), 'udprn')
           ]
         }
       };
@@ -91,10 +92,37 @@ describe('Personal Details Controller', function () {
       });
     });
 
-    it('should render appeal-application/personal-details/enter-address.njk with address from CCD if page loaded without postcode lookup', function () {
+    it('when called with edit param should render appeal-application/personal-details/enter-address.njk and update session', function () {
+      req.query = { 'edit': '' };
+
       // @ts-ignore
       req.session.appeal.application.addressLookup = {
+        postcode: 'selectedPostcode',
+        selected: 'udprn',
+        result: {
+          addresses: [
+            new Address('123', 'organisationName', 'departmentName', 'poBoxNumber', 'buildingName', 'subBuildingName', 2, 'thoroughfareName', 'dependentThoroughfareName', 'dependentLocality', 'doubleDependentLocality', 'postTown', 'postcode', 'postcodeType', 'formattedAddress', new Point('type', [ 1, 2 ]), 'udprn')
+          ]
+        }
       };
+      getManualEnterAddressPage(req as Request, res as Response, next);
+      expect(res.render).to.have.been.calledOnce.calledWith('appeal-application/personal-details/enter-address.njk', {
+        address: {
+          line1: 'subBuildingName buildingName',
+          line2: '2 dependentThoroughfareName, thoroughfareName, doubleDependentLocality, dependentLocality',
+          city: 'postTown',
+          county: '',
+          postcode: 'postcode'
+        },
+        selectedPostcode: 'selectedPostcode'
+      });
+      expect(req.session.isEdit).to.have.eq(true);
+
+    });
+
+    it('should render appeal-application/personal-details/enter-address.njk with address from CCD if page loaded without postcode lookup', function () {
+      // @ts-ignore
+      req.session.appeal.application.addressLookup = {};
       _.set(req.session.appeal.application, 'personalDetails.address', {
         line1: 'subBuildingName buildingName',
         line2: '2 dependentThoroughfareName, thoroughfareName, doubleDependentLocality, dependentLocality',
@@ -121,7 +149,7 @@ describe('Personal Details Controller', function () {
         selected: 'udprn',
         result: {
           addresses: [
-            new Address('123', 'organisationName', 'departmentName', 'poBoxNumber', 'buildingName', 'subBuildingName', 2, 'thoroughfareName', 'dependentThoroughfareName', 'dependentLocality', 'doubleDependentLocality', 'postTown', 'postcode', 'postcodeType', 'formattedAddress', new Point('type', [1, 2]), 'udprn')
+            new Address('123', 'organisationName', 'departmentName', 'poBoxNumber', 'buildingName', 'subBuildingName', 2, 'thoroughfareName', 'dependentThoroughfareName', 'dependentLocality', 'doubleDependentLocality', 'postTown', 'postcode', 'postcodeType', 'formattedAddress', new Point('type', [ 1, 2 ]), 'udprn')
           ]
         }
       };
@@ -153,6 +181,28 @@ describe('Personal Details Controller', function () {
 
       await postManualEnterAddressPage(updateAppealService as UpdateAppealService)(req as Request, res as Response, next);
       expect(res.redirect).to.have.been.calledWith(paths.taskList);
+    });
+
+    it('should catch an exception and call next()', async () => {
+      const error = new Error('the error');
+      res.render = sandbox.stub().throws(error);
+      await postManualEnterAddressPage(updateAppealService as UpdateAppealService)(req as Request, res as Response, next);
+      expect(next).to.have.been.calledOnce.calledWith(error);
+    });
+
+    it('when in edit mode should validate and redirect to CYA page and reset the isEdit flag', async () => {
+      req.session.isEdit = true;
+
+      req.body['address-line-1'] = '60 GPS';
+      req.body['address-town'] = 'London';
+      req.body['address-county'] = 'London';
+      req.body['address-line-2'] = '';
+      req.body['address-postcode'] = 'W1W 7RT';
+
+      await postManualEnterAddressPage(updateAppealService as UpdateAppealService)(req as Request, res as Response, next);
+      expect(res.redirect).to.have.been.calledWith(paths.checkAndSend);
+      expect(req.session.isEdit).to.have.eq(false);
+
     });
 
     it('should catch an exception and call next()', async () => {

--- a/test/unit/controllers/enter-address.test.ts
+++ b/test/unit/controllers/enter-address.test.ts
@@ -116,7 +116,7 @@ describe('Personal Details Controller', function () {
         },
         selectedPostcode: 'selectedPostcode'
       });
-      expect(req.session.isEdit).to.have.eq(true);
+      expect(req.session.appeal.application.isEdit).to.have.eq(true);
 
     });
 
@@ -191,7 +191,7 @@ describe('Personal Details Controller', function () {
     });
 
     it('when in edit mode should validate and redirect to CYA page and reset the isEdit flag', async () => {
-      req.session.isEdit = true;
+      req.session.appeal.application.isEdit = true;
 
       req.body['address-line-1'] = '60 GPS';
       req.body['address-town'] = 'London';
@@ -201,7 +201,7 @@ describe('Personal Details Controller', function () {
 
       await postManualEnterAddressPage(updateAppealService as UpdateAppealService)(req as Request, res as Response, next);
       expect(res.redirect).to.have.been.calledWith(paths.checkAndSend);
-      expect(req.session.isEdit).to.have.eq(false);
+      expect(req.session.appeal.application.isEdit).to.have.eq(false);
 
     });
 

--- a/test/unit/controllers/enter-dob.test.ts
+++ b/test/unit/controllers/enter-dob.test.ts
@@ -75,7 +75,7 @@ describe('Personal Details Controller', function () {
 
       getDateOfBirthPage(req as Request, res as Response, next);
 
-      expect(req.session.isEdit).to.have.eq(true);
+      expect(req.session.appeal.application.isEdit).to.have.eq(true);
       expect(res.render).to.have.been.calledOnce.calledWith('appeal-application/personal-details/date-of-birth.njk');
     });
   });
@@ -94,7 +94,7 @@ describe('Personal Details Controller', function () {
     });
 
     it('when in edit mode should validate and redirect to CYA page and reset isEdit flag', async () => {
-      req.session.isEdit = true;
+      req.session.appeal.application.isEdit = true;
 
       req.body.day = 1;
       req.body.month = 11;
@@ -105,7 +105,7 @@ describe('Personal Details Controller', function () {
       await postDateOfBirth(updateAppealService as UpdateAppealService)(req as Request, res as Response, next);
 
       expect(res.redirect).to.have.been.calledWith(paths.checkAndSend);
-      expect(req.session.isEdit).to.have.eq(false);
+      expect(req.session.appeal.application.isEdit).to.have.eq(false);
 
     });
   });

--- a/test/unit/controllers/enter-dob.test.ts
+++ b/test/unit/controllers/enter-dob.test.ts
@@ -69,6 +69,15 @@ describe('Personal Details Controller', function () {
       getDateOfBirthPage(req as Request, res as Response, next);
       expect(res.render).to.have.been.calledOnce.calledWith('appeal-application/personal-details/date-of-birth.njk');
     });
+
+    it('when called with edit param should render appeal-application/personal-details/date-of-birth.njk and update session', () => {
+      req.query = { 'edit': '' };
+
+      getDateOfBirthPage(req as Request, res as Response, next);
+
+      expect(req.session.isEdit).to.have.eq(true);
+      expect(res.render).to.have.been.calledOnce.calledWith('appeal-application/personal-details/date-of-birth.njk');
+    });
   });
 
   describe('postDateOfBirth', () => {
@@ -82,6 +91,22 @@ describe('Personal Details Controller', function () {
       await postDateOfBirth(updateAppealService as UpdateAppealService)(req as Request, res as Response, next);
 
       expect(res.redirect).to.have.been.calledWith(paths.personalDetails.nationality);
+    });
+
+    it('when in edit mode should validate and redirect to CYA page and reset isEdit flag', async () => {
+      req.session.isEdit = true;
+
+      req.body.day = 1;
+      req.body.month = 11;
+      req.body.year = 1993;
+
+      req.session.personalDetails = {};
+
+      await postDateOfBirth(updateAppealService as UpdateAppealService)(req as Request, res as Response, next);
+
+      expect(res.redirect).to.have.been.calledWith(paths.checkAndSend);
+      expect(req.session.isEdit).to.have.eq(false);
+
     });
   });
 
@@ -101,6 +126,7 @@ describe('Personal Details Controller', function () {
           text: errorMessage
         };
       }
+
       const errorDay = createError('day', i18n.validationErrors.dateOfBirth.incorrectFormat);
       const errorMonth = createError('month', i18n.validationErrors.dateOfBirth.incorrectFormat);
       const errorYear = createError('year', i18n.validationErrors.dateOfBirth.incorrectFormat);
@@ -162,4 +188,5 @@ describe('Personal Details Controller', function () {
       );
     });
   });
-});
+})
+;

--- a/test/unit/controllers/enter-name-page.test.ts
+++ b/test/unit/controllers/enter-name-page.test.ts
@@ -73,7 +73,7 @@ describe('Personal Details Controller', function () {
     it('when called with edit should render personal-details/name.njk and update session', function () {
       req.query = { 'edit': '' };
       getNamePage(req as Request, res as Response, next);
-      expect(req.session.isEdit).to.have.eq(true);
+      expect(req.session.appeal.application.isEdit).to.have.eq(true);
       expect(res.render).to.have.been.calledOnce.calledWith('appeal-application/personal-details/name.njk');
     });
 
@@ -90,7 +90,6 @@ describe('Personal Details Controller', function () {
     it('should validate and redirect to next page personal-details/date-of-birth', async () => {
       req.body.givenNames = 'Lewis';
       req.body.familyName = 'Williams';
-      req.session.personalDetails = {};
 
       await postNamePage(updateAppealService as UpdateAppealService)(req as Request, res as Response, next);
 
@@ -98,16 +97,15 @@ describe('Personal Details Controller', function () {
     });
 
     it('when in edit mode should validate and redirect to CYA page and reset isEdit flag', async () => {
-      req.session.isEdit = true;
+      req.session.appeal.application.isEdit = true;
 
       req.body.givenNames = 'Lewis';
       req.body.familyName = 'Williams';
-      req.session.personalDetails = {};
 
       await postNamePage(updateAppealService as UpdateAppealService)(req as Request, res as Response, next);
 
       expect(res.redirect).to.have.been.calledWith(paths.checkAndSend);
-      expect(req.session.isEdit).to.have.eq(false);
+      expect(req.session.appeal.application.isEdit).to.have.eq(false);
 
     });
   });

--- a/test/unit/controllers/home-office-details.test.ts
+++ b/test/unit/controllers/home-office-details.test.ts
@@ -90,7 +90,7 @@ describe('Home Office Details Controller', function () {
     it('when called with edit param should render home-office/details.njk and update session', function () {
       req.query = { 'edit': '' };
       getHomeOfficeDetails(req as Request, res as Response, next);
-      expect(req.session.isEdit).to.have.eq(true);
+      expect(req.session.appeal.application.isEdit).to.have.eq(true);
       expect(res.render).to.have.been.calledOnce.calledWith('appeal-application/home-office/details.njk');
     });
 
@@ -112,14 +112,14 @@ describe('Home Office Details Controller', function () {
     });
 
     it('when in edit mode should validate and redirect check-and-send.njk and reset isEdit flag', async () => {
-      req.session.isEdit = true;
+      req.session.appeal.application.isEdit = true;
 
       req.body['homeOfficeRefNumber'] = 'A1234567';
       await postHomeOfficeDetails(updateAppealService as UpdateAppealService)(req as Request, res as Response, next);
 
       expect(req.session.appeal.application.homeOfficeRefNumber).to.be.eql('A1234567');
       expect(res.redirect).to.have.been.calledWith(paths.checkAndSend);
-      expect(req.session.isEdit).to.have.eq(false);
+      expect(req.session.appeal.application.isEdit).to.have.eq(false);
 
     });
 
@@ -162,7 +162,7 @@ describe('Home Office Details Controller', function () {
       req.query = { 'edit': '' };
 
       getDateLetterSent(req as Request, res as Response, next);
-      expect(req.session.isEdit).to.have.eq(true);
+      expect(req.session.appeal.application.isEdit).to.have.eq(true);
       expect(res.render).to.have.been.calledWith('appeal-application/home-office/letter-sent.njk');
     });
 
@@ -192,7 +192,7 @@ describe('Home Office Details Controller', function () {
     });
 
     it('when in edit mode should validate and redirect to CYA page if letter is not older than 14 days and reset isEdit flag', async () => {
-      req.session.isEdit = true;
+      req.session.appeal.application.isEdit = true;
 
       const date = moment().subtract(14, 'd');
       req.body['day'] = date.format('DD');
@@ -206,7 +206,7 @@ describe('Home Office Details Controller', function () {
       expect(dateLetterSent.year).to.be.eql(date.format('YYYY'));
 
       expect(res.redirect).to.have.been.calledWith(paths.checkAndSend);
-      expect(req.session.isEdit).to.have.eq(false);
+      expect(req.session.appeal.application.isEdit).to.have.eq(false);
 
     });
 
@@ -226,7 +226,7 @@ describe('Home Office Details Controller', function () {
     });
 
     it('when in edit mode should validate and redirect to Appeal Late page if appeal is later than 14 days and isEdit flag is not updated', async () => {
-      req.session.isEdit = true;
+      req.session.appeal.application.isEdit = true;
 
       const date = moment().subtract(15, 'd');
       req.body['day'] = date.format('DD');
@@ -240,7 +240,7 @@ describe('Home Office Details Controller', function () {
       expect(dateLetterSent.year).to.be.eql(date.format('YYYY'));
 
       expect(res.redirect).to.have.been.calledWith(paths.homeOffice.appealLate);
-      expect(req.session.isEdit).to.have.eq(true);
+      expect(req.session.appeal.application.isEdit).to.have.eq(true);
 
     });
 
@@ -316,12 +316,12 @@ describe('Home Office Details Controller', function () {
     });
 
     it('when in edit mode should validate and redirect to CYA and reset isEdit flag', async () => {
-      req.session.isEdit = true;
+      req.session.appeal.application.isEdit = true;
       req.body['appeal-late'] = 'My explanation why am late';
       await postAppealLate(updateAppealService as UpdateAppealService)(req as Request, res as Response, next);
 
       expect(res.redirect).to.have.been.calledWith(paths.checkAndSend);
-      expect(req.session.isEdit).to.have.eq(false);
+      expect(req.session.appeal.application.isEdit).to.have.eq(false);
 
     });
 

--- a/test/unit/controllers/home-office-details.test.ts
+++ b/test/unit/controllers/home-office-details.test.ts
@@ -87,6 +87,13 @@ describe('Home Office Details Controller', function () {
       expect(res.render).to.have.been.calledOnce.calledWith('appeal-application/home-office/details.njk');
     });
 
+    it('when called with edit param should render home-office/details.njk and update session', function () {
+      req.query = { 'edit': '' };
+      getHomeOfficeDetails(req as Request, res as Response, next);
+      expect(req.session.isEdit).to.have.eq(true);
+      expect(res.render).to.have.been.calledOnce.calledWith('appeal-application/home-office/details.njk');
+    });
+
     it('should catch exception and call next with the error', function () {
       const error = new Error('an error');
       res.render = sandbox.stub().throws(error);
@@ -102,6 +109,18 @@ describe('Home Office Details Controller', function () {
 
       expect(req.session.appeal.application.homeOfficeRefNumber).to.be.eql('A1234567');
       expect(res.redirect).to.have.been.calledWith(paths.homeOffice.letterSent);
+    });
+
+    it('when in edit mode should validate and redirect check-and-send.njk and reset isEdit flag', async () => {
+      req.session.isEdit = true;
+
+      req.body['homeOfficeRefNumber'] = 'A1234567';
+      await postHomeOfficeDetails(updateAppealService as UpdateAppealService)(req as Request, res as Response, next);
+
+      expect(req.session.appeal.application.homeOfficeRefNumber).to.be.eql('A1234567');
+      expect(res.redirect).to.have.been.calledWith(paths.checkAndSend);
+      expect(req.session.isEdit).to.have.eq(false);
+
     });
 
     it('should fail validation and render home-office/details.njk with error', async () => {
@@ -139,6 +158,14 @@ describe('Home Office Details Controller', function () {
       expect(res.render).to.have.been.calledWith('appeal-application/home-office/letter-sent.njk');
     });
 
+    it('when called with edit param should render home-office/letter-sent.njk and update session', () => {
+      req.query = { 'edit': '' };
+
+      getDateLetterSent(req as Request, res as Response, next);
+      expect(req.session.isEdit).to.have.eq(true);
+      expect(res.render).to.have.been.calledWith('appeal-application/home-office/letter-sent.njk');
+    });
+
     it('should catch exception and call next with the error', () => {
       const error = new Error('an error');
       res.render = sandbox.stub().throws(error);
@@ -164,6 +191,25 @@ describe('Home Office Details Controller', function () {
       expect(res.redirect).to.have.been.calledWith(paths.taskList);
     });
 
+    it('when in edit mode should validate and redirect to CYA page if letter is not older than 14 days and reset isEdit flag', async () => {
+      req.session.isEdit = true;
+
+      const date = moment().subtract(14, 'd');
+      req.body['day'] = date.format('DD');
+      req.body['month'] = date.format('MM');
+      req.body['year'] = date.format('YYYY');
+      await postDateLetterSent(updateAppealService as UpdateAppealService)(req as Request, res as Response, next);
+
+      const { dateLetterSent } = req.session.appeal.application;
+      expect(dateLetterSent.day).to.be.eql(date.format('DD'));
+      expect(dateLetterSent.month).to.be.eql(date.format('MM'));
+      expect(dateLetterSent.year).to.be.eql(date.format('YYYY'));
+
+      expect(res.redirect).to.have.been.calledWith(paths.checkAndSend);
+      expect(req.session.isEdit).to.have.eq(false);
+
+    });
+
     it('should validate and redirect to Appeal Late page', async () => {
       const date = moment().subtract(15, 'd');
       req.body['day'] = date.format('DD');
@@ -177,6 +223,25 @@ describe('Home Office Details Controller', function () {
       expect(dateLetterSent.year).to.be.eql(date.format('YYYY'));
 
       expect(res.redirect).to.have.been.calledWith(paths.homeOffice.appealLate);
+    });
+
+    it('when in edit mode should validate and redirect to Appeal Late page if appeal is later than 14 days and isEdit flag is not updated', async () => {
+      req.session.isEdit = true;
+
+      const date = moment().subtract(15, 'd');
+      req.body['day'] = date.format('DD');
+      req.body['month'] = date.format('MM');
+      req.body['year'] = date.format('YYYY');
+      await postDateLetterSent(updateAppealService as UpdateAppealService)(req as Request, res as Response, next);
+
+      const { dateLetterSent } = req.session.appeal.application;
+      expect(dateLetterSent.day).to.be.eql(date.format('DD'));
+      expect(dateLetterSent.month).to.be.eql(date.format('MM'));
+      expect(dateLetterSent.year).to.be.eql(date.format('YYYY'));
+
+      expect(res.redirect).to.have.been.calledWith(paths.homeOffice.appealLate);
+      expect(req.session.isEdit).to.have.eq(true);
+
     });
 
     it('should fail validation if the date is in the future and render error', async () => {
@@ -244,10 +309,20 @@ describe('Home Office Details Controller', function () {
     });
 
     it('should validate and redirect to Task List', async () => {
-      req.body['appeal-late'] = 'My exlplanation why am late';
+      req.body['appeal-late'] = 'My explanation why am late';
       await postAppealLate(updateAppealService as UpdateAppealService)(req as Request, res as Response, next);
 
       expect(res.redirect).to.have.been.calledWith(paths.taskList);
+    });
+
+    it('when in edit mode should validate and redirect to CYA and reset isEdit flag', async () => {
+      req.session.isEdit = true;
+      req.body['appeal-late'] = 'My explanation why am late';
+      await postAppealLate(updateAppealService as UpdateAppealService)(req as Request, res as Response, next);
+
+      expect(res.redirect).to.have.been.calledWith(paths.checkAndSend);
+      expect(req.session.isEdit).to.have.eq(false);
+
     });
 
     it('should catch exception and call next with the error', async () => {

--- a/test/unit/controllers/nationatily-page.test.ts
+++ b/test/unit/controllers/nationatily-page.test.ts
@@ -80,7 +80,7 @@ describe('Nationality details Controller', function () {
       req.query = { 'edit': '' };
       getNationalityPage(req as Request, res as Response, next);
       expect(res.render).to.have.been.calledOnce.calledWith('appeal-application/personal-details/nationality.njk');
-      expect(req.session.isEdit).to.have.eq(true);
+      expect(req.session.appeal.application.isEdit).to.have.eq(true);
     });
 
     it('should catch an exception and call next()', () => {
@@ -100,13 +100,13 @@ describe('Nationality details Controller', function () {
     });
 
     it('when in edit mode should validate and redirect to CYA page and reset isEdit flag', async () => {
-      req.session.isEdit = true;
+      req.session.appeal.application.isEdit = true;
 
       req.body.nationality = 'AQ';
       await postNationalityPage(updateAppealService as UpdateAppealService)(req as Request, res as Response, next);
 
       expect(res.redirect).to.have.been.calledWith(paths.checkAndSend);
-      expect(req.session.isEdit).to.have.eq(false);
+      expect(req.session.appeal.application.isEdit).to.have.eq(false);
 
     });
 

--- a/test/unit/controllers/type-of-appeal.test.ts
+++ b/test/unit/controllers/type-of-appeal.test.ts
@@ -76,7 +76,7 @@ describe('Type of appeal Controller', () => {
 
       getTypeOfAppeal(req as Request, res as Response, next);
 
-      expect(req.session.isEdit).to.have.eq(true);
+      expect(req.session.appeal.application.isEdit).to.have.eq(true);
       expect(res.render).to.have.been.calledOnce.calledWith('appeal-application/type-of-appeal.njk', { types: appealTypes });
     });
 
@@ -113,13 +113,13 @@ describe('Type of appeal Controller', () => {
     });
 
     it('when in edit mode should validate and redirect to the CYA page and reset isEdit flag', async () => {
-      req.session.isEdit = true;
+      req.session.appeal.application.isEdit = true;
 
       req.body = { 'button': 'save-and-continue', 'appealType': 'human-rights' };
 
       await postTypeOfAppeal(updateAppealService as UpdateAppealService)(req as Request, res as Response, next);
       expect(res.redirect).to.have.been.calledOnce.calledWith(paths.checkAndSend);
-      expect(req.session.isEdit).to.have.eq(false);
+      expect(req.session.appeal.application.isEdit).to.have.eq(false);
 
     });
 
@@ -131,13 +131,13 @@ describe('Type of appeal Controller', () => {
     });
 
     it('postTypeOfAppeal when in edit mode when clicked on save-and-continue with multiple selections should redirect to CYA page and reset isEdit flag', async () => {
-      req.session.isEdit = true;
+      req.session.appeal.application.isEdit = true;
 
       req.body = { 'button': 'save-and-continue', 'appealType': [ 'human-rights', 'eea', 'protection' ] };
 
       await postTypeOfAppeal(updateAppealService as UpdateAppealService)(req as Request, res as Response, next);
       expect(res.redirect).to.have.been.calledOnce.calledWith(paths.checkAndSend);
-      expect(req.session.isEdit).to.have.eq(false);
+      expect(req.session.appeal.application.isEdit).to.have.eq(false);
 
     });
 

--- a/test/unit/controllers/type-of-appeal.test.ts
+++ b/test/unit/controllers/type-of-appeal.test.ts
@@ -71,6 +71,15 @@ describe('Type of appeal Controller', () => {
       expect(res.render).to.have.been.calledOnce.calledWith('appeal-application/type-of-appeal.njk', { types: appealTypes });
     });
 
+    it('when called with edit param should render type-of-appeal.njk and update session ', () => {
+      req.query = { 'edit': '' };
+
+      getTypeOfAppeal(req as Request, res as Response, next);
+
+      expect(req.session.isEdit).to.have.eq(true);
+      expect(res.render).to.have.been.calledOnce.calledWith('appeal-application/type-of-appeal.njk', { types: appealTypes });
+    });
+
     it('getTypeOfAppeal should catch exception and call next with the error', () => {
       const error = new Error('an error');
       res.render = sandbox.stub().throws(error);
@@ -100,14 +109,36 @@ describe('Type of appeal Controller', () => {
       req.body = { 'button': 'save-and-continue', 'appealType': 'human-rights' };
 
       await postTypeOfAppeal(updateAppealService as UpdateAppealService)(req as Request, res as Response, next);
-      expect(res.redirect).to.have.been.calledOnce.calledWith('/task-list');
+      expect(res.redirect).to.have.been.calledOnce.calledWith(paths.taskList);
+    });
+
+    it('when in edit mode should validate and redirect to the CYA page and reset isEdit flag', async () => {
+      req.session.isEdit = true;
+
+      req.body = { 'button': 'save-and-continue', 'appealType': 'human-rights' };
+
+      await postTypeOfAppeal(updateAppealService as UpdateAppealService)(req as Request, res as Response, next);
+      expect(res.redirect).to.have.been.calledOnce.calledWith(paths.checkAndSend);
+      expect(req.session.isEdit).to.have.eq(false);
+
     });
 
     it('postTypeOfAppeal when clicked on save-and-continue with multiple selections should redirect to the next page', async () => {
       req.body = { 'button': 'save-and-continue', 'appealType': [ 'human-rights', 'eea', 'protection' ] };
 
       await postTypeOfAppeal(updateAppealService as UpdateAppealService)(req as Request, res as Response, next);
-      expect(res.redirect).to.have.been.calledOnce.calledWith('/task-list');
+      expect(res.redirect).to.have.been.calledOnce.calledWith(paths.taskList);
+    });
+
+    it('postTypeOfAppeal when in edit mode when clicked on save-and-continue with multiple selections should redirect to CYA page and reset isEdit flag', async () => {
+      req.session.isEdit = true;
+
+      req.body = { 'button': 'save-and-continue', 'appealType': [ 'human-rights', 'eea', 'protection' ] };
+
+      await postTypeOfAppeal(updateAppealService as UpdateAppealService)(req as Request, res as Response, next);
+      expect(res.redirect).to.have.been.calledOnce.calledWith(paths.checkAndSend);
+      expect(req.session.isEdit).to.have.eq(false);
+
     });
 
     it('postTypeOfAppeal should catch exception and call next with the error', async () => {

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -78,6 +78,7 @@ interface AppealApplication {
     result?: any;
     selected?: any;
   };
+  isEdit?: boolean;
 }
 
 interface CaseBuilding {


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/RIA-2281
https://tools.hmcts.net/jira/browse/RIA-2282
### Change description ###

**RIA-2281:** Fixes Change links from CYA page, when clicking in a 'change' link in CYA once the data is changed it should redirect back to the CYA page.
Added tests to cover all scenarios


**RIA-2282:** Splits contact details summary row in Address and contact details as they are different sections and data is captured at different stages.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ x] No
```
