### PR TITLE
RIA-2902-supporting-evidence-page-fix

### DIFF
--- a/app/controllers/reasons-for-appeal/check-and-send.ts
+++ b/app/controllers/reasons-for-appeal/check-and-send.ts
@@ -20,7 +20,7 @@ function getCheckAndSend(req: Request, res: Response, next: NextFunction): void 
 
     if (_.has(req.session.appeal.reasonsForAppeal, 'evidences')) {
 
-      const evidences: Evidence[] = req.session.appeal.reasonsForAppeal.evidences;
+      const evidences: Evidence[] = req.session.appeal.reasonsForAppeal.evidences || [];
       const evidenceNames: string[] = evidences.map((evidence) => evidence.name);
       if (evidenceNames.length) {
         summaryRows.push(addSummaryRow(i18n.common.cya.supportingEvidenceRowTitle, evidenceNames, paths.reasonsForAppeal.supportingEvidenceUpload + editParameter, Delimiter.BREAK_LINE));

--- a/app/controllers/reasons-for-appeal/reason-for-appeal.ts
+++ b/app/controllers/reasons-for-appeal/reason-for-appeal.ts
@@ -6,6 +6,7 @@ import { paths } from '../../paths';
 import { Events } from '../../service/ccd-service';
 import { documentIdToDocStoreUrl, DocumentManagementService } from '../../service/document-management-service';
 import UpdateAppealService from '../../service/update-appeal-service';
+import { shouldValidateWhenSaveForLater } from '../../utils/save-for-later-utils';
 import { getConditionalRedirectUrl } from '../../utils/url-utils';
 import { asBooleanValue } from '../../utils/utils';
 import {
@@ -90,7 +91,7 @@ function postAdditionalSupportingEvidenceQuestionPage(req: Request, res: Respons
     }
     if (answer === 'yes') {
       return res.redirect(paths.reasonsForAppeal.supportingEvidenceUpload);
-    } else {
+    } else if (answer === 'no') {
       return res.redirect(paths.reasonsForAppeal.checkAndSend);
     }
   } catch (e) {

--- a/test/functional/features/reason-for-appeal.feature
+++ b/test/functional/features/reason-for-appeal.feature
@@ -39,3 +39,27 @@ Feature: Reason for appeal
     Then I should see the reasons for appeal confirmation page
     And I see the respond by date is 2 weeks in the future
 
+  Scenario: Navigate through reasons for appeal with no additional evidence
+    Given I am authenticated as a valid appellant
+    When I visit reasons for appeal
+    And I click "Save and continue" button
+    Then I should see error summary
+
+    When I click "Save for later" button
+    Then I should see error summary
+
+    When I visit the "reasons for appeal" page
+    Then I enter "A description of why I think the appeal is wrong" into the reason for appeal text box and click Save and Continue
+    Then I should see the "supporting evidence question" page
+
+    When I click "Continue" button
+    Then I should see error summary
+
+    When I select No and click continue
+    Then I should see the reasons for appeal CYA page
+
+    When I click "Save and continue" button
+    Then I should see the reasons for appeal confirmation page
+    And I see the respond by date is 2 weeks in the future
+
+

--- a/test/functional/features/reason-for-appeal.feature
+++ b/test/functional/features/reason-for-appeal.feature
@@ -58,7 +58,7 @@ Feature: Reason for appeal
     When I select No and click continue
     Then I should see the reasons for appeal CYA page
 
-    When I click "Save and continue" button
+    When I click "Send" button
     Then I should see the reasons for appeal confirmation page
     And I see the respond by date is 2 weeks in the future
 


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/secure/RapidBoard.jspa?rapidView=1190&projectKey=RIA&view=detail&selectedIssue=RIA-2902


### Change description ###
fixed service error page when click no on supporting evidence


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ x ] No
```
