### PR TITLE
Clean up: Running tests under NODE_ENV=test

### DIFF
--- a/app/app.ts
+++ b/app/app.ts
@@ -32,7 +32,7 @@ function createApp() {
   app.use(cookieParser());
   app.post('*', filterRequest);
 
-  if (environment === 'development' || environment === 'test') {
+  if (environment === 'development') {
     const [ serverDevConfig, clientDevConfig ] = webpackDevConfig;
     const compiler = webpack([ serverDevConfig, clientDevConfig ]);
     const options = { stats: 'errors-only' } as Options;

--- a/app/controllers/appeal-application/task-list.ts
+++ b/app/controllers/appeal-application/task-list.ts
@@ -1,5 +1,5 @@
 import { NextFunction, Request, Response, Router } from 'express';
-import { applicationStatusUpdate, logSession } from '../../middleware/session-middleware';
+import { applicationStatusUpdate } from '../../middleware/session-middleware';
 import { paths } from '../../paths';
 
 /**
@@ -58,7 +58,7 @@ function getTaskList(req: Request, res: Response, next: NextFunction) {
 
 function setupTaskListController(): Router {
   const router = Router();
-  router.get(paths.taskList, logSession, applicationStatusUpdate, getTaskList);
+  router.get(paths.taskList, applicationStatusUpdate, getTaskList);
   return router;
 }
 

--- a/app/controllers/idam.ts
+++ b/app/controllers/idam.ts
@@ -38,7 +38,7 @@ function setupIdamController(): Router {
   const router = Router();
   router.use(idamExpressMiddleware.userDetails(idamConfig));
   router.get(paths.login, authenticateMiddleware, getLogin);
-  router.get(paths.redirectUrl, idamExpressMiddleware.landingPage(idamConfig), initSession, logSession, getRedirectUrl);
+  router.get(paths.redirectUrl, idamExpressMiddleware.landingPage(idamConfig), initSession, getRedirectUrl);
   router.use(idamExpressMiddleware.protect(idamConfig), checkSession(idamConfig));
   router.get(paths.logout, idamExpressMiddleware.logout(idamConfig), getLogout);
 

--- a/app/routes.ts
+++ b/app/routes.ts
@@ -25,6 +25,7 @@ import UpdateAppealService from './service/update-appeal-service';
 import { setupSecrets } from './setupSecrets';
 
 const config = setupSecrets();
+const sessionLoggerEnabled: boolean = config.get('session.useLogger');
 
 export const authenticationService: AuthenticationService = new AuthenticationService(new IdamService(), S2SService.getInstance());
 export const updateAppealService: UpdateAppealService = new UpdateAppealService(new CcdService(), authenticationService);
@@ -56,7 +57,7 @@ router.use(eligibilityController);
 // protected by idam
 router.use(idamController);
 // router.use(initSession);
-if (process.env.NODE_ENV === 'development') {
+if (process.env.NODE_ENV === 'development' && sessionLoggerEnabled) {
   router.use(logSession);
 }
 router.use(indexController);

--- a/app/session.ts
+++ b/app/session.ts
@@ -1,9 +1,10 @@
 import config from 'config';
+
 const redis = require('redis');
 const session = require('express-session');
 
-const useRedis = config.get('session.useRedis') === 'true';
-const isSecure = config.get('session.cookie.secure') === 'true';
+const useRedis: boolean = config.get('session.useRedis') === true;
+const isSecure: boolean = config.get('session.cookie.secure') === true;
 
 function setupSession() {
   if (useRedis) {

--- a/config/custom-environment-variables.json
+++ b/config/custom-environment-variables.json
@@ -19,6 +19,7 @@
   "microservice": "MICROSERVICE",
   "session": {
     "useRedis": "USE_REDIS",
+    "useLogger": "USE_SESSION_LOGGER",
     "redis": {
       "url": "REDIS_URL",
       "secret": "SESSION_SECRET"

--- a/config/default.json
+++ b/config/default.json
@@ -3,7 +3,7 @@
   "httpProxy": false,
   "proxy": {
     "host": "proxyout.reform.hmcts.net",
-    "port" : 8080
+    "port": 8080
   },
   "appInsights": {
     "instrumentationKey": ""
@@ -22,7 +22,8 @@
   },
   "microservice": "iac",
   "session": {
-    "useRedis": "true",
+    "useRedis": true,
+    "useLogger": false,
     "redis": {
       "url": "redis://127.0.0.1:6379",
       "secret": "defaultsecret",
@@ -31,7 +32,7 @@
     "cookie": {
       "secret": "defaultcookiesecret",
       "maxAgeInMs": 1200000,
-      "secure": "false"
+      "secure": false
     }
   },
   "s2s": {

--- a/config/development.json
+++ b/config/development.json
@@ -1,9 +1,10 @@
 {
   "testUrl": "https://localhost:3000",
   "session": {
-    "useRedis": "false"
+    "useRedis": true,
+    "useLogger": true
   },
   "evidenceUpload": {
-    "maxFileSizeInMb": 0.001
+    "maxFileSizeInMb": 6
   }
 }

--- a/config/test.json
+++ b/config/test.json
@@ -1,6 +1,9 @@
 {
   "testUrl": "https://localhost:3000",
   "session": {
-    "useRedis": "false"
+    "useRedis": false
+  },
+  "evidenceUpload": {
+    "maxFileSizeInMb": 0.001
   }
 }

--- a/package.json
+++ b/package.json
@@ -13,9 +13,9 @@
     "mock-postcode": "dyson test/mock/postcode-lookup/services/ 20002",
     "mock-dm-store": "dyson test/mock/document-management-store/services/ 20003",
     "lint": "tslint --project .",
-    "test": "yarn test:unit && TEST_URL=https://localhost:3000 cross-env USE_REDIS=false yarn codecept:functional",
+    "test": "yarn test:unit && yarn codecept:functional",
     "test:accessibility": "IDAM_WEB_URL=http://localhost:20001 IDAM_API_URL=http://localhost:20001 CCD_API_URL=http://localhost:20000 NODE_PATH=. TS_NODE_PROJECT=tsconfig.json NODE_ENV=development USE_REDDIS=false mocha test/accessibility/*.ts --exit",
-    "test:unit": "rm -rf test/coverage && nyc mocha --recursive \"test/unit/**/*.test.ts\"",
+    "test:unit": "rm -rf test/coverage && cross-env NODE_ENV=test nyc mocha --recursive \"test/unit/**/*.test.ts\"",
     "test:coverage": "nyc report",
     "test:a11y": "yarn test:accessibility",
     "sonar-scan": "sonar-scanner",
@@ -23,7 +23,7 @@
     "test:functional": "yarn codecept:e2e",
     "test:all": "yarn lint && yarn test && yarn test:a11y && yarn test:smoke && yarn test:functional",
     "codecept:crossbrowser": "codeceptjs run -c codecept.crossbrowser.js",
-    "codecept:functional": "IDAM_WEB_URL=http://localhost:20001 IDAM_API_URL=http://localhost:20001 CCD_API_URL=http://localhost:20000 ADDRESS_LOOKUP_URL=http://localhost:20002 DOC_MANAGEMENT_URL=http://localhost:20003 cross-env NODE_ENV=development codeceptjs run -c codecept.functional.js --verbose -g \"@broken\" --invert",
+    "codecept:functional": " TEST_URL=https://localhost:3000 USE_REDIS=false IDAM_WEB_URL=http://localhost:20001 IDAM_API_URL=http://localhost:20001 CCD_API_URL=http://localhost:20000 ADDRESS_LOOKUP_URL=http://localhost:20002 DOC_MANAGEMENT_URL=http://localhost:20003 cross-env NODE_ENV=test codeceptjs run -c codecept.functional.js --verbose -g \"@broken\" --invert",
     "codecept:e2e": "IDAM_API_URL=http://idam-api.aat.platform.hmcts.net codeceptjs run -c codecept.e2e.js --verbose --debug"
   },
   "husky": {

--- a/test/e2e-test/pages/helper-functions.ts
+++ b/test/e2e-test/pages/helper-functions.ts
@@ -4,7 +4,6 @@ const idamApiUrl = require('config').get('idam.apiUrl');
 const { I } = inject();
 
 async function createUser() {
-
   const randomNumber = parseInt(Math.random() * 10000000 + '', 10);
   const email = `ia_citizen${randomNumber}@hmcts.net`;
   const password = 'Apassword123';
@@ -40,7 +39,7 @@ async function createUser() {
 
 async function signInHelper() {
   const environment: string = process.env.NODE_ENV;
-  if (environment !== 'development') {
+  if (environment !== ('test' || 'development')) {
     const userDetails = await createUser();
     I.fillField('#username', userDetails.email);
     I.fillField('#password', userDetails.password);


### PR DESCRIPTION
### Change description ###

- Runs tests as NODE_ENV test to pick up per-environment configuration.
- Removes the session logger and adds logic to allow session logger under dev environment only when env property "useLogger" is set.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x ] No
```
