### PR TITLE
Refactoring 'save for later' logic

### DIFF
--- a/app/controllers/contact-details.ts
+++ b/app/controllers/contact-details.ts
@@ -24,6 +24,9 @@ function getContactDetails(req: Request, res: Response, next: NextFunction) {
 function postContactDetails(updateAppealService: UpdateAppealService) {
   return async (req: Request, res: Response, next: NextFunction) => {
     try {
+      if (!shouldValidateWhenSaveForLater(req.body, 'selections')) {
+        return getConditionalRedirectUrl(req, res, paths.taskList);
+      }
       if (!req.body.selections) {
         req.body.selections = '';
       }
@@ -49,17 +52,15 @@ function postContactDetails(updateAppealService: UpdateAppealService) {
 
       const contactDetails = { email, wantsEmail, phone, wantsSms };
 
-      if (shouldValidateWhenSaveForLater(req.body, 'selections')) {
-        const validation = contactDetailsValidation(req.body);
+      const validation = contactDetailsValidation(req.body);
 
-        if (validation) {
-          return res.render('appeal-application/contact-details.njk', {
-            contactDetails,
-            errors: validation,
-            errorList: Object.values(validation),
-            previousPage: paths.taskList
-          });
-        }
+      if (validation) {
+        return res.render('appeal-application/contact-details.njk', {
+          contactDetails,
+          errors: validation,
+          errorList: Object.values(validation),
+          previousPage: paths.taskList
+        });
       }
 
       req.session.appeal.application.contactDetails = contactDetails;

--- a/app/controllers/personal-details.ts
+++ b/app/controllers/personal-details.ts
@@ -37,16 +37,17 @@ function getDateOfBirthPage(req: Request, res: Response, next: NextFunction) {
 function postDateOfBirth(updateAppealService: UpdateAppealService) {
   return async function (req: Request, res: Response, next: NextFunction) {
     try {
-      if (shouldValidateWhenSaveForLater(req.body, 'day', 'month', 'year')) {
-        const validation = dateOfBirthValidation(req.body);
-        if (validation != null) {
-          return res.render('appeal-application/personal-details/date-of-birth.njk', {
-            errors: validation,
-            errorList: Object.values(validation),
-            dob: { ...req.body },
-            previousPage: paths.personalDetails.name
-          });
-        }
+      if (!shouldValidateWhenSaveForLater(req.body, 'day', 'month', 'year')) {
+        return getConditionalRedirectUrl(req, res, paths.taskList);
+      }
+      const validation = dateOfBirthValidation(req.body);
+      if (validation != null) {
+        return res.render('appeal-application/personal-details/date-of-birth.njk', {
+          errors: validation,
+          errorList: Object.values(validation),
+          dob: { ...req.body },
+          previousPage: paths.personalDetails.name
+        });
       }
 
       req.session.appeal.application.personalDetails = {
@@ -82,19 +83,20 @@ function getNamePage(req: Request, res: Response, next: NextFunction) {
 function postNamePage(updateAppealService: UpdateAppealService) {
   return async function (req: Request, res: Response, next: NextFunction) {
     try {
-      if (shouldValidateWhenSaveForLater(req.body, 'familyName', 'givenNames')) {
-        const validation = appellantNamesValidation(req.body);
-        if (validation) {
-          return res.render('appeal-application/personal-details/name.njk', {
-            personalDetails: {
-              familyName: req.body.familyName,
-              givenNames: req.body.givenNames
-            },
-            error: validation,
-            errorList: Object.values(validation),
-            previousPage: paths.taskList
-          });
-        }
+      if (!shouldValidateWhenSaveForLater(req.body, 'day', 'month', 'year')) {
+        return getConditionalRedirectUrl(req, res, paths.taskList);
+      }
+      const validation = appellantNamesValidation(req.body);
+      if (validation) {
+        return res.render('appeal-application/personal-details/name.njk', {
+          personalDetails: {
+            familyName: req.body.familyName,
+            givenNames: req.body.givenNames
+          },
+          error: validation,
+          errorList: Object.values(validation),
+          previousPage: paths.taskList
+        });
       }
       const { application } = req.session.appeal;
       application.personalDetails = {
@@ -132,18 +134,19 @@ function getNationalityPage(req: Request, res: Response, next: NextFunction) {
 function postNationalityPage(updateAppealService: UpdateAppealService) {
   return async function (req: Request, res: Response, next: NextFunction) {
     try {
-      if (shouldValidateWhenSaveForLater(req.body, 'nationality')) {
-        const validation = nationalityValidation(req.body);
-        if (validation) {
-          const nationality = req.body.nationality;
-          const nationalitiesOptions = getNationalitiesOptions(countryList, nationality, i18n.pages.nationality.defaultNationality);
-          return res.render('appeal-application/personal-details/nationality.njk', {
-            nationalitiesOptions,
-            errors: validation,
-            errorList: Object.values(validation),
-            previousPage: paths.personalDetails.dob
-          });
-        }
+      if (!shouldValidateWhenSaveForLater(req.body, 'nationality')) {
+        return getConditionalRedirectUrl(req, res, paths.taskList);
+      }
+      const validation = nationalityValidation(req.body);
+      if (validation) {
+        const nationality = req.body.nationality;
+        const nationalitiesOptions = getNationalitiesOptions(countryList, nationality, i18n.pages.nationality.defaultNationality);
+        return res.render('appeal-application/personal-details/nationality.njk', {
+          nationalitiesOptions,
+          errors: validation,
+          errorList: Object.values(validation),
+          previousPage: paths.personalDetails.dob
+        });
       }
       const { application } = req.session.appeal;
       application.personalDetails = {
@@ -282,23 +285,24 @@ function getManualEnterAddressPage(req: Request, res: Response, next: NextFuncti
 function postManualEnterAddressPage(updateAppealService: UpdateAppealService) {
   return async (req: Request, res: Response, next: NextFunction) => {
     try {
-      if (shouldValidateWhenSaveForLater(req.body, 'address-line-1', 'address-line-2', 'address-town', 'address-county', 'address-postcode')) {
-        const validation = addressValidation(req.body);
-        if (validation !== null) {
-          const previousPage = req.session.previousPage ? req.session.previousPage : paths.personalDetails.nationality;
-          return res.render('appeal-application/personal-details/enter-address.njk', {
-            address: {
-              line1: req.body['address-line-1'],
-              line2: req.body['address-line-2'],
-              city: req.body['address-town'],
-              county: req.body['address-county'],
-              postcode: req.body['address-postcode']
-            },
-            error: validation,
-            errorList: Object.values(validation),
-            previousPage: previousPage
-          });
-        }
+      if (!shouldValidateWhenSaveForLater(req.body, 'address-line-1', 'address-line-2', 'address-town', 'address-county', 'address-postcode')) {
+        return getConditionalRedirectUrl(req, res, paths.taskList);
+      }
+      const validation = addressValidation(req.body);
+      if (validation !== null) {
+        const previousPage = req.session.previousPage ? req.session.previousPage : paths.personalDetails.nationality;
+        return res.render('appeal-application/personal-details/enter-address.njk', {
+          address: {
+            line1: req.body['address-line-1'],
+            line2: req.body['address-line-2'],
+            city: req.body['address-town'],
+            county: req.body['address-county'],
+            postcode: req.body['address-postcode']
+          },
+          error: validation,
+          errorList: Object.values(validation),
+          previousPage: previousPage
+        });
       }
 
       req.session.appeal.application.personalDetails = {

--- a/app/controllers/type-of-appeal.ts
+++ b/app/controllers/type-of-appeal.ts
@@ -31,16 +31,17 @@ function getTypeOfAppeal(req: Request, res: Response, next: NextFunction) {
 function postTypeOfAppeal(updateAppealService: UpdateAppealService) {
   return async (req: Request, res: Response, next: NextFunction) => {
     try {
-      if (shouldValidateWhenSaveForLater(req.body, 'appealType')) {
-        const validation = typeOfAppealValidation(req.body);
-        if (validation) {
-          return res.render('appeal-application/type-of-appeal.njk', {
-            types: appealTypes,
-            errors: validation,
-            errorList: Object.values(validation),
-            previousPage: paths.taskList
-          });
-        }
+      if (!shouldValidateWhenSaveForLater(req.body, 'appealType')) {
+        return getConditionalRedirectUrl(req, res, paths.taskList);
+      }
+      const validation = typeOfAppealValidation(req.body);
+      if (validation) {
+        return res.render('appeal-application/type-of-appeal.njk', {
+          types: appealTypes,
+          errors: validation,
+          errorList: Object.values(validation),
+          previousPage: paths.taskList
+        });
       }
 
       req.session.appeal.application.appealType = req.body['appealType'];

--- a/test/unit/controllers/contact-details.test.ts
+++ b/test/unit/controllers/contact-details.test.ts
@@ -5,6 +5,7 @@ import {
   setupContactDetailsController
 } from '../../../app/controllers/contact-details';
 import { paths } from '../../../app/paths';
+import { Events } from '../../../app/service/ccd-service';
 import UpdateAppealService from '../../../app/service/update-appeal-service';
 import Logger from '../../../app/utils/logger';
 import i18n from '../../../locale/en.json';
@@ -115,6 +116,8 @@ describe('Contact details Controller', () => {
         };
 
         await postContactDetails(updateAppealService as UpdateAppealService)(req as Request, res as Response, next);
+
+        expect(updateAppealService.submitEvent).to.not.have.been.called;
         expect(res.render).to.have.been.calledWith('appeal-application/contact-details.njk', expectedData);
       });
 
@@ -151,6 +154,8 @@ describe('Contact details Controller', () => {
         };
 
         await postContactDetails(updateAppealService as UpdateAppealService)(req as Request, res as Response, next);
+
+        expect(updateAppealService.submitEvent).to.not.have.been.called;
         expect(res.render).to.have.been.calledWith('appeal-application/contact-details.njk', expectedData);
       });
 
@@ -162,6 +167,8 @@ describe('Contact details Controller', () => {
         };
 
         await postContactDetails(updateAppealService as UpdateAppealService)(req as Request, res as Response, next);
+
+        expect(updateAppealService.submitEvent).to.not.have.been.called;
         expect(res.redirect).to.have.been.calledWith(paths.taskList);
       });
 
@@ -195,6 +202,8 @@ describe('Contact details Controller', () => {
         };
 
         await postContactDetails(updateAppealService as UpdateAppealService)(req as Request, res as Response, next);
+
+        expect(updateAppealService.submitEvent).to.not.have.been.called;
         expect(res.render).to.have.been.calledWith('appeal-application/contact-details.njk', expectedData);
       });
 
@@ -225,6 +234,8 @@ describe('Contact details Controller', () => {
         };
 
         await postContactDetails(updateAppealService as UpdateAppealService)(req as Request, res as Response, next);
+
+        expect(updateAppealService.submitEvent).to.not.have.been.called;
         expect(res.render).to.have.been.calledWith('appeal-application/contact-details.njk', expectedData);
       });
 
@@ -242,6 +253,8 @@ describe('Contact details Controller', () => {
         };
 
         await postContactDetails(updateAppealService as UpdateAppealService)(req as Request, res as Response, next);
+
+        expect(updateAppealService.submitEvent).to.have.been.calledWith(Events.EDIT_APPEAL, req);
         expect(req.session.appeal.application.contactDetails).to.deep.equal(contactDetailsExpectation);
         expect(res.redirect).to.have.been.calledWith(paths.taskList);
       });
@@ -261,6 +274,8 @@ describe('Contact details Controller', () => {
         };
 
         await postContactDetails(updateAppealService as UpdateAppealService)(req as Request, res as Response, next);
+
+        expect(updateAppealService.submitEvent).to.have.been.calledWith(Events.EDIT_APPEAL, req);
         expect(req.session.appeal.application.contactDetails).to.deep.equal(contactDetailsExpectation);
         expect(res.redirect).to.have.been.calledWith(paths.checkAndSend);
         expect(req.session.appeal.application.isEdit).to.have.eq(false);
@@ -295,6 +310,8 @@ describe('Contact details Controller', () => {
         };
 
         await postContactDetails(updateAppealService as UpdateAppealService)(req as Request, res as Response, next);
+
+        expect(updateAppealService.submitEvent).to.not.have.been.called;
         expect(res.render).to.have.been.calledWith('appeal-application/contact-details.njk', expectedData);
       });
 
@@ -325,6 +342,8 @@ describe('Contact details Controller', () => {
         };
 
         await postContactDetails(updateAppealService as UpdateAppealService)(req as Request, res as Response, next);
+
+        expect(updateAppealService.submitEvent).to.not.have.been.called;
         expect(res.render).to.have.been.calledWith('appeal-application/contact-details.njk', expectedData);
       });
 
@@ -342,6 +361,8 @@ describe('Contact details Controller', () => {
         };
 
         await postContactDetails(updateAppealService as UpdateAppealService)(req as Request, res as Response, next);
+
+        expect(updateAppealService.submitEvent).to.have.been.calledWith(Events.EDIT_APPEAL, req);
         expect(req.session.appeal.application.contactDetails).to.deep.equal(contactDetailsExpectation);
         expect(res.redirect).to.have.been.calledWith(paths.taskList);
       });
@@ -363,6 +384,8 @@ describe('Contact details Controller', () => {
       };
 
       await postContactDetails(updateAppealService as UpdateAppealService)(req as Request, res as Response, next);
+
+      expect(updateAppealService.submitEvent).to.have.been.calledWith(Events.EDIT_APPEAL, req);
       expect(req.session.appeal.application.contactDetails).to.deep.equal(contactDetailsExpectation);
       expect(res.redirect).to.have.been.calledWith(paths.checkAndSend);
       expect(req.session.appeal.application.isEdit).to.have.eq(false);

--- a/test/unit/controllers/enter-address.test.ts
+++ b/test/unit/controllers/enter-address.test.ts
@@ -7,6 +7,7 @@ import {
   setupPersonalDetailsController
 } from '../../../app/controllers/personal-details';
 import { paths } from '../../../app/paths';
+import { Events } from '../../../app/service/ccd-service';
 import UpdateAppealService from '../../../app/service/update-appeal-service';
 import Logger from '../../../app/utils/logger';
 import { expect, sinon } from '../../utils/testUtils';
@@ -149,6 +150,8 @@ describe('Personal Details Controller', function () {
       req.body['address-postcode'] = 'W';
 
       await postManualEnterAddressPage(updateAppealService as UpdateAppealService)(req as Request, res as Response, next);
+
+      expect(updateAppealService.submitEvent).not.to.have.been.called;
       expect(res.render).to.have.been.calledWith('appeal-application/personal-details/enter-address.njk');
     });
 
@@ -160,6 +163,8 @@ describe('Personal Details Controller', function () {
       req.body['address-postcode'] = 'W1W 7RT';
 
       await postManualEnterAddressPage(updateAppealService as UpdateAppealService)(req as Request, res as Response, next);
+
+      expect(updateAppealService.submitEvent).to.have.been.calledWith(Events.EDIT_APPEAL, req);
       expect(res.redirect).to.have.been.calledWith(paths.taskList);
     });
 
@@ -180,9 +185,31 @@ describe('Personal Details Controller', function () {
       req.body['address-postcode'] = 'W1W 7RT';
 
       await postManualEnterAddressPage(updateAppealService as UpdateAppealService)(req as Request, res as Response, next);
-      expect(res.redirect).to.have.been.calledWith(paths.checkAndSend);
-      expect(req.session.appeal.application.isEdit).to.have.eq(false);
 
+      expect(updateAppealService.submitEvent).to.have.been.calledWith(Events.EDIT_APPEAL, req);
+      expect(req.session.appeal.application.isEdit).to.have.eq(false);
+      expect(res.redirect).to.have.been.calledWith(paths.checkAndSend);
+    });
+
+    it('should redirect to task list and not validate if nothing selected and save for later clicked', async () => {
+      req.body = {
+        'saveForLater': 'saveForLater'
+      };
+      await postManualEnterAddressPage(updateAppealService as UpdateAppealService)(req as Request, res as Response, next);
+
+      expect(updateAppealService.submitEvent).to.not.have.been.called;
+      expect(res.redirect).to.have.been.calledWith(paths.taskList);
+    });
+
+    it('should redirect to CYA page and not validate if nothing selected and save for later clicked and reset isEdit flag', async () => {
+      req.session.appeal.application.isEdit = true;
+      req.body = {
+        'saveForLater': 'saveForLater'
+      };
+      await postManualEnterAddressPage(updateAppealService as UpdateAppealService)(req as Request, res as Response, next);
+
+      expect(updateAppealService.submitEvent).to.not.have.been.called;
+      expect(res.redirect).to.have.been.calledWith(paths.checkAndSend);
     });
 
     it('should catch an exception and call next()', async () => {

--- a/test/unit/controllers/enter-dob.test.ts
+++ b/test/unit/controllers/enter-dob.test.ts
@@ -6,6 +6,7 @@ import {
   setupPersonalDetailsController
 } from '../../../app/controllers/personal-details';
 import { paths } from '../../../app/paths';
+import { Events } from '../../../app/service/ccd-service';
 import UpdateAppealService from '../../../app/service/update-appeal-service';
 import Logger from '../../../app/utils/logger';
 import i18n from '../../../locale/en.json';
@@ -85,32 +86,61 @@ describe('Personal Details Controller', function () {
       req.body.day = 1;
       req.body.month = 11;
       req.body.year = 1993;
-
       req.session.personalDetails = {};
 
       await postDateOfBirth(updateAppealService as UpdateAppealService)(req as Request, res as Response, next);
 
+      expect(updateAppealService.submitEvent).to.have.been.calledWith(Events.EDIT_APPEAL, req);
       expect(res.redirect).to.have.been.calledWith(paths.personalDetails.nationality);
     });
 
     it('when in edit mode should validate and redirect to CYA page and reset isEdit flag', async () => {
       req.session.appeal.application.isEdit = true;
-
       req.body.day = 1;
       req.body.month = 11;
       req.body.year = 1993;
-
       req.session.personalDetails = {};
 
       await postDateOfBirth(updateAppealService as UpdateAppealService)(req as Request, res as Response, next);
 
+      expect(updateAppealService.submitEvent).to.have.been.calledWith(Events.EDIT_APPEAL, req);
       expect(res.redirect).to.have.been.calledWith(paths.checkAndSend);
       expect(req.session.appeal.application.isEdit).to.have.eq(false);
+    });
 
+    it('should redirect to task list and not validate if nothing selected and save for later clicked', async () => {
+      req.body = {
+        'saveForLater': 'saveForLater'
+      };
+
+      await postDateOfBirth(updateAppealService as UpdateAppealService)(req as Request, res as Response, next);
+
+      expect(updateAppealService.submitEvent).to.not.have.been.called;
+      expect(res.redirect).to.have.been.calledWith(paths.taskList);
+    });
+
+    it('should redirect to CYA page and not validate if nothing selected and save for later clicked and reset isEdit flag', async () => {
+      req.session.appeal.application.isEdit = true;
+      req.body = {
+        'saveForLater': 'saveForLater'
+      };
+
+      await postDateOfBirth(updateAppealService as UpdateAppealService)(req as Request, res as Response, next);
+
+      expect(updateAppealService.submitEvent).to.not.have.been.called;
+      expect(res.redirect).to.have.been.calledWith(paths.checkAndSend);
     });
   });
 
   describe('Should catch an error.', function () {
+    function createError(fieldName, errorMessage) {
+      return {
+        href: `#${fieldName}`,
+        key: fieldName,
+        text: errorMessage
+      };
+    }
+
     it('getDateOfBirthPage should catch an exception and call next()', () => {
       const error = new Error('the error');
       res.render = sandbox.stub().throws(error);
@@ -119,22 +149,12 @@ describe('Personal Details Controller', function () {
     });
 
     it('should early fail validation and render appeal-application/personal-details/date-of-birth.njk with error', async () => {
-      function createError(fieldName, errorMessage) {
-        return {
-          href: `#${fieldName}`,
-          key: fieldName,
-          text: errorMessage
-        };
-      }
-
       const errorDay = createError('day', i18n.validationErrors.dateOfBirth.incorrectFormat);
-      const errorMonth = createError('month', i18n.validationErrors.dateOfBirth.incorrectFormat);
-      const errorYear = createError('year', i18n.validationErrors.dateOfBirth.incorrectFormat);
-      const errorDate = createError('date', i18n.validationErrors.dateOfBirth.inPast);
-
       req.body.day = 0;
 
       await postDateOfBirth(updateAppealService as UpdateAppealService)(req as Request, res as Response, next);
+
+      expect(updateAppealService.submitEvent).to.not.have.been.called;
       expect(res.render).to.have.been.calledWith(
         'appeal-application/personal-details/date-of-birth.njk',
         {
@@ -146,10 +166,15 @@ describe('Personal Details Controller', function () {
           previousPage: paths.personalDetails.name
         }
       );
+    });
 
+    it('should early fail validation and render appeal-application/personal-details/date-of-birth.njk with error', async () => {
       req.body.day = 1;
       req.body.month = 0;
+      const errorMonth = createError('month', i18n.validationErrors.dateOfBirth.incorrectFormat);
       await postDateOfBirth(updateAppealService as UpdateAppealService)(req as Request, res as Response, next);
+
+      expect(updateAppealService.submitEvent).to.not.have.been.called;
       expect(res.render).to.have.been.calledWith(
         'appeal-application/personal-details/date-of-birth.njk',
         {
@@ -161,10 +186,16 @@ describe('Personal Details Controller', function () {
           previousPage: paths.personalDetails.name
         }
       );
+    });
 
+    it('should early fail validation and render appeal-application/personal-details/date-of-birth.njk with error', async () => {
+      req.body.day = 1;
       req.body.month = 1;
       req.body.year = 0;
+      const errorYear = createError('year', i18n.validationErrors.dateOfBirth.incorrectFormat);
       await postDateOfBirth(updateAppealService as UpdateAppealService)(req as Request, res as Response, next);
+
+      expect(updateAppealService.submitEvent).to.not.have.been.called;
       expect(res.render).to.have.been.calledWith(
         'appeal-application/personal-details/date-of-birth.njk',
         {
@@ -176,9 +207,16 @@ describe('Personal Details Controller', function () {
           previousPage: paths.personalDetails.name
         }
       );
+    });
 
+    it('should early fail validation and render appeal-application/personal-details/date-of-birth.njk with error', async () => {
+      req.body.day = 1;
+      req.body.month = 1;
       req.body.year = 9999;
+      const errorDate = createError('date', i18n.validationErrors.dateOfBirth.inPast);
       await postDateOfBirth(updateAppealService as UpdateAppealService)(req as Request, res as Response, next);
+
+      expect(updateAppealService.submitEvent).to.not.have.been.called;
       expect(res.render).to.have.been.calledWith(
         'appeal-application/personal-details/date-of-birth.njk',
         {

--- a/test/unit/controllers/enter-name-page.test.ts
+++ b/test/unit/controllers/enter-name-page.test.ts
@@ -1,6 +1,7 @@
 import { NextFunction, Request, Response } from 'express';
 import { getNamePage, postNamePage, setupPersonalDetailsController } from '../../../app/controllers/personal-details';
 import { paths } from '../../../app/paths';
+import { Events } from '../../../app/service/ccd-service';
 import UpdateAppealService from '../../../app/service/update-appeal-service';
 import Logger from '../../../app/utils/logger';
 import { expect, sinon } from '../../utils/testUtils';
@@ -100,20 +101,41 @@ describe('Personal Details Controller', function () {
 
       await postNamePage(updateAppealService as UpdateAppealService)(req as Request, res as Response, next);
 
+      expect(updateAppealService.submitEvent).to.have.been.calledWith(Events.EDIT_APPEAL, req);
       expect(res.redirect).to.have.been.calledWith(paths.personalDetails.dob);
     });
 
     it('when in edit mode should validate and redirect to CYA page and reset isEdit flag', async () => {
       req.session.appeal.application.isEdit = true;
-
       req.body.givenNames = 'Lewis';
       req.body.familyName = 'Williams';
 
       await postNamePage(updateAppealService as UpdateAppealService)(req as Request, res as Response, next);
 
+      expect(updateAppealService.submitEvent).to.have.been.calledWith(Events.EDIT_APPEAL, req);
       expect(res.redirect).to.have.been.calledWith(paths.checkAndSend);
       expect(req.session.appeal.application.isEdit).to.have.eq(false);
+    });
 
+    it('should redirect to task list and not validate if nothing selected and save for later clicked', async () => {
+      req.body = {
+        'saveForLater': 'saveForLater'
+      };
+      await postNamePage(updateAppealService as UpdateAppealService)(req as Request, res as Response, next);
+
+      expect(updateAppealService.submitEvent).to.not.have.been.called;
+      expect(res.redirect).to.have.been.calledWith(paths.taskList);
+    });
+
+    it('should redirect to CYA page and not validate if nothing selected and save for later clicked and reset isEdit flag', async () => {
+      req.session.appeal.application.isEdit = true;
+      req.body = {
+        'saveForLater': 'saveForLater'
+      };
+      await postNamePage(updateAppealService as UpdateAppealService)(req as Request, res as Response, next);
+
+      expect(updateAppealService.submitEvent).to.not.have.been.called;
+      expect(res.redirect).to.have.been.calledWith(paths.checkAndSend);
     });
   });
 
@@ -141,6 +163,7 @@ describe('Personal Details Controller', function () {
         text: 'Enter your given name or names'
       };
 
+      expect(updateAppealService.submitEvent).to.not.have.been.called;
       expect(res.render).to.have.been.calledWith(
         'appeal-application/personal-details/name.njk',
         {

--- a/test/unit/controllers/home-office-details.test.ts
+++ b/test/unit/controllers/home-office-details.test.ts
@@ -8,6 +8,7 @@ import {
   setupHomeOfficeDetailsController
 } from '../../../app/controllers/home-office-details';
 import { paths } from '../../../app/paths';
+import { Events } from '../../../app/service/ccd-service';
 import UpdateAppealService from '../../../app/service/update-appeal-service';
 import Logger from '../../../app/utils/logger';
 import { expect, sinon } from '../../utils/testUtils';
@@ -100,6 +101,7 @@ describe('Home Office Details Controller', function () {
       req.body['homeOfficeRefNumber'] = 'A1234567';
       await postHomeOfficeDetails(updateAppealService as UpdateAppealService)(req as Request, res as Response, next);
 
+      expect(updateAppealService.submitEvent).to.have.been.calledWith(Events.EDIT_APPEAL, req);
       expect(req.session.appeal.application.homeOfficeRefNumber).to.be.eql('A1234567');
       expect(res.redirect).to.have.been.calledWith(paths.homeOffice.letterSent);
     });
@@ -109,6 +111,7 @@ describe('Home Office Details Controller', function () {
       req.body['saveForLater'] = 'saveForLater';
       await postHomeOfficeDetails(updateAppealService as UpdateAppealService)(req as Request, res as Response, next);
 
+      expect(updateAppealService.submitEvent).to.have.been.calledWith(Events.EDIT_APPEAL, req);
       expect(req.session.appeal.application.homeOfficeRefNumber).to.be.eql('A1234567');
       expect(res.redirect).to.have.been.calledWith(paths.taskList);
     });
@@ -119,6 +122,7 @@ describe('Home Office Details Controller', function () {
       req.body['homeOfficeRefNumber'] = 'A1234567';
       await postHomeOfficeDetails(updateAppealService as UpdateAppealService)(req as Request, res as Response, next);
 
+      expect(updateAppealService.submitEvent).to.have.been.calledWith(Events.EDIT_APPEAL, req);
       expect(req.session.appeal.application.homeOfficeRefNumber).to.be.eql('A1234567');
       expect(res.redirect).to.have.been.calledWith(paths.checkAndSend);
       expect(req.session.appeal.application.isEdit).to.have.eq(false);
@@ -134,6 +138,7 @@ describe('Home Office Details Controller', function () {
         key: 'homeOfficeRefNumber',
         text: 'Enter the Home Office reference number in the correct format'
       };
+      expect(updateAppealService.submitEvent).to.not.have.been.called;
       expect(res.render).to.have.been.calledWith(
         'appeal-application/home-office/details.njk',
         {
@@ -156,6 +161,7 @@ describe('Home Office Details Controller', function () {
         key: 'homeOfficeRefNumber',
         text: 'Enter the Home Office reference number in the correct format'
       };
+      expect(updateAppealService.submitEvent).to.not.have.been.called;
       expect(res.render).to.have.been.calledWith(
         'appeal-application/home-office/details.njk',
         {
@@ -177,6 +183,7 @@ describe('Home Office Details Controller', function () {
         key: 'homeOfficeRefNumber',
         text: 'Enter the Home Office reference number'
       };
+      expect(updateAppealService.submitEvent).to.not.have.been.called;
       expect(res.render).to.have.been.calledWith(
         'appeal-application/home-office/details.njk',
         {
@@ -194,6 +201,7 @@ describe('Home Office Details Controller', function () {
       req.body['saveForLater'] = 'saveForLater';
       await postHomeOfficeDetails(updateAppealService as UpdateAppealService)(req as Request, res as Response, next);
 
+      expect(updateAppealService.submitEvent).to.not.have.been.called;
       expect(res.redirect).to.have.been.calledWith(paths.taskList);
     });
 
@@ -230,7 +238,7 @@ describe('Home Office Details Controller', function () {
   });
 
   describe('postDateLetterSent', () => {
-    it('should validate and redirect to Task list page if letter is not older than 14 days', async () => {
+    it('should validate and redirect to Task list page', async () => {
       const date = moment().subtract(14, 'd');
       req.body['day'] = date.format('DD');
       req.body['month'] = date.format('MM');
@@ -238,6 +246,7 @@ describe('Home Office Details Controller', function () {
       await postDateLetterSent(updateAppealService as UpdateAppealService)(req as Request, res as Response, next);
 
       const { dateLetterSent } = req.session.appeal.application;
+      expect(updateAppealService.submitEvent).to.have.been.calledWith(Events.EDIT_APPEAL, req);
       expect(dateLetterSent.day).to.be.eql(date.format('DD'));
       expect(dateLetterSent.month).to.be.eql(date.format('MM'));
       expect(dateLetterSent.year).to.be.eql(date.format('YYYY'));
@@ -245,7 +254,7 @@ describe('Home Office Details Controller', function () {
       expect(res.redirect).to.have.been.calledWith(paths.taskList);
     });
 
-    it('when in edit mode should validate and redirect to CYA page if letter is not older than 14 days and reset isEdit flag', async () => {
+    it('should validate and redirect to CYA page and reset isEdit flag', async () => {
       req.session.appeal.application.isEdit = true;
 
       const date = moment().subtract(14, 'd');
@@ -255,6 +264,7 @@ describe('Home Office Details Controller', function () {
       await postDateLetterSent(updateAppealService as UpdateAppealService)(req as Request, res as Response, next);
 
       const { dateLetterSent } = req.session.appeal.application;
+      expect(updateAppealService.submitEvent).to.have.been.calledWith(Events.EDIT_APPEAL, req);
       expect(dateLetterSent.day).to.be.eql(date.format('DD'));
       expect(dateLetterSent.month).to.be.eql(date.format('MM'));
       expect(dateLetterSent.year).to.be.eql(date.format('YYYY'));
@@ -272,6 +282,7 @@ describe('Home Office Details Controller', function () {
       await postDateLetterSent(updateAppealService as UpdateAppealService)(req as Request, res as Response, next);
 
       const { dateLetterSent } = req.session.appeal.application;
+      expect(updateAppealService.submitEvent).to.have.been.calledWith(Events.EDIT_APPEAL, req);
       expect(dateLetterSent.day).to.be.eql(date.format('DD'));
       expect(dateLetterSent.month).to.be.eql(date.format('MM'));
       expect(dateLetterSent.year).to.be.eql(date.format('YYYY'));
@@ -288,6 +299,7 @@ describe('Home Office Details Controller', function () {
       await postDateLetterSent(updateAppealService as UpdateAppealService)(req as Request, res as Response, next);
 
       const { dateLetterSent } = req.session.appeal.application;
+      expect(updateAppealService.submitEvent).to.have.been.calledWith(Events.EDIT_APPEAL, req);
       expect(dateLetterSent.day).to.be.eql(date.format('DD'));
       expect(dateLetterSent.month).to.be.eql(date.format('MM'));
       expect(dateLetterSent.year).to.be.eql(date.format('YYYY'));
@@ -303,10 +315,11 @@ describe('Home Office Details Controller', function () {
       req.body.saveForLater = 'saveForLater';
       await postDateLetterSent(updateAppealService as UpdateAppealService)(req as Request, res as Response, next);
 
+      expect(updateAppealService.submitEvent).to.not.have.been.called;
       expect(res.redirect).to.have.been.calledWith(paths.taskList);
     });
 
-    it('when in edit mode should validate and redirect to Appeal Late page if appeal is later than 14 days and isEdit flag is not updated', async () => {
+    it('should validate and redirect to Appeal Late page and isEdit flag is not updated', async () => {
       req.session.appeal.application.isEdit = true;
 
       const date = moment().subtract(15, 'd');
@@ -316,6 +329,7 @@ describe('Home Office Details Controller', function () {
       await postDateLetterSent(updateAppealService as UpdateAppealService)(req as Request, res as Response, next);
 
       const { dateLetterSent } = req.session.appeal.application;
+      expect(updateAppealService.submitEvent).to.have.been.calledWith(Events.EDIT_APPEAL, req);
       expect(dateLetterSent.day).to.be.eql(date.format('DD'));
       expect(dateLetterSent.month).to.be.eql(date.format('MM'));
       expect(dateLetterSent.year).to.be.eql(date.format('YYYY'));
@@ -332,6 +346,7 @@ describe('Home Office Details Controller', function () {
       req.body['year'] = date.format('YYYY');
       await postDateLetterSent(updateAppealService as UpdateAppealService)(req as Request, res as Response, next);
 
+      expect(updateAppealService.submitEvent).to.not.have.been.called;
       expect(res.render).to.have.been.calledWith('appeal-application/home-office/letter-sent.njk');
     });
 
@@ -350,6 +365,7 @@ describe('Home Office Details Controller', function () {
       const errorList = [ dateError ];
       await postDateLetterSent(updateAppealService as UpdateAppealService)(req as Request, res as Response, next);
 
+      expect(updateAppealService.submitEvent).to.not.have.been.called;
       expect(res.render).to.have.been.calledWith('appeal-application/home-office/letter-sent.njk',
         {
           error,
@@ -365,6 +381,7 @@ describe('Home Office Details Controller', function () {
       res.render = sandbox.stub().throws(error);
       await postDateLetterSent(updateAppealService as UpdateAppealService)(req as Request, res as Response, next);
 
+      expect(updateAppealService.submitEvent).to.not.have.been.called;
       expect(next).to.have.been.calledOnce.calledWith(error);
     });
   });

--- a/test/unit/controllers/nationatily-page.test.ts
+++ b/test/unit/controllers/nationatily-page.test.ts
@@ -8,6 +8,7 @@ import {
 } from '../../../app/controllers/personal-details';
 import { countryList } from '../../../app/data/country-list';
 import { paths } from '../../../app/paths';
+import { Events } from '../../../app/service/ccd-service';
 import UpdateAppealService from '../../../app/service/update-appeal-service';
 import Logger from '../../../app/utils/logger';
 import { getNationalitiesOptions } from '../../../app/utils/nationalities';
@@ -96,6 +97,7 @@ describe('Nationality details Controller', function () {
       req.body.nationality = 'AQ';
       await postNationalityPage(updateAppealService as UpdateAppealService)(req as Request, res as Response, next);
 
+      expect(updateAppealService.submitEvent).to.have.been.calledWith(Events.EDIT_APPEAL, req);
       expect(res.redirect).to.have.been.calledWith(paths.personalDetails.enterPostcode);
     });
 
@@ -105,6 +107,7 @@ describe('Nationality details Controller', function () {
       req.body.nationality = 'AQ';
       await postNationalityPage(updateAppealService as UpdateAppealService)(req as Request, res as Response, next);
 
+      expect(updateAppealService.submitEvent).to.have.been.calledWith(Events.EDIT_APPEAL, req);
       expect(res.redirect).to.have.been.calledWith(paths.checkAndSend);
       expect(req.session.appeal.application.isEdit).to.have.eq(false);
 
@@ -118,6 +121,8 @@ describe('Nationality details Controller', function () {
         key: 'nationality',
         text: i18n.validationErrors.nationality.selectNationality
       };
+
+      expect(updateAppealService.submitEvent).to.not.have.been.called;
       expect(res.render).to.have.been.calledWith('appeal-application/personal-details/nationality.njk',
         {
           errorList: [ error ],
@@ -125,6 +130,27 @@ describe('Nationality details Controller', function () {
           nationalitiesOptions,
           previousPage: paths.personalDetails.dob
         });
+    });
+
+    it('should redirect to task list and not validate if nothing selected and save for later clicked', async () => {
+      req.body = {
+        'saveForLater': 'saveForLater'
+      };
+      await postNationalityPage(updateAppealService as UpdateAppealService)(req as Request, res as Response, next);
+
+      expect(updateAppealService.submitEvent).to.not.have.been.called;
+      expect(res.redirect).to.have.been.calledWith(paths.taskList);
+    });
+
+    it('should redirect to CYA page and not validate if nothing selected and save for later clicked and reset isEdit flag', async () => {
+      req.session.appeal.application.isEdit = true;
+      req.body = {
+        'saveForLater': 'saveForLater'
+      };
+      await postNationalityPage(updateAppealService as UpdateAppealService)(req as Request, res as Response, next);
+
+      expect(updateAppealService.submitEvent).to.not.have.been.called;
+      expect(res.redirect).to.have.been.calledWith(paths.checkAndSend);
     });
 
     it('should catch an exception and call next() with error', async () => {

--- a/test/unit/controllers/type-of-appeal.test.ts
+++ b/test/unit/controllers/type-of-appeal.test.ts
@@ -6,6 +6,7 @@ import {
 } from '../../../app/controllers/type-of-appeal';
 import { appealTypes } from '../../../app/data/appeal-types';
 import { paths } from '../../../app/paths';
+import { Events } from '../../../app/service/ccd-service';
 import UpdateAppealService from '../../../app/service/update-appeal-service';
 import Logger from '../../../app/utils/logger';
 import { expect, sinon } from '../../utils/testUtils';
@@ -104,6 +105,8 @@ describe('Type of appeal Controller', () => {
       };
 
       await postTypeOfAppeal(updateAppealService as UpdateAppealService)(req as Request, res as Response, next);
+
+      expect(updateAppealService.submitEvent).to.not.have.been.called;
       expect(res.render).to.have.been.calledOnce.calledWith('appeal-application/type-of-appeal.njk', {
         types: appealTypes,
         errors: { appealType: expectedError },
@@ -116,13 +119,28 @@ describe('Type of appeal Controller', () => {
       req.body = { 'saveForLater': 'saveForLater' };
 
       await postTypeOfAppeal(updateAppealService as UpdateAppealService)(req as Request, res as Response, next);
+
+      expect(updateAppealService.submitEvent).to.not.have.been.called;
       expect(res.redirect).to.have.been.calledOnce.calledWith(paths.taskList);
+    });
+
+    it('should redirect to CYA page and not validate if nothing selected and save for later clicked and reset isEdit flag', async () => {
+      req.session.appeal.application.isEdit = true;
+      req.body = {
+        'saveForLater': 'saveForLater'
+      };
+      await postTypeOfAppeal(updateAppealService as UpdateAppealService)(req as Request, res as Response, next);
+
+      expect(updateAppealService.submitEvent).to.not.have.been.called;
+      expect(res.redirect).to.have.been.calledWith(paths.checkAndSend);
     });
 
     it('should validate and redirect to the task-list page', async () => {
       req.body = { 'button': 'save-and-continue', 'appealType': 'human-rights' };
 
       await postTypeOfAppeal(updateAppealService as UpdateAppealService)(req as Request, res as Response, next);
+
+      expect(updateAppealService.submitEvent).to.have.been.calledWith(Events.EDIT_APPEAL, req);
       expect(res.redirect).to.have.been.calledOnce.calledWith(paths.taskList);
     });
 
@@ -132,15 +150,18 @@ describe('Type of appeal Controller', () => {
       req.body = { 'button': 'save-and-continue', 'appealType': 'human-rights' };
 
       await postTypeOfAppeal(updateAppealService as UpdateAppealService)(req as Request, res as Response, next);
+
+      expect(updateAppealService.submitEvent).to.have.been.calledWith(Events.EDIT_APPEAL, req);
       expect(res.redirect).to.have.been.calledOnce.calledWith(paths.checkAndSend);
       expect(req.session.appeal.application.isEdit).to.have.eq(false);
-
     });
 
     it('postTypeOfAppeal when clicked on save-and-continue with multiple selections should redirect to the next page', async () => {
       req.body = { 'button': 'save-and-continue', 'appealType': 'protection' };
 
       await postTypeOfAppeal(updateAppealService as UpdateAppealService)(req as Request, res as Response, next);
+
+      expect(updateAppealService.submitEvent).to.have.been.calledWith(Events.EDIT_APPEAL, req);
       expect(res.redirect).to.have.been.calledOnce.calledWith(paths.taskList);
     });
 
@@ -150,6 +171,8 @@ describe('Type of appeal Controller', () => {
       req.body = { 'button': 'save-and-continue', 'appealType': 'protection' };
 
       await postTypeOfAppeal(updateAppealService as UpdateAppealService)(req as Request, res as Response, next);
+
+      expect(updateAppealService.submitEvent).to.have.been.calledWith(Events.EDIT_APPEAL, req);
       expect(res.redirect).to.have.been.calledOnce.calledWith(paths.checkAndSend);
       expect(req.session.appeal.application.isEdit).to.have.eq(false);
 


### PR DESCRIPTION
### JIRA link (if applicable) ###



### Change description ###
Refactoring save for later logic
- if 'save for later' is clicked but body is empty, 'submitEvent' should not be called.
- refactoring unit tests


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ X ] No
```
