### PR TITLE
Ria 2770 accessibility empty link bug

### DIFF
--- a/app/controllers/appeal-application/out-of-time.ts
+++ b/app/controllers/appeal-application/out-of-time.ts
@@ -66,7 +66,6 @@ function postAppealLate(documentManagementService: DocumentManagementService, up
         application.lateAppeal = {
           ...application.lateAppeal,
           evidence: {
-            id: evidenceStored.id,
             fileId: evidenceStored.fileId,
             name: evidenceStored.name
           }

--- a/app/controllers/reasons-for-appeal/check-and-send.ts
+++ b/app/controllers/reasons-for-appeal/check-and-send.ts
@@ -19,8 +19,8 @@ function getCheckAndSend(req: Request, res: Response, next: NextFunction): void 
 
     if (_.has(req.session.appeal.reasonsForAppeal, 'evidences')) {
 
-      const evidences: Evidences = req.session.appeal.reasonsForAppeal.evidences;
-      const evidenceNames: string[] = Object.values(evidences).map((evidence) => evidence.name);
+      const evidences: Evidence[] = req.session.appeal.reasonsForAppeal.evidences;
+      const evidenceNames: string[] = evidences.map((evidence) => evidence.name);
       if (evidenceNames.length) {
         summaryRows.push(addSummaryRow(i18n.common.cya.supportingEvidenceRowTitle, evidenceNames, paths.reasonsForAppeal.supportingEvidenceUpload + editParameter, Delimiter.BREAK_LINE));
         previousPage = paths.reasonsForAppeal.supportingEvidenceUpload;

--- a/app/service/document-management-service.ts
+++ b/app/service/document-management-service.ts
@@ -104,7 +104,7 @@ class DocumentManagementService {
       files: [ {
         value: uploadData.file.buffer,
         options: {
-          filename: `${Date.now()}-${uploadData.file.originalname}`,
+          filename: uploadData.file.originalname,
           contentType: uploadData.file.mimetype
         }
       } ],
@@ -156,12 +156,10 @@ class DocumentManagementService {
     return this.upload(userId, headers, uploadData)
       .then(response => {
         const res: DocumentManagementStoreResponse = JSON.parse(response);
-        const docName = res._embedded.documents[0].originalDocumentName;
         const documentMapperId: string = addToDocumentMapper(res._embedded.documents[0]._links.self.href, req.session.appeal.documentMap);
         return {
-          id: docName,
           fileId: documentMapperId,
-          name: docName.substring(docName.indexOf('-') + 1)
+          name: res._embedded.documents[0].originalDocumentName
         } as DocumentUploadResponse;
       });
   }

--- a/test/unit/controllers/reasons-for-appeal/check-and-send.test.ts
+++ b/test/unit/controllers/reasons-for-appeal/check-and-send.test.ts
@@ -29,7 +29,8 @@ describe('Reasons For Appeal - Check and send Controller', () => {
         appeal: {
           application: {},
           reasonsForAppeal: {
-            applicationReason: 'a reason'
+            applicationReason: 'a reason',
+            evidences: [] as Evidence[]
           }
         } as Partial<Appeal>
       } as Partial<Express.Session>
@@ -66,18 +67,15 @@ describe('Reasons For Appeal - Check and send Controller', () => {
         addSummaryRow(i18n.common.cya.answerRowTitle, [ req.session.appeal.reasonsForAppeal.applicationReason ], paths.reasonsForAppeal.decision + editParameter),
         addSummaryRow(i18n.common.cya.supportingEvidenceRowTitle, [ 'File1.png', 'File2.png' ], paths.reasonsForAppeal.supportingEvidenceUpload + editParameter, Delimiter.BREAK_LINE)
       ];
-      req.session.appeal.reasonsForAppeal.evidences = {
-        '1-File1.png': {
-          id: '1-File1.png',
+      req.session.appeal.reasonsForAppeal.evidences = [
+        {
           fileId: '1234',
           name: 'File1.png'
-        },
-        '2-File2.png': {
-          id: '2-File2.png',
+        }, {
           fileId: '1234',
           name: 'File2.png'
         }
-      };
+      ];
 
       getCheckAndSend(req as Request, res as Response, next);
       expect(res.render).to.have.been.calledWith('reasons-for-appeal/check-and-send-page.njk', {

--- a/test/unit/controllers/reasons-for-appeal/reason-for-appeal.test.ts
+++ b/test/unit/controllers/reasons-for-appeal/reason-for-appeal.test.ts
@@ -138,13 +138,12 @@ describe('Reasons for Appeal Controller', function () {
 
   describe('postSupportingEvidenceSubmit.', function () {
 
-    const evidenceMock = {
-      someEvidenceId: {
-        id: 'someEvidenceId',
+    const evidenceMock = [
+      {
         fileId: 'someUUID',
         name: 'name.png'
       }
-    };
+    ];
     it('should fail validation and render reasons-for-appeal/supporting-evidence-upload-page.njk with error', async () => {
       req.session.appeal.reasonsForAppeal.evidences = undefined;
       await postSupportingEvidenceSubmit(updateAppealService as UpdateAppealService)(req as Request, res as Response, next);

--- a/test/unit/controllers/reasons-for-appeal/supporting-evidence-upload.test.ts
+++ b/test/unit/controllers/reasons-for-appeal/supporting-evidence-upload.test.ts
@@ -21,6 +21,12 @@ describe('Supporting Evidence Upload Controller', () => {
   let updateAppealService: Partial<UpdateAppealService>;
   let documentManagementService: Partial<DocumentManagementService>;
   const logger: Logger = new Logger();
+  const someEvidences: Evidence[] = [
+    {
+      fileId: 'someUUID',
+      name: 'name.png'
+    }
+  ];
 
   beforeEach(() => {
     sandbox = sinon.createSandbox();
@@ -80,7 +86,7 @@ describe('Supporting Evidence Upload Controller', () => {
 
   describe('getSupportingEvidenceUploadPage', () => {
     it('should render reasons-for-appeal/supporting-evidence-upload-page.njk', () => {
-      const evidences = {};
+      const evidences: Evidence[] = [];
       req.session.appeal.reasonsForAppeal.evidences = evidences;
 
       getSupportingEvidenceUploadPage(req as Request, res as Response, next);
@@ -93,19 +99,11 @@ describe('Supporting Evidence Upload Controller', () => {
     });
 
     it('should render reasons-for-appeal/supporting-evidence-upload-page.njk with saved evidences', () => {
-      const evidences = {
-        someEvidenceId: {
-          id: 'someEvidenceId',
-          fileId: 'someUUID',
-          name: 'name.png'
-        }
-      };
-
-      req.session.appeal.reasonsForAppeal.evidences = evidences;
+      req.session.appeal.reasonsForAppeal.evidences = someEvidences;
       getSupportingEvidenceUploadPage(req as Request, res as Response, next);
 
       expect(res.render).to.have.been.calledOnce.calledWith('reasons-for-appeal/supporting-evidence-upload-page.njk', {
-        evidences: Object.values(evidences),
+        evidences: someEvidences,
         evidenceCTA: paths.reasonsForAppeal.supportingEvidenceDeleteFile,
         previousPage: paths.reasonsForAppeal.supportingEvidence
       });
@@ -184,7 +182,6 @@ describe('Supporting Evidence Upload Controller', () => {
       req.file = mockFile as Express.Multer.File;
 
       const documentUploadResponse: DocumentUploadResponse = {
-        id: 'someEvidenceId',
         fileId: 'someUUID',
         name: 'name.png'
       };
@@ -199,13 +196,7 @@ describe('Supporting Evidence Upload Controller', () => {
     });
 
     it('getSupportingEvidenceDeleteFile should catch exception and call next with the error', async () => {
-      req.session.appeal.reasonsForAppeal.evidences = {
-        someEvidenceId: {
-          id: 'someEvidenceId',
-          fileId: 'someUUID',
-          name: 'name.png'
-        }
-      };
+      req.session.appeal.reasonsForAppeal.evidences = someEvidences;
 
       const documentMap = { id: 'someUUID', url: 'docStoreURLToFile' };
       req.session.appeal.documentMap = [ documentMap ];
@@ -222,13 +213,7 @@ describe('Supporting Evidence Upload Controller', () => {
   describe('getSupportingEvidenceDeleteFile', () => {
 
     it('Should delete successfully when click on delete link and redirect to the upload-page page', async () => {
-      req.session.appeal.reasonsForAppeal.evidences = {
-        someEvidenceId: {
-          id: 'someEvidenceId',
-          fileId: 'someUUID',
-          name: 'name.png'
-        }
-      };
+      req.session.appeal.reasonsForAppeal.evidences = someEvidences;
 
       const documentMap = { id: 'someUUID', url: 'docStoreURLToFile' };
       req.session.appeal.documentMap = [ documentMap ];
@@ -240,13 +225,7 @@ describe('Supporting Evidence Upload Controller', () => {
     });
 
     it('getSupportingEvidenceDeleteFile should catch exception and call next with the error', async () => {
-      req.session.appeal.reasonsForAppeal.evidences = {
-        someEvidenceId: {
-          id: 'someEvidenceId',
-          fileId: 'someUUID',
-          name: 'name.png'
-        }
-      };
+      req.session.appeal.reasonsForAppeal.evidences = someEvidences;
 
       const documentMap = { id: 'someUUID', url: 'docStoreURLToFile' };
       req.session.appeal.documentMap = [ documentMap ];

--- a/test/unit/service/update-appeal-service.test.ts
+++ b/test/unit/service/update-appeal-service.test.ts
@@ -38,12 +38,15 @@ describe('update-appeal-service', () => {
       idam: {
         userDetails: {
           uid: userId,
-          forename: 'idamForename',
-          surname: 'idamSurname'
+          name: 'name',
+          given_name: 'given',
+          family_name: 'family'
         }
       },
-      session: {}
-    } as any;
+      session: {
+        appeal: {}
+      }
+    } as Partial<Request>;
 
     ccdServiceMock.expects('loadOrCreateCase')
       .withArgs(userId, { userToken, serviceToken })
@@ -136,9 +139,8 @@ describe('update-appeal-service', () => {
       expect(req.session.appeal.application.personalDetails.address.city).eq('LONDON');
       expect(req.session.appeal.application.personalDetails.address.postcode).eq('W1W 7RT');
       expect(req.session.appeal.application.isAppealLate).eq(true);
-      expect(req.session.appeal.application.lateAppeal.evidence.id).eq('1580296112615-evidence-file.jpeg');
+      expect(req.session.appeal.application.lateAppeal.evidence.name).eq('1580296112615-evidence-file.jpeg');
       validateUuid(req.session.appeal.application.lateAppeal.evidence.fileId);
-      expect(req.session.appeal.application.lateAppeal.evidence.name).eq('evidence-file.jpeg');
       expect(req.session.appeal.application.contactDetails.email).eq('email@example.net');
       expect(req.session.appeal.application.contactDetails.phone).eq('07123456789');
       expect(req.session.appeal.application.contactDetails.wantsEmail).eq(true);
@@ -390,7 +392,6 @@ describe('update-appeal-service', () => {
               lateAppeal: {
                 reason: 'a reason',
                 evidence: {
-                  id: '0000-somefile.png',
                   name: 'somefile.png',
                   fileId: '00000000-0000-0000-0000-000000000000'
                 }
@@ -422,18 +423,16 @@ describe('update-appeal-service', () => {
             } as AppealApplication,
             reasonsForAppeal: {
               applicationReason: 'I\'ve decided to appeal because ...',
-              evidences: {
-                '1-File1.png': {
-                  id: '1-File1.png',
+              evidences: [
+                {
                   fileId: '00000000-0000-0000-0000-000000000001',
                   name: 'File1.png'
                 },
-                '2-File2.png': {
-                  id: '2-File2.png',
+                {
                   fileId: '00000000-0000-0000-0000-000000000002',
                   name: 'File2.png'
                 }
-              } as Evidences
+              ] as Evidence[]
             },
             respondentDocuments: [
               {
@@ -480,7 +479,7 @@ describe('update-appeal-service', () => {
         submissionOutOfTime: 'Yes',
         applicationOutOfTimeExplanation: 'a reason',
         applicationOutOfTimeDocument: {
-          document_filename: '0000-somefile.png',
+          document_filename: 'somefile.png',
           document_url: 'http://dm-store:4506/documents/00000000-0000-0000-0000-000000000000',
           document_binary_url: 'http://dm-store:4506/documents/00000000-0000-0000-0000-000000000000/binary'
         },
@@ -520,14 +519,14 @@ describe('update-appeal-service', () => {
           {
             value: {
               document_url: 'http://dm-store:4506/documents/00000000-0000-0000-0000-000000000001',
-              document_filename: '1-File1.png',
+              document_filename: 'File1.png',
               document_binary_url: 'http://dm-store:4506/documents/00000000-0000-0000-0000-000000000001/binary'
             }
           },
           {
             value: {
               document_url: 'http://dm-store:4506/documents/00000000-0000-0000-0000-000000000002',
-              document_filename: '2-File2.png',
+              document_filename: 'File2.png',
               document_binary_url: 'http://dm-store:4506/documents/00000000-0000-0000-0000-000000000002/binary'
             }
           }

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -25,18 +25,12 @@ interface DocumentMap {
   url: string;
 }
 
-interface Evidences {
-  [key: string]: Evidence;
-}
-
 interface Evidence {
-  id?: string;
   fileId: string;
   name: string;
 }
 
 interface DocumentUploadResponse {
-  id: string;
   fileId: string;
   name: string;
 }
@@ -58,15 +52,17 @@ interface AppealDate {
   year: number;
 }
 
+interface LateAppeal {
+  reason: string;
+  evidence?: Evidence;
+}
+
 interface AppealApplication {
   homeOfficeRefNumber: string;
   dateLetterSent: AppealDate;
   appealType: string;
   isAppealLate: boolean;
-  lateAppeal?: {
-    reason?: string;
-    evidence?: Evidence;
-  };
+  lateAppeal?: LateAppeal;
   personalDetails: {
     givenNames: string;
     familyName: string;
@@ -97,7 +93,7 @@ interface AppealApplication {
 
 interface ReasonsForAppeal {
   applicationReason: string;
-  evidences?: Evidences;
+  evidences?: Evidence[];
   isEdit?: boolean;
 }
 

--- a/views/components/evidence-list.njk
+++ b/views/components/evidence-list.njk
@@ -16,10 +16,7 @@
       <tr class="govuk-table__row evidence">
         <td class="govuk-table__cell">{{ evidence.name }}</td>
         <td class="govuk-table__cell">
-          <a href="{{ cta }}?id={{ evidence.id }}">
-            <input type="button" name="delete[{{ evidence.id }}]" value="{{ i18n.components.evidenceList.delete }}"
-                   class="evidence-list__link">
-          </a>
+          <a class="govuk-link" href="{{ cta }}?id={{ evidence.fileId }}">{{ i18n.components.evidenceList.delete }}</a>
         </td>
       </tr>
     {% else %}

--- a/views/components/timeout-modal.njk
+++ b/views/components/timeout-modal.njk
@@ -1,7 +1,7 @@
 {% macro timeoutModal() %}
   <div class="timeout-modal" id="timeout-modal" role="dialog" aria-labelledby="dialog-title" aria-describedby="dialog-description" aria-hidden="true">
     <h2 class="govuk-heading-l" id="dialog-title">{{ i18n.components.timeoutModal.title }}</h2>
-    <p id="modal-countdown" id="dialog-description">{{ i18n.components.timeoutModal.initialDescription }}</p>
+    <p id="dialog-description">{{ i18n.components.timeoutModal.initialDescription }}</p>
 
     {{ govukButton({
       text: i18n.components.timeoutModal.cta,


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/RIA-2770


### Change description ###
- Fixing empty link accessibility bug
- Refactoring Evidences definition as an array instead of object on reasonsForAppeal
- Removing id on Evidence interface as it is not used and is just adding confusion


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ X ] No
```
