### PR TITLE
Simplify error pages

### DIFF
--- a/app/handlers/error-handler.ts
+++ b/app/handlers/error-handler.ts
@@ -1,6 +1,5 @@
 import { NextFunction, Request, Response } from 'express';
 import { INTERNAL_SERVER_ERROR, NOT_FOUND } from 'http-status-codes';
-import i18n from '../../locale/en.json';
 import Logger, { getLogLabel } from '../utils/logger';
 
 const logLabel: string = getLogLabel(__filename);
@@ -9,18 +8,7 @@ const logLabel: string = getLogLabel(__filename);
  */
 function pageNotFoundHandler(req: Request, res: Response, next: NextFunction) {
   res.status(NOT_FOUND);
-
-  const accept = req.headers['accept'];
-  const list = accept ? accept.split(',') : [];
-
-  if (list.includes('text/html')) {
-    res.render('errors/404.njk');
-  } else if (list.includes('application/json')) {
-    res.send({ error: NOT_FOUND, message: i18n.error.error404.title });
-  } else {
-    res.type('text');
-    res.send(i18n.error.error404.title);
-  }
+  res.render('errors/404.njk');
 }
 
 /**
@@ -31,18 +19,7 @@ function serverErrorHandler(err: any, req: Request, res: Response, next: NextFun
   logger.exception(err, logLabel);
 
   res.status(INTERNAL_SERVER_ERROR);
-
-  const accept = req.headers['accept'];
-  const list = accept ? accept.split(',') : [];
-
-  if (list.includes('text/html')) {
-    res.render('errors/500.njk');
-  } else if (list.includes('application/json')) {
-    res.send({ error: INTERNAL_SERVER_ERROR, message: i18n.error.error500.title });
-  } else {
-    res.type('text');
-    res.send(i18n.error.error500.title);
-  }
+  res.render('errors/500.njk');
 }
 
 export { pageNotFoundHandler, serverErrorHandler };

--- a/test/unit/handlers/error-handler.test.ts
+++ b/test/unit/handlers/error-handler.test.ts
@@ -31,30 +31,10 @@ describe('Error Handler', () => {
 
   describe('pageNotFoundHandler', () => {
     it('gives 404 page in HTML', () => {
-      req.headers = { accept: 'text/html' };
-
       pageNotFoundHandler(req as Request, res as Response, next);
 
       expect(res.status).to.have.been.calledOnce.calledWith(NOT_FOUND);
       expect(res.render).to.have.been.calledOnce.calledWith('errors/404.njk');
-    });
-
-    it('gives 404 page in JSON', () => {
-      req.headers = { accept: 'application/json' };
-
-      pageNotFoundHandler(req as Request, res as Response, next);
-
-      expect(res.status).to.have.been.calledOnce.calledWith(NOT_FOUND);
-      expect(res.send).to.have.been.calledOnce.calledWith({ error: NOT_FOUND, message: 'Page not found' });
-    });
-
-    it('gives 404 page in text', () => {
-      req.headers = { accept: 'text' };
-
-      pageNotFoundHandler(req as Request, res as Response, next);
-
-      expect(res.status).to.have.been.calledOnce.calledWith(NOT_FOUND);
-      expect(res.send).to.have.been.calledOnce.calledWith('Page not found');
     });
   });
 
@@ -65,25 +45,6 @@ describe('Error Handler', () => {
       serverErrorHandler(err, req as Request, res as Response, next);
       expect(res.status).to.have.been.calledOnce.calledWith(INTERNAL_SERVER_ERROR);
       expect(res.render).to.have.been.calledOnce.calledWith('errors/500.njk');
-    });
-
-    it('gives 500 page in JSON', () => {
-      req.headers = { accept: 'application/json' };
-      const err = new Error('Service is unavailable');
-      serverErrorHandler(err, req as Request, res as Response, next);
-      expect(res.status).to.have.been.calledOnce.calledWith(INTERNAL_SERVER_ERROR);
-      expect(res.send).to.have.been.calledOnce.calledWith({
-        error: INTERNAL_SERVER_ERROR,
-        message: 'Service unavailable'
-      });
-    });
-
-    it('gives 500 page in text', () => {
-      req.headers = { accept: 'text' };
-      const err = new Error('Service is unavailable');
-      serverErrorHandler(err, req as Request, res as Response, next);
-      expect(res.status).to.have.been.calledOnce.calledWith(INTERNAL_SERVER_ERROR);
-      expect(res.send).to.have.been.calledOnce.calledWith('Service unavailable');
     });
   });
 });


### PR DESCRIPTION
Previously we showed different error pages for different content types.
We only produce html and were causing ourselves issues if an accept
header was not set.