### PR TITLE
Ria 2770: accessibility empty link bug

### DIFF
--- a/app/controllers/appeal-application/out-of-time.ts
+++ b/app/controllers/appeal-application/out-of-time.ts
@@ -66,7 +66,6 @@ function postAppealLate(documentManagementService: DocumentManagementService, up
         application.lateAppeal = {
           ...application.lateAppeal,
           evidence: {
-            id: evidenceStored.id,
             fileId: evidenceStored.fileId,
             name: evidenceStored.name
           }

--- a/app/controllers/reasons-for-appeal/check-and-send.ts
+++ b/app/controllers/reasons-for-appeal/check-and-send.ts
@@ -19,8 +19,8 @@ function getCheckAndSend(req: Request, res: Response, next: NextFunction): void 
 
     if (_.has(req.session.appeal.reasonsForAppeal, 'evidences')) {
 
-      const evidences: Evidences = req.session.appeal.reasonsForAppeal.evidences;
-      const evidenceNames: string[] = Object.values(evidences).map((evidence) => evidence.name);
+      const evidences: Evidence[] = req.session.appeal.reasonsForAppeal.evidences;
+      const evidenceNames: string[] = evidences.map((evidence) => evidence.name);
       if (evidenceNames.length) {
         summaryRows.push(addSummaryRow(i18n.common.cya.supportingEvidenceRowTitle, evidenceNames, paths.reasonsForAppeal.supportingEvidenceUpload + editParameter, Delimiter.BREAK_LINE));
         previousPage = paths.reasonsForAppeal.supportingEvidenceUpload;

--- a/app/controllers/reasons-for-appeal/reason-for-appeal.ts
+++ b/app/controllers/reasons-for-appeal/reason-for-appeal.ts
@@ -152,16 +152,12 @@ function postSupportingEvidenceUploadFile(documentManagementService: DocumentMan
     try {
       if (req.file) {
         const evidenceStored: DocumentUploadResponse = await documentManagementService.uploadFile(req);
-        const { reasonsForAppeal } = req.session.appeal;
-        reasonsForAppeal.evidences = {
-          ...reasonsForAppeal.evidences,
-          [evidenceStored.id]: {
-            id: evidenceStored.id,
-            fileId: evidenceStored.fileId,
-            name: evidenceStored.name
-          }
-        };
-        await updateAppealService.submitEvent(Events.EDIT_REASONS_FOR_APPEAL, req);
+        const evidences: Evidence[] = [ ...(req.session.appeal.reasonsForAppeal.evidences || []) ];
+        evidences.push({
+          fileId: evidenceStored.fileId,
+          name: evidenceStored.name
+        });
+        req.session.appeal.reasonsForAppeal.evidences = [ ...evidences ];
         return res.redirect(paths.reasonsForAppeal.supportingEvidenceUpload);
       } else {
         let validationError;
@@ -192,7 +188,8 @@ function getSupportingEvidenceDeleteFile(documentManagementService: DocumentMana
         const fileId = req.query['id'];
         const targetUrl: string = documentIdToDocStoreUrl(fileId, req.session.appeal.documentMap);
         await documentManagementService.deleteFile(req, targetUrl);
-        delete req.session.appeal.reasonsForAppeal.evidences[fileId];
+        const evidences: Evidence[] = [ ...req.session.appeal.reasonsForAppeal.evidences ];
+        req.session.appeal.reasonsForAppeal.evidences = evidences.filter((evidence: Evidence) => evidence.fileId !== req.query['id']);
       }
       return res.redirect(paths.reasonsForAppeal.supportingEvidenceUpload);
     } catch (e) {

--- a/app/service/document-management-service.ts
+++ b/app/service/document-management-service.ts
@@ -114,7 +114,7 @@ class DocumentManagementService {
       files: [ {
         value: uploadData.file.buffer,
         options: {
-          filename: `${Date.now()}-${uploadData.file.originalname}`,
+          filename: uploadData.file.originalname,
           contentType: uploadData.file.mimetype
         }
       } ],
@@ -166,12 +166,10 @@ class DocumentManagementService {
     return this.upload(userId, headers, uploadData)
       .then(response => {
         const res: DocumentManagementStoreResponse = JSON.parse(response);
-        const docName = res._embedded.documents[0].originalDocumentName;
         const documentMapperId: string = addToDocumentMapper(res._embedded.documents[0]._links.self.href, req.session.appeal.documentMap);
         return {
-          id: docName,
           fileId: documentMapperId,
-          name: docName.substring(docName.indexOf('-') + 1)
+          name: res._embedded.documents[0].originalDocumentName
         } as DocumentUploadResponse;
       });
   }

--- a/app/service/update-appeal-service.ts
+++ b/app/service/update-appeal-service.ts
@@ -53,9 +53,9 @@ export default class UpdateAppealService {
 
     const appealType = caseData.appealType || null;
     const subscriptions = caseData.subscriptions || [];
-    let outOfTimeAppeal = null;
+    let outOfTimeAppeal: LateAppeal = null;
     let respondentDocuments: RespondentDocument[] = null;
-    let reasonsForAppealDocumentUploads: Evidences = null;
+    let reasonsForAppealDocumentUploads: Evidence[] = null;
 
     const contactDetails = subscriptions.reduce((contactDetails, subscription) => {
       const value = subscription.value;
@@ -81,23 +81,24 @@ export default class UpdateAppealService {
         outOfTimeAppeal = {
           ...outOfTimeAppeal,
           evidence: {
-            id: caseData.applicationOutOfTimeDocument.document_filename,
             fileId: documentMapperId,
-            name: this.fileIdToName(caseData.applicationOutOfTimeDocument.document_filename)
+            name: caseData.applicationOutOfTimeDocument.document_filename
           }
         };
       }
     }
     // TODO needs to use the document mapper.
     if (caseData.reasonsForAppealDocuments) {
-      reasonsForAppealDocumentUploads = {};
+      reasonsForAppealDocumentUploads = [];
       caseData.reasonsForAppealDocuments.forEach(document => {
         const documentMapperId: string = addToDocumentMapper(document.value.document_url, documentMap);
 
-        reasonsForAppealDocumentUploads[documentMapperId] = {
-          fileId: documentMapperId,
-          name: this.fileIdToName(document.value.document_filename)
-        };
+        reasonsForAppealDocumentUploads.push(
+          {
+            fileId: documentMapperId,
+            name: document.value.document_filename
+          }
+        );
       });
     }
 
@@ -174,10 +175,6 @@ export default class UpdateAppealService {
     } else if (answer === 'No') return false;
   }
 
-  fileIdToName(fileID: string): string {
-    return fileID.substring(fileID.indexOf('-') + 1);
-  }
-
   async submitEvent(event, req: Request): Promise<CcdCaseDetails> {
     const securityHeaders: SecurityHeaders = await this._authenticationService.getSecurityHeaders(req);
 
@@ -215,7 +212,7 @@ export default class UpdateAppealService {
 
         const documentLocationUrl: string = documentIdToDocStoreUrl(appeal.application.lateAppeal.evidence.fileId, appeal.documentMap);
         caseData.applicationOutOfTimeDocument = {
-          document_filename: appeal.application.lateAppeal.evidence.id,
+          document_filename: appeal.application.lateAppeal.evidence.name,
           document_url: documentLocationUrl,
           document_binary_url: `${documentLocationUrl}/binary`
         };
@@ -275,13 +272,13 @@ export default class UpdateAppealService {
     }
 
     if (_.has(appeal, 'reasonsForAppeal')) {
-      // save text and evidence file
       if (appeal.reasonsForAppeal.applicationReason) {
         caseData.reasonsForAppealDecision = appeal.reasonsForAppeal.applicationReason;
       }
       if (appeal.reasonsForAppeal.evidences) {
-        const evidences: Evidences = appeal.reasonsForAppeal.evidences;
-        caseData.reasonsForAppealDocuments = Object.values(evidences).map((evidence) => {
+        const evidences: Evidence[] = appeal.reasonsForAppeal.evidences;
+
+        caseData.reasonsForAppealDocuments = evidences.map((evidence) => {
           const documentLocationUrl: string = documentIdToDocStoreUrl(evidence.fileId, appeal.documentMap);
           return {
             value: {

--- a/test/unit/controllers/reasons-for-appeal/check-and-send.test.ts
+++ b/test/unit/controllers/reasons-for-appeal/check-and-send.test.ts
@@ -29,7 +29,8 @@ describe('Reasons For Appeal - Check and send Controller', () => {
         appeal: {
           application: {},
           reasonsForAppeal: {
-            applicationReason: 'a reason'
+            applicationReason: 'a reason',
+            evidences: [] as Evidence[]
           }
         } as Partial<Appeal>
       } as Partial<Express.Session>
@@ -66,18 +67,15 @@ describe('Reasons For Appeal - Check and send Controller', () => {
         addSummaryRow(i18n.common.cya.answerRowTitle, [ req.session.appeal.reasonsForAppeal.applicationReason ], paths.reasonsForAppeal.decision + editParameter),
         addSummaryRow(i18n.common.cya.supportingEvidenceRowTitle, [ 'File1.png', 'File2.png' ], paths.reasonsForAppeal.supportingEvidenceUpload + editParameter, Delimiter.BREAK_LINE)
       ];
-      req.session.appeal.reasonsForAppeal.evidences = {
-        '1-File1.png': {
-          id: '1-File1.png',
+      req.session.appeal.reasonsForAppeal.evidences = [
+        {
           fileId: '1234',
           name: 'File1.png'
-        },
-        '2-File2.png': {
-          id: '2-File2.png',
+        }, {
           fileId: '1234',
           name: 'File2.png'
         }
-      };
+      ];
 
       getCheckAndSend(req as Request, res as Response, next);
       expect(res.render).to.have.been.calledWith('reasons-for-appeal/check-and-send-page.njk', {

--- a/test/unit/controllers/reasons-for-appeal/reason-for-appeal.test.ts
+++ b/test/unit/controllers/reasons-for-appeal/reason-for-appeal.test.ts
@@ -140,13 +140,12 @@ describe('Reasons for Appeal Controller', function () {
 
   describe('postSupportingEvidenceSubmit.', function () {
 
-    const evidenceMock = {
-      someEvidenceId: {
-        id: 'someEvidenceId',
+    const evidenceMock = [
+      {
         fileId: 'someUUID',
         name: 'name.png'
       }
-    };
+    ];
     it('should fail validation and render reasons-for-appeal/supporting-evidence-upload-page.njk with error', async () => {
       req.session.appeal.reasonsForAppeal.evidences = undefined;
       await postSupportingEvidenceSubmit(updateAppealService as UpdateAppealService)(req as Request, res as Response, next);

--- a/test/unit/controllers/reasons-for-appeal/supporting-evidence-upload.test.ts
+++ b/test/unit/controllers/reasons-for-appeal/supporting-evidence-upload.test.ts
@@ -21,6 +21,12 @@ describe('Supporting Evidence Upload Controller', () => {
   let updateAppealService: Partial<UpdateAppealService>;
   let documentManagementService: Partial<DocumentManagementService>;
   const logger: Logger = new Logger();
+  const someEvidences: Evidence[] = [
+    {
+      fileId: 'someUUID',
+      name: 'name.png'
+    }
+  ];
 
   beforeEach(() => {
     sandbox = sinon.createSandbox();
@@ -80,7 +86,7 @@ describe('Supporting Evidence Upload Controller', () => {
 
   describe('getSupportingEvidenceUploadPage', () => {
     it('should render reasons-for-appeal/supporting-evidence-upload-page.njk', () => {
-      const evidences = {};
+      const evidences: Evidence[] = [];
       req.session.appeal.reasonsForAppeal.evidences = evidences;
 
       getSupportingEvidenceUploadPage(req as Request, res as Response, next);
@@ -94,19 +100,11 @@ describe('Supporting Evidence Upload Controller', () => {
     });
 
     it('should render reasons-for-appeal/supporting-evidence-upload-page.njk with saved evidences', () => {
-      const evidences = {
-        someEvidenceId: {
-          id: 'someEvidenceId',
-          fileId: 'someUUID',
-          name: 'name.png'
-        }
-      };
-
-      req.session.appeal.reasonsForAppeal.evidences = evidences;
+      req.session.appeal.reasonsForAppeal.evidences = someEvidences;
       getSupportingEvidenceUploadPage(req as Request, res as Response, next);
 
       expect(res.render).to.have.been.calledOnce.calledWith('reasons-for-appeal/supporting-evidence-upload-page.njk', {
-        evidences: Object.values(evidences),
+        evidences: someEvidences,
         evidenceCTA: paths.reasonsForAppeal.supportingEvidenceDeleteFile,
         previousPage: paths.reasonsForAppeal.supportingEvidence,
         askForMoreTimeFeatureEnabled: false
@@ -192,7 +190,6 @@ describe('Supporting Evidence Upload Controller', () => {
       req.file = mockFile as Express.Multer.File;
 
       const documentUploadResponse: DocumentUploadResponse = {
-        id: 'someEvidenceId',
         fileId: 'someUUID',
         name: 'name.png'
       };
@@ -207,13 +204,7 @@ describe('Supporting Evidence Upload Controller', () => {
     });
 
     it('getSupportingEvidenceDeleteFile should catch exception and call next with the error', async () => {
-      req.session.appeal.reasonsForAppeal.evidences = {
-        someEvidenceId: {
-          id: 'someEvidenceId',
-          fileId: 'someUUID',
-          name: 'name.png'
-        }
-      };
+      req.session.appeal.reasonsForAppeal.evidences = someEvidences;
 
       const documentMap = { id: 'someUUID', url: 'docStoreURLToFile' };
       req.session.appeal.documentMap = [ documentMap ];
@@ -230,13 +221,7 @@ describe('Supporting Evidence Upload Controller', () => {
   describe('getSupportingEvidenceDeleteFile', () => {
 
     it('Should delete successfully when click on delete link and redirect to the upload-page page', async () => {
-      req.session.appeal.reasonsForAppeal.evidences = {
-        someEvidenceId: {
-          id: 'someEvidenceId',
-          fileId: 'someUUID',
-          name: 'name.png'
-        }
-      };
+      req.session.appeal.reasonsForAppeal.evidences = someEvidences;
 
       const documentMap = { id: 'someUUID', url: 'docStoreURLToFile' };
       req.session.appeal.documentMap = [ documentMap ];
@@ -248,13 +233,7 @@ describe('Supporting Evidence Upload Controller', () => {
     });
 
     it('getSupportingEvidenceDeleteFile should catch exception and call next with the error', async () => {
-      req.session.appeal.reasonsForAppeal.evidences = {
-        someEvidenceId: {
-          id: 'someEvidenceId',
-          fileId: 'someUUID',
-          name: 'name.png'
-        }
-      };
+      req.session.appeal.reasonsForAppeal.evidences = someEvidences;
 
       const documentMap = { id: 'someUUID', url: 'docStoreURLToFile' };
       req.session.appeal.documentMap = [ documentMap ];

--- a/test/unit/service/update-appeal-service.test.ts
+++ b/test/unit/service/update-appeal-service.test.ts
@@ -38,12 +38,15 @@ describe('update-appeal-service', () => {
       idam: {
         userDetails: {
           uid: userId,
-          forename: 'idamForename',
-          surname: 'idamSurname'
+          name: 'name',
+          given_name: 'given',
+          family_name: 'family'
         }
       },
-      session: {}
-    } as any;
+      session: {
+        appeal: {}
+      }
+    } as Partial<Request>;
 
     ccdServiceMock.expects('loadOrCreateCase')
       .withArgs(userId, { userToken, serviceToken })
@@ -136,9 +139,8 @@ describe('update-appeal-service', () => {
       expect(req.session.appeal.application.personalDetails.address.city).eq('LONDON');
       expect(req.session.appeal.application.personalDetails.address.postcode).eq('W1W 7RT');
       expect(req.session.appeal.application.isAppealLate).eq(true);
-      expect(req.session.appeal.application.lateAppeal.evidence.id).eq('1580296112615-evidence-file.jpeg');
+      expect(req.session.appeal.application.lateAppeal.evidence.name).eq('1580296112615-evidence-file.jpeg');
       validateUuid(req.session.appeal.application.lateAppeal.evidence.fileId);
-      expect(req.session.appeal.application.lateAppeal.evidence.name).eq('evidence-file.jpeg');
       expect(req.session.appeal.application.contactDetails.email).eq('email@example.net');
       expect(req.session.appeal.application.contactDetails.phone).eq('07123456789');
       expect(req.session.appeal.application.contactDetails.wantsEmail).eq(true);
@@ -392,7 +394,6 @@ describe('update-appeal-service', () => {
               lateAppeal: {
                 reason: 'a reason',
                 evidence: {
-                  id: '0000-somefile.png',
                   name: 'somefile.png',
                   fileId: '00000000-0000-0000-0000-000000000000'
                 }
@@ -424,18 +425,16 @@ describe('update-appeal-service', () => {
             } as AppealApplication,
             reasonsForAppeal: {
               applicationReason: 'I\'ve decided to appeal because ...',
-              evidences: {
-                '1-File1.png': {
-                  id: '1-File1.png',
+              evidences: [
+                {
                   fileId: '00000000-0000-0000-0000-000000000001',
                   name: 'File1.png'
                 },
-                '2-File2.png': {
-                  id: '2-File2.png',
+                {
                   fileId: '00000000-0000-0000-0000-000000000002',
                   name: 'File2.png'
                 }
-              } as Evidences
+              ] as Evidence[]
             },
             respondentDocuments: [
               {
@@ -482,7 +481,7 @@ describe('update-appeal-service', () => {
         submissionOutOfTime: 'Yes',
         applicationOutOfTimeExplanation: 'a reason',
         applicationOutOfTimeDocument: {
-          document_filename: '0000-somefile.png',
+          document_filename: 'somefile.png',
           document_url: 'http://dm-store:4506/documents/00000000-0000-0000-0000-000000000000',
           document_binary_url: 'http://dm-store:4506/documents/00000000-0000-0000-0000-000000000000/binary'
         },

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -42,18 +42,12 @@ interface DocumentMap {
   url: string;
 }
 
-interface Evidences {
-  [key: string]: Evidence;
-}
-
 interface Evidence {
-  id?: string;
   fileId: string;
   name: string;
 }
 
 interface DocumentUploadResponse {
-  id: string;
   fileId: string;
   name: string;
 }
@@ -96,15 +90,17 @@ interface AppealDate {
   year: number;
 }
 
+interface LateAppeal {
+  reason: string;
+  evidence?: Evidence;
+}
+
 interface AppealApplication {
   homeOfficeRefNumber: string;
   dateLetterSent: AppealDate;
   appealType: string;
   isAppealLate: boolean;
-  lateAppeal?: {
-    reason?: string;
-    evidence?: Evidence;
-  };
+  lateAppeal?: LateAppeal;
   personalDetails: {
     givenNames: string;
     familyName: string;
@@ -135,7 +131,7 @@ interface AppealApplication {
 
 interface ReasonsForAppeal {
   applicationReason: string;
-  evidences?: Evidences;
+  evidences?: Evidence[];
   isEdit?: boolean;
 }
 

--- a/views/components/evidence-list.njk
+++ b/views/components/evidence-list.njk
@@ -16,10 +16,7 @@
       <tr class="govuk-table__row evidence">
         <td class="govuk-table__cell">{{ evidence.name }}</td>
         <td class="govuk-table__cell">
-          <a href="{{ cta }}?id={{ evidence.fileId }}">
-            <input type="button" name="delete[{{ evidence.fileId }}]" value="{{ i18n.components.evidenceList.delete }}"
-                   class="evidence-list__link">
-          </a>
+          <a class="govuk-link" href="{{ cta }}?id={{ evidence.fileId }}">{{ i18n.components.evidenceList.delete }}</a>
         </td>
       </tr>
     {% else %}

--- a/views/components/timeout-modal.njk
+++ b/views/components/timeout-modal.njk
@@ -1,7 +1,7 @@
 {% macro timeoutModal() %}
   <div class="timeout-modal" id="timeout-modal" role="dialog" aria-labelledby="dialog-title" aria-describedby="dialog-description" aria-hidden="true">
     <h2 class="govuk-heading-l" id="dialog-title">{{ i18n.components.timeoutModal.title }}</h2>
-    <p id="modal-countdown" id="dialog-description">{{ i18n.components.timeoutModal.initialDescription }}</p>
+    <p id="dialog-description">{{ i18n.components.timeoutModal.initialDescription }}</p>
 
     {{ govukButton({
       text: i18n.components.timeoutModal.cta,


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/RIA-2770


### Change description ###
- Fixing empty link accessibility bug
- Refactoring Evidences definition as an array instead of object on reasonsForAppeal
- Removing id on Evidence interface as it is not used and is just adding confusion


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ X ] No
```
