### PR TITLE
RIA-2741: Overview page copy changes for awaitingRespondentEvidence

### DIFF
--- a/app/utils/application-state-utils.ts
+++ b/app/utils/application-state-utils.ts
@@ -72,6 +72,17 @@ const APPEAL_STATE = {
       respondByText: i18n.pages.overviewPage.doThisNext.respondByText
     }
   },
+  'awaitingRespondentEvidence': {
+    descriptionParagraphs: [
+      i18n.pages.overviewPage.doThisNext.awaitingRespondentEvidence.detailsSent,
+      i18n.pages.overviewPage.doThisNext.awaitingRespondentEvidence.dueDate
+    ],
+    info: {
+      title: i18n.pages.overviewPage.doThisNext.awaitingRespondentEvidence.info.title,
+      url: i18n.pages.overviewPage.doThisNext.awaitingRespondentEvidence.info.url
+    },
+    cta: null
+  },
   'reasonsForAppealSubmitted': {
     descriptionParagraphs: [
       i18n.pages.overviewPage.doThisNext.reasonsForAppealSubmitted.detailsSent,

--- a/app/utils/event-deadline-date-finder.ts
+++ b/app/utils/event-deadline-date-finder.ts
@@ -5,6 +5,7 @@ function getDeadline(currentAppealStatus: string, history) {
     case 'appealStarted': {
       return null;
     }
+    case 'awaitingRespondentEvidence':
     case 'appealSubmitted': {
       const daysToDeadline = 14;
       const triggeringDate = history['appealSubmitted'].date;

--- a/locale/en.json
+++ b/locale/en.json
@@ -290,10 +290,18 @@
         },
         "appealSubmitted": {
           "detailsSent": "Your appeal details have been sent to the Tribunal.",
-          "dueDate": "A Tribunal Caseworker will contact you by <span class='govuk-body govuk-!-font-weight-bold'>{{ applicationNextStep.deadline }}</span> to tell you what to do next.",
+          "dueDate": "A Tribunal Caseworker will contact you by <span  class='govuk-!-font-weight-bold'> {{ applicationNextStep.deadline }}</span>  to tell you what to do next.",
           "info": {
             "title": "Helpful Information",
-            "url": "<a class=\"govuk-link\" href=\"#\">What is a Tribunal Caseworker?</a>"
+            "url": "<a class='govuk-link' href='/tribunal-caseworker'>What is a Tribunal Caseworker?</a>"
+          }
+        },
+        "awaitingRespondentEvidence": {
+          "detailsSent": "Your appeal details have been sent to the Tribunal.",
+          "dueDate": "A Tribunal Caseworker will contact you by <span  class='govuk-!-font-weight-bold'> {{ applicationNextStep.deadline }}</span>  to tell you what to do next.",
+          "info": {
+            "title": "Helpful Information",
+            "url": "<a class='govuk-link' href='/tribunal-caseworker'>What is a Tribunal Caseworker?</a>"
           }
         },
         "awaitingReasonsForAppeal": {
@@ -322,7 +330,7 @@
         },
         "reasonsForAppealSubmitted": {
           "detailsSent": "You have told us why you think the Home Office decision is wrong.",
-          "dueDate": "A Tribunal Caseworker will contact you by <span class='govuk-body govuk-!-font-weight-bold'>Date TBC</span> to tell you what to do next."
+          "dueDate": "A Tribunal Caseworker will contact you by <span class='govuk-!-font-weight-bold'>Date TBC</span> to tell you what to do next."
         }
       }
     },

--- a/test/unit/utils/application-state-utils.test.ts
+++ b/test/unit/utils/application-state-utils.test.ts
@@ -86,12 +86,12 @@ describe('application-state-utils', () => {
         deadline: '21 February 2020',
         descriptionParagraphs: [
           'Your appeal details have been sent to the Tribunal.',
-          "A Tribunal Caseworker will contact you by <span class='govuk-body govuk-!-font-weight-bold'>{{ applicationNextStep.deadline }}</span> to tell you what to do next."
+          'A Tribunal Caseworker will contact you by <span  class=\'govuk-!-font-weight-bold\'> {{ applicationNextStep.deadline }}</span>  to tell you what to do next.'
         ],
 
         info: {
           title: 'Helpful Information',
-          url: '<a class="govuk-link" href="#">What is a Tribunal Caseworker?</a>'
+          url: '<a class=\'govuk-link\' href=\'/tribunal-caseworker\'>What is a Tribunal Caseworker?</a>'
         }
       });
     });
@@ -164,7 +164,7 @@ describe('application-state-utils', () => {
       deadline: 'TBC',
       descriptionParagraphs: [
         'You have told us why you think the Home Office decision is wrong.',
-        'A Tribunal Caseworker will contact you by <span class=\'govuk-body govuk-!-font-weight-bold\'>Date TBC</span> to tell you what to do next.'
+        'A Tribunal Caseworker will contact you by <span class=\'govuk-!-font-weight-bold\'>Date TBC</span> to tell you what to do next.'
       ]
     });
   });


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/RIA-2741


### Change description ###
Adding content for awaitingRespondentEvidence state on overview's page 'do next' component


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ X ] No
```
