### PR TITLE
RIA-2818: Updating Session after .submitEvent()

### DIFF
--- a/app/controllers/appeal-application/check-and-send.ts
+++ b/app/controllers/appeal-application/check-and-send.ts
@@ -105,8 +105,8 @@ function postCheckAndSend(updateAppealService: UpdateAppealService) {
           previousPage: paths.taskList
         });
       }
-      const updatedAppeal = await updateAppealService.submitEvent(Events.SUBMIT_APPEAL, req);
-      req.session.appeal.appealStatus = updatedAppeal.state;
+      const ccdCase: CcdCaseDetails = await updateAppealService.submitEvent(Events.SUBMIT_APPEAL, req);
+      updateAppealService.assignAppealDetailsToSession(req, ccdCase);
       return res.redirect(paths.confirmation);
     } catch (error) {
       next(error);

--- a/app/controllers/reasons-for-appeal/check-and-send.ts
+++ b/app/controllers/reasons-for-appeal/check-and-send.ts
@@ -42,8 +42,8 @@ function postCheckAndSend(updateAppealService: UpdateAppealService) {
       if (!shouldValidateWhenSaveForLater(req.body)) {
         return res.redirect(paths.overview);
       }
-      const updatedAppeal = await updateAppealService.submitEvent(Events.SUBMIT_REASONS_FOR_APPEAL, req);
-      req.session.appeal.appealStatus = updatedAppeal.state;
+      const ccdCase: CcdCaseDetails = await updateAppealService.submitEvent(Events.SUBMIT_REASONS_FOR_APPEAL, req);
+      updateAppealService.assignAppealDetailsToSession(req, ccdCase);
       return res.redirect(paths.reasonsForAppeal.confirmation);
     } catch (error) {
       next(error);

--- a/app/service/update-appeal-service.ts
+++ b/app/service/update-appeal-service.ts
@@ -34,10 +34,13 @@ export default class UpdateAppealService {
   async loadAppeal(req: Request) {
     const securityHeaders: SecurityHeaders = await this._authenticationService.getSecurityHeaders(req);
     const ccdCase: CcdCaseDetails = await this._ccdService.loadOrCreateCase(req.idam.userDetails.uid, securityHeaders);
+    this.assignAppealDetailsToSession(req, ccdCase);
+  }
 
+  assignAppealDetailsToSession(req: Request, ccdCase: CcdCaseDetails) {
     req.session.ccdCaseId = ccdCase.id;
 
-    const caseData: Partial<CaseData> = ccdCase.case_data;
+    const caseData: Partial<CaseData> = ccdCase.case_data || {};
     const dateLetterSent = this.getDate(caseData.homeOfficeDecisionDate);
     const dateOfBirth = this.getDate(caseData.appellantDateOfBirth);
 
@@ -150,7 +153,7 @@ export default class UpdateAppealService {
     };
   }
 
-  private getDate(ccdDate): AppealDate {
+  getDate(ccdDate): AppealDate {
     if (ccdDate) {
       let dateLetterSent = {
         year: null,
@@ -189,8 +192,8 @@ export default class UpdateAppealService {
       case_data: caseData
     };
 
-    const updatedAppeal = await this._ccdService.updateAppeal(event, currentUserId, updatedCcdCase, securityHeaders);
-    return updatedAppeal;
+    const ccdCase: CcdCaseDetails = await this._ccdService.updateAppeal(event, currentUserId, updatedCcdCase, securityHeaders);
+    return ccdCase;
   }
 
   convertToCcdCaseData(appeal: Appeal) {

--- a/test/unit/controllers/check-and-send.test.ts
+++ b/test/unit/controllers/check-and-send.test.ts
@@ -89,6 +89,7 @@ describe('Check and Send Controller', () => {
     sandbox = sinon.createSandbox();
     req = {
       session: {
+        ccdCaseId: '1234567',
         appeal: {
           status: 'appealStarted'
         }
@@ -104,7 +105,12 @@ describe('Check and Send Controller', () => {
       } as any
     } as Partial<Request>;
 
-    updateAppealService = { submitEvent: sandbox.stub().returns({ state: 'appealSubmitted' }) };
+    updateAppealService = {
+      submitEvent: sandbox.stub().returns({ state: 'appealSubmitted' }),
+      assignAppealDetailsToSession: sandbox.spy(UpdateAppealService.prototype, 'assignAppealDetailsToSession'),
+      getDate: sandbox.spy(UpdateAppealService.prototype, 'getDate'),
+      yesNoToBool: sandbox.spy(UpdateAppealService.prototype, 'yesNoToBool')
+    } as Partial<UpdateAppealService>;
 
     res = {
       render: sandbox.stub(),

--- a/test/unit/controllers/reasons-for-appeal/check-and-send.test.ts
+++ b/test/unit/controllers/reasons-for-appeal/check-and-send.test.ts
@@ -44,7 +44,14 @@ describe('Reasons For Appeal - Check and send Controller', () => {
     routerGetStub = sandbox.stub(express.Router as never, 'get');
     routerPostStub = sandbox.stub(express.Router as never, 'post');
     next = sandbox.stub() as NextFunction;
-    updateAppealService = { submitEvent: sandbox.stub().returns({ state: 'reasonsForAppealSubmitted' }) } as Partial<UpdateAppealService>;
+
+    updateAppealService = {
+      submitEvent: sandbox.stub().returns({ state: 'reasonsForAppealSubmitted' }),
+      assignAppealDetailsToSession: sandbox.spy(UpdateAppealService.prototype, 'assignAppealDetailsToSession'),
+      getDate: sandbox.spy(UpdateAppealService.prototype, 'getDate'),
+      yesNoToBool: sandbox.spy(UpdateAppealService.prototype, 'yesNoToBool')
+    } as Partial<UpdateAppealService>;
+
   });
 
   afterEach(() => {


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/RIA-2818

### Change description ###

The entire session now updates after completing a .submitEvent() request.

- This avoids having to update the case status manually and possibly creating more bugs in the future.
- Fixes a bug that could occur is case_data was undefined


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x ] No
```
