### PR TITLE
RIA-2897 Cross site scripting - 'late appeal' page

### DIFF
--- a/app/app.ts
+++ b/app/app.ts
@@ -10,6 +10,7 @@ import internationalization from '../locale/en.json';
 import webpackDevConfig from '../webpack/webpack.dev.js';
 import { configureLogger, configureNunjucks, configureS2S } from './app-config';
 import { pageNotFoundHandler, serverErrorHandler } from './handlers/error-handler';
+import { handleFileUploadErrors, uploadConfiguration } from './middleware/file-upload-validation-middleware';
 import { isUserAuthenticated } from './middleware/is-user-authenticated';
 import { logErrorMiddleware, logRequestMiddleware } from './middleware/logger';
 import { filterRequest } from './middleware/xss-middleware';
@@ -37,6 +38,7 @@ function createApp() {
   app.use(bodyParser.urlencoded({ extended: true }));
   app.use(cookieParser());
   app.use(csurf());
+  app.post('*', uploadConfiguration, handleFileUploadErrors);
   app.post('*', filterRequest);
 
   if (environment === 'development') {

--- a/app/controllers/appeal-application/out-of-time.ts
+++ b/app/controllers/appeal-application/out-of-time.ts
@@ -1,6 +1,5 @@
 import { NextFunction, Request, Response, Router } from 'express';
 import * as _ from 'lodash';
-import { handleFileUploadErrors, uploadConfiguration } from '../../middleware/file-upload-validation-middleware';
 import { paths } from '../../paths';
 import { Events } from '../../service/ccd-service';
 import { documentIdToDocStoreUrl, DocumentManagementService } from '../../service/document-management-service';
@@ -113,8 +112,8 @@ function setupOutOfTimeController(deps?: any): Router {
 
   const router = Router();
   router.get(paths.homeOffice.appealLate, getAppealLate);
-  router.post(paths.homeOffice.appealLate, uploadConfiguration, handleFileUploadErrors, postAppealLate(deps.documentManagementService, deps.updateAppealService));
-  router.post(paths.homeOffice.deleteEvidence, uploadConfiguration, handleFileUploadErrors, postAppealLateDeleteFile(deps.documentManagementService, deps.updateAppealService));
+  router.post(paths.homeOffice.appealLate, postAppealLate(deps.documentManagementService, deps.updateAppealService));
+  router.post(paths.homeOffice.deleteEvidence, postAppealLateDeleteFile(deps.documentManagementService, deps.updateAppealService));
   return router;
 }
 

--- a/app/controllers/reasons-for-appeal/reason-for-appeal.ts
+++ b/app/controllers/reasons-for-appeal/reason-for-appeal.ts
@@ -2,7 +2,6 @@ import config from 'config';
 import { NextFunction, Request, Response, Router } from 'express';
 import * as _ from 'lodash';
 import i18n from '../../../locale/en.json';
-import { handleFileUploadErrors, uploadConfiguration } from '../../middleware/file-upload-validation-middleware';
 import { paths } from '../../paths';
 import { Events } from '../../service/ccd-service';
 import { documentIdToDocStoreUrl, DocumentManagementService } from '../../service/document-management-service';
@@ -215,7 +214,7 @@ function setupReasonsForAppealController(deps?: any): Router {
   router.get(paths.reasonsForAppeal.supportingEvidence, getAdditionalSupportingEvidenceQuestionPage);
   router.post(paths.reasonsForAppeal.supportingEvidence, postAdditionalSupportingEvidenceQuestionPage);
   router.get(paths.reasonsForAppeal.supportingEvidenceUpload, getSupportingEvidenceUploadPage);
-  router.post(paths.reasonsForAppeal.supportingEvidenceUploadFile, uploadConfiguration, handleFileUploadErrors, postSupportingEvidenceUploadFile(deps.documentManagementService, deps.updateAppealService));
+  router.post(paths.reasonsForAppeal.supportingEvidenceUploadFile, postSupportingEvidenceUploadFile(deps.documentManagementService, deps.updateAppealService));
   router.get(paths.reasonsForAppeal.supportingEvidenceDeleteFile, getSupportingEvidenceDeleteFile(deps.documentManagementService));
   router.post(paths.reasonsForAppeal.supportingEvidenceSubmit, postSupportingEvidenceSubmit(deps.updateAppealService));
   router.get(paths.reasonsForAppeal.confirmation, getConfirmationPage);


### PR DESCRIPTION
The multipart forms were being processed after our XSS middleware. This
meant any text fields on pages that also contained a file upload (only
place at the moment is the reasons for a late appeal page) were not
being filtered for XSS exploits.

Moved the multipart form middleware to be before the XSS middleware in
the app.js file. This does mean that is is registered for all endpoints
but uses Multer which says in the docs it will not process any form that
is not multipart.

### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/RIA-2897