### PR TITLE
When we check a s2s token to see if it is still valid we allow an offset

### DIFF
--- a/app/utils/jwt-utils.ts
+++ b/app/utils/jwt-utils.ts
@@ -21,14 +21,14 @@ export function decodeJWTToken(jwtToken: string) {
  * @param jwtToken the jwt token to be verified
  */
 export function isJWTExpired(jwtToken: string) {
-  let offset = 20; // 20 seconds
+  let offset = 5 * 60; // 5 minutes
   let isExpiredToken = false;
 
   const decoded = decodeJWTToken(jwtToken);
 
   const currentTime = Math.round(new Date().getTime() / 1000);
 
-  if (decoded && decoded.exp < (currentTime - offset)) {
+  if (decoded && decoded.exp < (currentTime + offset)) {
     isExpiredToken = true;
   }
   return isExpiredToken;

--- a/test/unit/utils/jwt-utils.test.ts
+++ b/test/unit/utils/jwt-utils.test.ts
@@ -35,7 +35,7 @@ describe('JWT Utils', () => {
     expect(result).eq(true);
   });
 
-  it('checks that a token is expired taking into account the 20 seconds offset', () => {
+  it('checks that a token is expired taking into account the 5 minute offset', () => {
     const dateInSeconds = currentDateInSeconds() - 30;
 
     const mockedDecodedToken = {
@@ -52,8 +52,9 @@ describe('JWT Utils', () => {
     expect(result).eq(true);
   });
 
-  it('checks that a token is valid taking into account the 20 seconds offset', () => {
-    const dateInSeconds = currentDateInSeconds();
+  it('checks that a token is valid taking into account the 5 minute offset', () => {
+    const justOverFiveMinutesInSeconds = 5 * 60 + 10;
+    const dateInSeconds = currentDateInSeconds() + justOverFiveMinutesInSeconds;
 
     const mockedDecodedToken = {
       'sub': 'someSubject',


### PR DESCRIPTION
for processes to complete once the token has been checked. This was
being taken off of current time so we were extending the time a token
was valid for. Added it to current time to reduce the time a token is
valid for. Also increased the offset to 5 minutes just to make sure we
are never using an expired token.