### PR TITLE
RIA-2355 Back link on manual address page

### DIFF
--- a/test/unit/controllers/enter-address.test.ts
+++ b/test/unit/controllers/enter-address.test.ts
@@ -84,7 +84,20 @@ describe('Personal Details Controller', function () {
       };
       getManualEnterAddressPage(req as Request, res as Response, next);
       expect(res.render).to.have.been.calledOnce.calledWith('appeal-application/personal-details/enter-address.njk', {
-        address
+        address,
+        previousPage: '/personal-details/nationality'
+      });
+    });
+
+    it('should redirect to previous page', function () {
+      req.session.appeal.application.personalDetails.address = {
+        ...address
+      };
+      req.session.previousPage = '/lastpage';
+      getManualEnterAddressPage(req as Request, res as Response, next);
+      expect(res.render).to.have.been.calledOnce.calledWith('appeal-application/personal-details/enter-address.njk', {
+        address,
+        previousPage: '/lastpage'
       });
     });
 
@@ -95,7 +108,8 @@ describe('Personal Details Controller', function () {
       };
       getManualEnterAddressPage(req as Request, res as Response, next);
       expect(res.render).to.have.been.calledOnce.calledWith('appeal-application/personal-details/enter-address.njk', {
-        address
+        address,
+        previousPage: '/personal-details/nationality'
       });
       expect(req.session.appeal.application.isEdit).to.have.eq(true);
 
@@ -105,7 +119,10 @@ describe('Personal Details Controller', function () {
       req.session.appeal.application.addressLookup = {};
       _.set(req.session.appeal.application, 'personalDetails.address', { ...address });
       getManualEnterAddressPage(req as Request, res as Response, next);
-      expect(res.render).to.have.been.calledOnce.calledWith('appeal-application/personal-details/enter-address.njk', { address });
+      expect(res.render).to.have.been.calledOnce.calledWith('appeal-application/personal-details/enter-address.njk', {
+        address,
+        previousPage: '/personal-details/nationality'
+      });
     });
 
     it('should catch an exception and call next()', () => {

--- a/views/appeal-application/personal-details/enter-address.njk
+++ b/views/appeal-application/personal-details/enter-address.njk
@@ -3,7 +3,6 @@
 {% set pageTitleName = i18n.pages.enterAddress.title %}
 {% extends '../../layout.njk' %}
 
-
 {% block content %}
   {% if error %}
     {{ govukErrorSummary({


### PR DESCRIPTION
The back link on the manual address page was missing. There is not a
single page you come from for the manual address so store your source in
the session and set that.

### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/RIA-2355

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
