### PR TITLE
RIA-2414 Setup AKS

### DIFF
--- a/Jenkinsfile_CNP
+++ b/Jenkinsfile_CNP
@@ -10,10 +10,8 @@ def product = "ia"
 def component = "aip-frontend"
 
 def secrets = [
-        'sscs-${env}': [
-                secret('sscs-s2s-secret', 'S2S_SECRET')
-        ],
         'ia-${env}': [
+                secret('sscs-s2s-secret', 'S2S_SECRET'),
                 secret('idam-secret', 'IDAM_CLIENT_SECRET'),
                 secret('saucelabs', 'SAUCELABS_SECRET'),
                 secret('addressLookupToken', 'ADDRESS_LOOKUP_TOKEN'),

--- a/app/setupSecrets.ts
+++ b/app/setupSecrets.ts
@@ -14,7 +14,7 @@ const setSecret = (secretPath, configPath) => {
 const setupSecrets = () => {
   setSecret('secrets.ia.idam-secret', 'idam.secret');
   setSecret('secrets.ia.addressLookupToken', 'addressLookup.token');
-  setSecret('secrets.sscs.sscs-s2s-secret', 's2s.secret');
+  setSecret('secrets.ia.sscs-s2s-secret', 's2s.secret');
 
   return config;
 };

--- a/charts/ia-aip-frontend/values.preview.template.yaml
+++ b/charts/ia-aip-frontend/values.preview.template.yaml
@@ -22,6 +22,4 @@ nodejs:
       secrets:
         - idam-secret
         - addressLookupToken
-    sscs:
-      secrets:
         - sscs-s2s-secret

--- a/charts/ia-aip-frontend/values.yaml
+++ b/charts/ia-aip-frontend/values.yaml
@@ -14,8 +14,6 @@ nodejs:
       secrets:
         - idam-secret
         - addressLookupToken
-    sscs:
-      secrets:
         - sscs-s2s-secret
 redis:
   cluster:

--- a/infrastructure/main.tf
+++ b/infrastructure/main.tf
@@ -36,7 +36,7 @@ data "azurerm_key_vault_secret" "addressLookupToken" {
 
 data "azurerm_key_vault_secret" "s2s_secret" {
   name      = "sscs-s2s-secret"
-  vault_uri = "https://sscs-aat.vault.azure.net/"
+  vault_uri = ${data.azurerm_key_vault.ia_key_vault.vault_uri}"
 }
 
 


### PR DESCRIPTION
This app is currently using the sscs s2s secret. It should not be and we
need a task to fix this. As the new way we load secrets can only load
them from vault copied the sscs s2s secret to ia vault for now.

### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/RIA-2414
