### PR TITLE
RIA-2798 Redirect to IDAM register page

### DIFF
--- a/app/config/idam-config.ts
+++ b/app/config/idam-config.ts
@@ -2,12 +2,15 @@ import { paths } from '../paths';
 import { setupSecrets } from '../setupSecrets';
 
 const config = setupSecrets();
+const loginUrl = `${config.get('idam.webUrl')}/login`;
 
 export const idamConfig = {
   redirectUri: 'https://localhost:3000/redirectUrl',
   indexUrl: paths.login,
   idamApiUrl: config.get('idam.apiUrl'),
-  idamLoginUrl: `${config.get('idam.webUrl')}/login`,
+  idamLoginUrl: loginUrl,
+  idamUserLoginUrl: loginUrl,
+  idamRegistrationUrl: `${config.get('idam.webUrl')}/users/selfRegister`,
   idamSecret: config.get('idam.secret'),
   idamClientID: config.get('microservice'),
   openId: true

--- a/app/controllers/idam.ts
+++ b/app/controllers/idam.ts
@@ -3,7 +3,7 @@ import { NextFunction, Request, Response, Router } from 'express';
 import { idamConfig } from '../config/idam-config';
 import { checkSession, initSession } from '../middleware/session-middleware';
 import { paths } from '../paths';
-import { getIdamRedirectUrl } from '../utils/url-utils';
+import { getIdamLoginUrl, getIdamRedirectUrl } from '../utils/url-utils';
 
 function getLogin(req: Request, res: Response, next: NextFunction) {
   try {
@@ -31,6 +31,7 @@ function getRedirectUrl(req: Request, res: Response, next: NextFunction) {
 
 function authenticateMiddleware(req: Request, res: Response, next: NextFunction) {
   idamConfig.redirectUri = getIdamRedirectUrl(req);
+  idamConfig.idamLoginUrl = getIdamLoginUrl(req);
   idamExpressMiddleware.authenticate(idamConfig)(req, res, next);
 }
 

--- a/app/utils/url-utils.ts
+++ b/app/utils/url-utils.ts
@@ -1,6 +1,7 @@
 import config from 'config';
 import { Request, Response } from 'express';
 import * as _ from 'lodash';
+import { idamConfig } from '../config/idam-config';
 import { paths } from '../paths';
 
 const appPort = config.get('node.port');
@@ -12,6 +13,13 @@ export function getUrl(protocol: string, host: string, path: string): string {
 
 export function getIdamRedirectUrl(req: Request): string {
   return getUrl('https', req.hostname, '/redirectUrl');
+}
+
+export function getIdamLoginUrl(req: Request) {
+  if (req.query['register']) {
+    return idamConfig.idamRegistrationUrl;
+  }
+  return idamConfig.idamUserLoginUrl;
 }
 
 /**

--- a/test/e2e-test/features/basic.feature
+++ b/test/e2e-test/features/basic.feature
@@ -18,6 +18,8 @@ Feature: Business rules
     When I select No and click continue
     Then I should see the eligible page
     When I click continue
+    Then I should see the Create an account page
+    When I click Sign in to your account
     Then I should see the sign in page
     When I enter creds and click sign in
     And I click continue

--- a/test/e2e-test/pages/sign-in.ts
+++ b/test/e2e-test/pages/sign-in.ts
@@ -18,6 +18,14 @@ module.exports = {
       await I.seeInTitle('Sign in - HMCTS Access');
     });
 
+    Then('I should see the Create an account page', async () => {
+      await I.seeInTitle('Self Register - HMCTS Access');
+    });
+
+    When('I click Sign in to your account', async () => {
+      await I.click('Sign in to your account.');
+    });
+
     When('I enter creds and click sign in', async () => {
       await signInHelper();
     });

--- a/test/mock/idam/services/register-page.js
+++ b/test/mock/idam/services/register-page.js
@@ -1,0 +1,32 @@
+const cache = require('memory-cache');
+
+const skipLogin = process.env.SKIP_LOGIN === 'true';
+
+module.exports = {
+  path: '/users/selfRegister',
+  method: 'GET',
+  render: (req, res) => {
+    const redirectUri = req.query.redirect_uri;
+    const stateParam = req.query.state ? req.query.state : '';
+
+    if (skipLogin) {
+      cache.put('email', 'skipped_login@hmcts.net');
+      res.redirect(`${redirectUri}?code=123${stateParam}`);
+    } else {
+      res.append('Content-Type', 'text/html');
+      // use the redirect url in request for the final redirect
+      res.send(`<html><head>
+        <title>Register - HMCTS Access</title>
+        </head><body>
+        <h1>Register - HMCTS Access</h1>
+        <form action="/login" method="post">
+        Username: <input type="text" id="username" name="username"/><br />
+        Password: <input type="text" id="password" name="password"/><br />
+        <input type="text" name="redirect_uri" value="${redirectUri}"/>
+        <input type="text" name="state" value="${stateParam}"/>
+        <input id="login" class="button" type="submit" name="save" value="Sign in"/>
+        </form>
+        </body></html>`);
+    }
+  }
+};

--- a/test/unit/utils/url-utils.test.ts
+++ b/test/unit/utils/url-utils.test.ts
@@ -1,5 +1,5 @@
 import { Request } from 'express';
-import { getIdamRedirectUrl } from '../../../app/utils/url-utils';
+import { getIdamLoginUrl, getIdamRedirectUrl } from '../../../app/utils/url-utils';
 
 import { expect } from '../../utils/testUtils';
 
@@ -22,5 +22,27 @@ describe('creates url', () => {
     const redirectUrl = getIdamRedirectUrl(req as Request);
 
     expect(redirectUrl).eq('https://localhost:3000/redirectUrl');
+  });
+
+  it('getIdamLoginUrl for login', () => {
+    const req = {
+      query: {
+        register: true
+      }
+    } as Partial<Request>;
+
+    const loginUrl = getIdamLoginUrl(req as Request);
+
+    expect(loginUrl).eq('IDAM_WEB_URL/users/selfRegister');
+  });
+
+  it('getIdamLoginUrl for login', () => {
+    const req = {
+      query: {}
+    } as Partial<Request>;
+
+    const loginUrl = getIdamLoginUrl(req as Request);
+
+    expect(loginUrl).eq('IDAM_WEB_URL/login');
   });
 });

--- a/views/eligibility/eligible-page.njk
+++ b/views/eligibility/eligible-page.njk
@@ -10,7 +10,7 @@
 
     {{ govukButton({
         text: i18n.common.buttons.continue,
-        href: "/login",
+        href: paths.login + "?register=true",
         isStartButton: false
     }) }}
 {% endblock  %}


### PR DESCRIPTION
After the user has answered the eligibility questions redirect them to
the IDAM self registration page rather than the login page. If they
click the I already have an account link then direct them to the login
page.

### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/RIA-2798

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
