### PR TITLE
RIA-2482 Having to go to the start page twice

### DIFF
--- a/app/middleware/session-middleware.ts
+++ b/app/middleware/session-middleware.ts
@@ -28,7 +28,7 @@ function checkSession(args: any = {}) {
     const tokenCookieName = args.tokenCookieName || '__auth-token';
     if (req.cookies && req.cookies[tokenCookieName] && !_.has(req, 'session.appeal.application')) {
       res.clearCookie(tokenCookieName, '/');
-      res.redirect(paths.start);
+      res.redirect(paths.login);
     } else {
       next();
     }

--- a/test/unit/middleware/session-middleware.test.ts
+++ b/test/unit/middleware/session-middleware.test.ts
@@ -84,7 +84,7 @@ describe('session-middleware', () => {
     req.session.appeal = {} as any;
     checkSession({})(req as Request, res as Response, next);
 
-    expect(res.redirect).to.have.been.calledWith(paths.start);
+    expect(res.redirect).to.have.been.calledWith(paths.login);
     expect(res.clearCookie).to.have.been.called;
   });
 


### PR DESCRIPTION
We were redirecting to the start page if you were not logged in.
If you had a session but it had expired we had code that noticed the
session had expired and removed the session cookie then redirected you
to the start page. Change it to redirect you to the login page.