### PR TITLE
RIA-2810: Removes the TBC placeholder in deadlines set by TCW's.

### DIFF
--- a/app/controllers/appeal-application/confirmation-page.ts
+++ b/app/controllers/appeal-application/confirmation-page.ts
@@ -5,9 +5,10 @@ import moment from 'moment';
 const daysToWaitAfterSubmission = config.get('daysToWait.afterSubmission');
 
 import { paths } from '../../paths';
+import { dayMonthYearFormat } from '../../utils/date-formats';
 
 export const daysToWaitUntilContact = (days: number) => {
-  const date = moment().add(days,'days').format('DD MMMM YYYY');
+  const date = moment().add(days,'days').format(dayMonthYearFormat);
   return date;
 };
 function getConfirmationPage(req: Request, res: Response, next: NextFunction) {

--- a/app/controllers/detail-viewers.ts
+++ b/app/controllers/detail-viewers.ts
@@ -11,6 +11,7 @@ import {
   documentIdToDocStoreUrl,
   DocumentManagementService
 } from '../service/document-management-service';
+import { dayMonthYearFormat } from '../utils/date-formats';
 import { addSummaryRow, Delimiter } from '../utils/summary-list';
 
 /**
@@ -32,7 +33,7 @@ const getAppealApplicationData = (eventId: string, req: Request) => {
 };
 
 const formatDateLongDate = (date: string) => {
-  return moment(date).format('DD MMMM YYYY');
+  return moment(date).format(dayMonthYearFormat);
 };
 
 function setupAppealDetails(req: Request): Array<any> {
@@ -133,7 +134,7 @@ function getHoEvidenceDetailsViewer(req: Request, res: Response, next: NextFunct
       documents = respondentDocs.map(document => {
         const formattedFileName = fileNameFormatter(document.evidence.name);
         const urlHtml = `<a class='govuk-link' target='_blank' rel="noopener noreferrer" href='${paths.detailsViewers.document}/${document.evidence.fileId}'>${formattedFileName}</a>`;
-        const formattedDate = moment(document.dateUploaded).format('DD MMMM YYYY');
+        const formattedDate = moment(document.dateUploaded).format(dayMonthYearFormat);
         return {
           dateUploaded: formattedDate,
           url: urlHtml

--- a/app/service/update-appeal-service.ts
+++ b/app/service/update-appeal-service.ts
@@ -55,6 +55,7 @@ export default class UpdateAppealService {
     const subscriptions = caseData.subscriptions || [];
     let outOfTimeAppeal: LateAppeal = null;
     let respondentDocuments: RespondentDocument[] = null;
+    let directions: Direction[] = null;
     let reasonsForAppealDocumentUploads: Evidence[] = null;
 
     const contactDetails = subscriptions.reduce((contactDetails, subscription) => {
@@ -118,7 +119,18 @@ export default class UpdateAppealService {
         respondentDocuments.push(evidence);
       });
     }
-
+    if (caseData.directions) {
+      directions = [];
+      caseData.directions.forEach(d => {
+        let direction: Direction = {
+          tag: d.value.tag,
+          parties: d.value.parties,
+          dueDate: d.value.dateDue,
+          dateSent: d.value.dateSent
+        };
+        directions.push(direction);
+      });
+    }
     req.session.appeal = {
       appealStatus: ccdCase.state,
       appealCreatedDate: ccdCase.created_date,
@@ -148,7 +160,8 @@ export default class UpdateAppealService {
       },
       hearingRequirements: {},
       respondentDocuments: respondentDocuments,
-      documentMap: documentMap
+      documentMap: documentMap,
+      directions: directions
     };
   }
 

--- a/app/service/update-appeal-service.ts
+++ b/app/service/update-appeal-service.ts
@@ -88,7 +88,7 @@ export default class UpdateAppealService {
         };
       }
     }
-    // TODO needs to use the document mapper.
+
     if (caseData.reasonsForAppealDocuments) {
       reasonsForAppealDocumentUploads = [];
       caseData.reasonsForAppealDocuments.forEach(document => {
@@ -120,17 +120,16 @@ export default class UpdateAppealService {
       });
     }
     if (caseData.directions) {
-      directions = [];
-      caseData.directions.forEach(d => {
-        let direction: Direction = {
+      directions = caseData.directions.map(d => {
+        return {
           tag: d.value.tag,
           parties: d.value.parties,
           dueDate: d.value.dateDue,
           dateSent: d.value.dateSent
         };
-        directions.push(direction);
       });
     }
+
     req.session.appeal = {
       appealStatus: ccdCase.state,
       appealCreatedDate: ccdCase.created_date,

--- a/app/utils/application-state-utils.ts
+++ b/app/utils/application-state-utils.ts
@@ -5,6 +5,7 @@ import i18n from '../../locale/en.json';
 import { paths } from '../paths';
 import { SecurityHeaders } from '../service/authentication-service';
 import UpdateAppealService from '../service/update-appeal-service';
+import { dayMonthYearFormat } from './date-formats';
 import { getDeadline } from './event-deadline-date-finder';
 
 const APPEAL_STATE = {
@@ -167,7 +168,7 @@ function getAppealApplicationNextStep(req: Request) {
 }
 
 function constructEventObject(event) {
-  const formattedDate = moment(event.date).format('DD MMMM YYYY');
+  const formattedDate = moment(event.date).format(dayMonthYearFormat);
   return {
     date: `${formattedDate}`,
     title: i18n.pages.overviewPage.timeline[event.id].title,

--- a/app/utils/application-state-utils.ts
+++ b/app/utils/application-state-utils.ts
@@ -161,8 +161,8 @@ function getAppealApplicationNextStep(req: Request) {
     }
   };
 
-  doThisNextSection.deadline = getDeadline(currentAppealStatus, history);
-
+  const directions = req.session.appeal.directions;
+  doThisNextSection.deadline = getDeadline(currentAppealStatus, directions, history);
   return doThisNextSection;
 }
 

--- a/app/utils/date-formats.ts
+++ b/app/utils/date-formats.ts
@@ -1,0 +1,8 @@
+/**
+ * Main format used within the app should format the date to: "21 April 2020"
+ */
+const dayMonthYearFormat = 'DD MMMM YYYY';
+
+export {
+  dayMonthYearFormat
+};

--- a/app/utils/event-deadline-date-finder.ts
+++ b/app/utils/event-deadline-date-finder.ts
@@ -4,26 +4,57 @@ import moment from 'moment';
 const daysToWaitAfterSubmission = config.get('daysToWait.afterSubmission');
 const daysToWaitAfterReasonsForAppeal = config.get('daysToWait.afterReasonsForAppeal');
 
-function getDeadline(currentAppealStatus: string, history) {
+/**
+ * Finds a targeted direction, retrieves it's due date and returns it as a string with the correct date format
+ * @param directions the directions
+ * @param directionTagToLookFor the direction to find
+ */
+function getFormattedDirectionDueDate(directions: Direction[], directionTagToLookFor: string) {
+  let formattedDeadline = null;
+  const direction = directions.find(d => d.tag === directionTagToLookFor);
+  if (direction) {
+    const dueDate = direction.dueDate;
+    formattedDeadline = moment(dueDate).format('DD MMMM YYYY');
+  }
+  return formattedDeadline;
+}
+
+/**
+ * Given the current case status it retrieves deadlines based on the business logic.
+ * @param currentAppealStatus the appeal status
+ * @param directions all the directions
+ */
+function getDeadline(currentAppealStatus: string, directions: Direction[], history) {
+
+  let formattedDeadline;
+
   switch (currentAppealStatus) {
     case 'appealStarted': {
-      return null;
+      formattedDeadline = null;
+      break;
     }
-    case 'awaitingRespondentEvidence':
-    case 'appealSubmitted': {
+    case 'appealSubmitted':
+    case 'awaitingRespondentEvidence': {
       const triggeringDate = history['appealSubmitted'].date;
-      const formattedDeadline = moment(triggeringDate).add(daysToWaitAfterSubmission, 'days').format('DD MMMM YYYY');
-      return formattedDeadline || null;
+      formattedDeadline = moment(triggeringDate).add(daysToWaitAfterSubmission, 'days').format('DD MMMM YYYY');
+      break;
+    }
+    case 'awaitingReasonsForAppeal': {
+      formattedDeadline = getFormattedDirectionDueDate(directions, 'requestReasonsForAppeal');
+      break;
     }
     case 'reasonsForAppealSubmitted': {
       const triggeringDate = history['submitReasonsForAppeal'].date;
-      const formattedDeadline = moment(triggeringDate).add(daysToWaitAfterReasonsForAppeal, 'days').format('DD MMMM YYYY');
-      return formattedDeadline || null;
+      formattedDeadline = moment(triggeringDate).add(daysToWaitAfterReasonsForAppeal, 'days').format('DD MMMM YYYY');
+      break;
     }
     default: {
-      return 'TBC';
+      formattedDeadline = 'TBC';
+      break;
     }
   }
+
+  return formattedDeadline;
 }
 
 export {

--- a/app/utils/event-deadline-date-finder.ts
+++ b/app/utils/event-deadline-date-finder.ts
@@ -1,5 +1,6 @@
 import config from 'config';
 import moment from 'moment';
+import { dayMonthYearFormat } from './date-formats';
 
 const daysToWaitAfterSubmission = config.get('daysToWait.afterSubmission');
 const daysToWaitAfterReasonsForAppeal = config.get('daysToWait.afterReasonsForAppeal');
@@ -11,10 +12,12 @@ const daysToWaitAfterReasonsForAppeal = config.get('daysToWait.afterReasonsForAp
  */
 function getFormattedDirectionDueDate(directions: Direction[], directionTagToLookFor: string) {
   let formattedDeadline = null;
-  const direction = directions.find(d => d.tag === directionTagToLookFor);
-  if (direction) {
-    const dueDate = direction.dueDate;
-    formattedDeadline = moment(dueDate).format('DD MMMM YYYY');
+  if (directions) {
+    const direction = directions.find(d => d.tag === directionTagToLookFor);
+    if (direction) {
+      const dueDate = direction.dueDate;
+      formattedDeadline = moment(dueDate).format(dayMonthYearFormat);
+    }
   }
   return formattedDeadline;
 }
@@ -36,16 +39,17 @@ function getDeadline(currentAppealStatus: string, directions: Direction[], histo
     case 'appealSubmitted':
     case 'awaitingRespondentEvidence': {
       const triggeringDate = history['appealSubmitted'].date;
-      formattedDeadline = moment(triggeringDate).add(daysToWaitAfterSubmission, 'days').format('DD MMMM YYYY');
+      formattedDeadline = moment(triggeringDate).add(daysToWaitAfterSubmission, 'days').format(dayMonthYearFormat);
       break;
     }
-    case 'awaitingReasonsForAppeal': {
+    case 'awaitingReasonsForAppeal':
+    case 'awaitingReasonsForAppealPartial': {
       formattedDeadline = getFormattedDirectionDueDate(directions, 'requestReasonsForAppeal');
       break;
     }
     case 'reasonsForAppealSubmitted': {
       const triggeringDate = history['submitReasonsForAppeal'].date;
-      formattedDeadline = moment(triggeringDate).add(daysToWaitAfterReasonsForAppeal, 'days').format('DD MMMM YYYY');
+      formattedDeadline = moment(triggeringDate).add(daysToWaitAfterReasonsForAppeal, 'days').format(dayMonthYearFormat);
       break;
     }
     default: {

--- a/test/e2e-test/pages/appeal-sent/appeal-sent.ts
+++ b/test/e2e-test/pages/appeal-sent/appeal-sent.ts
@@ -1,5 +1,6 @@
 import moment from 'moment';
 import { paths } from '../../../../app/paths';
+import { dayMonthYearFormat } from '../../../../app/utils/date-formats';
 
 module.exports = {
   appealSent(I) {
@@ -8,7 +9,7 @@ module.exports = {
     });
 
     Then('I see the respond by date is 4 weeks in the future', async () => {
-      I.seeInSource(moment().add(28,'days').format('DD MMMM YYYY'));
+      I.seeInSource(moment().add(28,'days').format(dayMonthYearFormat));
     });
   }
 };

--- a/test/e2e-test/pages/reasons-for-appeal/reasons-for-appeal-confirmation.ts
+++ b/test/e2e-test/pages/reasons-for-appeal/reasons-for-appeal-confirmation.ts
@@ -1,5 +1,6 @@
 import moment from 'moment';
 import { paths } from '../../../../app/paths';
+import { dayMonthYearFormat } from '../../../../app/utils/date-formats';
 const config = require('config');
 
 const testUrl = config.get('testUrl');
@@ -11,7 +12,7 @@ module.exports = {
     });
 
     Then('I see the respond by date is 2 weeks in the future', async () => {
-      I.seeInSource(moment().add(14,'days').format('DD MMMM YYYY'));
+      I.seeInSource(moment().add(14,'days').format(dayMonthYearFormat));
     });
 
   }

--- a/test/unit/controllers/application-overview.test.ts
+++ b/test/unit/controllers/application-overview.test.ts
@@ -9,6 +9,7 @@ import { paths } from '../../../app/paths';
 import { AuthenticationService } from '../../../app/service/authentication-service';
 import { CcdService } from '../../../app/service/ccd-service';
 import UpdateAppealService from '../../../app/service/update-appeal-service';
+import { dayMonthYearFormat } from '../../../app/utils/date-formats';
 import Logger from '../../../app/utils/logger';
 import { expect, sinon } from '../../utils/testUtils';
 import { expectedMultipleEventsData } from '../mockData/events/expectations';
@@ -124,7 +125,7 @@ describe('Confirmation Page Controller', () => {
       completed: false,
       title: 'Your appeal<br/> decision'
     } ];
-    const date = moment().format('DD MMMM YYYY');
+    const date = moment().format(dayMonthYearFormat);
 
     const expectedHistory = [ {
       'date': date,

--- a/test/unit/utils/application-state-utils.test.ts
+++ b/test/unit/utils/application-state-utils.test.ts
@@ -17,7 +17,8 @@ describe('application-state-utils', () => {
         appeal: {
           application: {},
           caseBuilding: {},
-          reasonsForAppeal: {}
+          reasonsForAppeal: {},
+          directions: {}
         }
       },
       idam: {
@@ -100,6 +101,19 @@ describe('application-state-utils', () => {
     it('when application status is awaitingReasonsForAppeal should get correct \'Do This next section\'', () => {
       req.session.appeal.appealStatus = 'awaitingReasonsForAppeal';
       req.session.lastModified = '2020-02-07T16:00:00.000';
+      req.session.appeal.directions = [
+        {
+          tag: 'requestReasonsForAppeal',
+          parties: 'appellant',
+          dueDate: '2020-04-21',
+          dateSent: '2020-03-24'
+        },
+        {
+          tag: 'respondentEvidence',
+          parties: 'respondent',
+          dueDate: '2020-04-07',
+          dateSent: '2020-03-24'
+        } ];
       const result = getAppealApplicationNextStep(req as Request);
 
       expect(result).to.eql(
@@ -109,7 +123,7 @@ describe('application-state-utils', () => {
             respondByText: 'You need to respond by {{ applicationNextStep.deadline }}.',
             url: '/case-building/home-office-decision-wrong'
           },
-          deadline: 'TBC',
+          deadline: '21 April 2020',
           descriptionParagraphs: [
             'Tell us why you think the Home Office decision to refuse your claim is wrong.'
           ],
@@ -130,6 +144,19 @@ describe('application-state-utils', () => {
     req.session.appeal.appealStatus = 'awaitingReasonsForAppeal';
     req.session.lastModified = '2020-02-07T16:00:00.000';
     req.session.appeal.reasonsForAppeal.applicationReason = 'A text description of why I decided to appeal';
+    req.session.appeal.directions = [
+      {
+        tag: 'requestReasonsForAppeal',
+        parties: 'appellant',
+        dueDate: '2020-04-21',
+        dateSent: '2020-03-24'
+      },
+      {
+        tag: 'respondentEvidence',
+        parties: 'respondent',
+        dueDate: '2020-04-07',
+        dateSent: '2020-03-24'
+      } ];
     const result = getAppealApplicationNextStep(req as Request);
 
     expect(result).to.eql(
@@ -138,7 +165,7 @@ describe('application-state-utils', () => {
           respondByText: 'You need to respond by {{ applicationNextStep.deadline }}.',
           url: '/case-building/home-office-decision-wrong'
         },
-        deadline: 'TBC',
+        deadline: '21 April 2020',
         descriptionParagraphs: [
           'You need to finish telling us why you think the Home Office decision to refuse your claim is wrong.'
         ],

--- a/test/unit/utils/event-deadline-date-finder.test.ts
+++ b/test/unit/utils/event-deadline-date-finder.test.ts
@@ -2,26 +2,29 @@ import { getDeadline } from '../../../app/utils/event-deadline-date-finder';
 import { expect } from '../../utils/testUtils';
 
 describe('event-deadline-date-finder', () => {
+  const directions = [
+    {
+      tag: 'requestReasonsForAppeal',
+      parties: 'appellant',
+      dueDate: '2020-04-21',
+      dateSent: '2020-03-24'
+    },
+    {
+      tag: 'respondentEvidence',
+      parties: 'respondent',
+      dueDate: '2020-04-07',
+      dateSent: '2020-03-24'
+    } ];
   describe('getDeadline', () => {
     it('appealStarted should return null', () => {
-      const history = {
-        appealStarted: {
-          event: 'appealStarted',
-          date: '2020-02-07T16:00:00.000'
-        },
-        appealSubmitted: {
-          event: 'appealSubmitted',
-          date: '2020-02-08T16:00:00.000'
-        }
-      };
 
       const currentAppealStatus = 'appealStarted';
-      const result = getDeadline(currentAppealStatus, history);
+      const result = getDeadline(currentAppealStatus, directions, []);
 
       expect(result).to.be.null;
     });
 
-    it('appealSubmitted should return a formatted date with 14 days offset', () => {
+    it('appealSubmitted should return a formatted date with 14 days offset from the appealSubmission date', () => {
       const history = {
         appealStarted: {
           event: 'appealStarted',
@@ -34,9 +37,85 @@ describe('event-deadline-date-finder', () => {
       };
 
       const currentAppealStatus = 'appealSubmitted';
-      const result = getDeadline(currentAppealStatus, history);
+      const result = getDeadline(currentAppealStatus, directions, history);
 
       expect(result).to.be.equal('07 March 2020');
     });
+
+    it('awaitingRespondentEvidence should return a formatted date with 14 days offset from the appealSubmission date', () => {
+      const history = {
+        appealStarted: {
+          event: 'appealStarted',
+          date: '2020-02-07T16:00:00.000'
+        },
+        appealSubmitted: {
+          event: 'appealSubmitted',
+          date: '2020-02-08T16:00:00.000'
+        }
+      };
+
+      const currentAppealStatus = 'appealSubmitted';
+      const result = getDeadline(currentAppealStatus, directions, history);
+
+      expect(result).to.be.equal('07 March 2020');
+    });
+  });
+
+  it('awaitingRespondentEvidence should return a formatted date with 14 days offset from the appealSubmission date', () => {
+    const history = {
+      appealStarted: {
+        event: 'appealStarted',
+        date: '2020-02-07T16:00:00.000'
+      },
+      appealSubmitted: {
+        event: 'appealSubmitted',
+        date: '2020-02-08T16:00:00.000'
+      }
+    };
+
+    const currentAppealStatus = 'awaitingRespondentEvidence';
+    const result = getDeadline(currentAppealStatus, directions, history);
+
+    expect(result).to.be.equal('07 March 2020');
+  });
+
+  it('awaitingReasonsForAppeal should return a formatted date with the requestReasonForAppeal direction due date', () => {
+    const history = {
+      appealStarted: {
+        event: 'appealStarted',
+        date: '2020-02-07T16:00:00.000'
+      },
+      appealSubmitted: {
+        event: 'appealSubmitted',
+        date: '2020-02-08T16:00:00.000'
+      }
+    };
+
+    const currentAppealStatus = 'awaitingReasonsForAppeal';
+    const result = getDeadline(currentAppealStatus, directions, history);
+
+    expect(result).to.be.equal('21 April 2020');
+  });
+
+  it('reasonsForAppealSubmitted should return a formatted date with 14 days offset from the submitReasonsForAppeal event', () => {
+    const history = {
+      appealStarted: {
+        event: 'appealStarted',
+        date: '2020-02-07T16:00:00.000'
+      },
+      appealSubmitted: {
+        event: 'appealSubmitted',
+        date: '2020-02-08T16:00:00.000'
+      },
+      submitReasonsForAppeal: {
+        event: 'submitReasonsForAppeal',
+        date: '2020-02-18T16:00:00.000'
+      }
+    };
+
+    const currentAppealStatus = 'reasonsForAppealSubmitted';
+    const result = getDeadline(currentAppealStatus, directions, history);
+
+    expect(result).to.be.equal('03 March 2020');
   });
 });

--- a/test/unit/utils/event-deadline-date-finder.test.ts
+++ b/test/unit/utils/event-deadline-date-finder.test.ts
@@ -59,63 +59,63 @@ describe('event-deadline-date-finder', () => {
 
       expect(result).to.be.equal('07 March 2020');
     });
-  });
 
-  it('awaitingRespondentEvidence should return a formatted date with 14 days offset from the appealSubmission date', () => {
-    const history = {
-      appealStarted: {
-        event: 'appealStarted',
-        date: '2020-02-07T16:00:00.000'
-      },
-      appealSubmitted: {
-        event: 'appealSubmitted',
-        date: '2020-02-08T16:00:00.000'
-      }
-    };
+    it('awaitingRespondentEvidence should return a formatted date with 14 days offset from the appealSubmission date', () => {
+      const history = {
+        appealStarted: {
+          event: 'appealStarted',
+          date: '2020-02-07T16:00:00.000'
+        },
+        appealSubmitted: {
+          event: 'appealSubmitted',
+          date: '2020-02-08T16:00:00.000'
+        }
+      };
 
-    const currentAppealStatus = 'awaitingRespondentEvidence';
-    const result = getDeadline(currentAppealStatus, directions, history);
+      const currentAppealStatus = 'awaitingRespondentEvidence';
+      const result = getDeadline(currentAppealStatus, directions, history);
 
-    expect(result).to.be.equal('07 March 2020');
-  });
+      expect(result).to.be.equal('07 March 2020');
+    });
 
-  it('awaitingReasonsForAppeal should return a formatted date with the requestReasonForAppeal direction due date', () => {
-    const history = {
-      appealStarted: {
-        event: 'appealStarted',
-        date: '2020-02-07T16:00:00.000'
-      },
-      appealSubmitted: {
-        event: 'appealSubmitted',
-        date: '2020-02-08T16:00:00.000'
-      }
-    };
+    it('awaitingReasonsForAppeal should return a formatted date with the requestReasonForAppeal direction due date', () => {
+      const history = {
+        appealStarted: {
+          event: 'appealStarted',
+          date: '2020-02-07T16:00:00.000'
+        },
+        appealSubmitted: {
+          event: 'appealSubmitted',
+          date: '2020-02-08T16:00:00.000'
+        }
+      };
 
-    const currentAppealStatus = 'awaitingReasonsForAppeal';
-    const result = getDeadline(currentAppealStatus, directions, history);
+      const currentAppealStatus = 'awaitingReasonsForAppeal';
+      const result = getDeadline(currentAppealStatus, directions, history);
 
-    expect(result).to.be.equal('21 April 2020');
-  });
+      expect(result).to.be.equal('21 April 2020');
+    });
 
-  it('reasonsForAppealSubmitted should return a formatted date with 14 days offset from the submitReasonsForAppeal event', () => {
-    const history = {
-      appealStarted: {
-        event: 'appealStarted',
-        date: '2020-02-07T16:00:00.000'
-      },
-      appealSubmitted: {
-        event: 'appealSubmitted',
-        date: '2020-02-08T16:00:00.000'
-      },
-      submitReasonsForAppeal: {
-        event: 'submitReasonsForAppeal',
-        date: '2020-02-18T16:00:00.000'
-      }
-    };
+    it('reasonsForAppealSubmitted should return a formatted date with 14 days offset from the submitReasonsForAppeal event', () => {
+      const history = {
+        appealStarted: {
+          event: 'appealStarted',
+          date: '2020-02-07T16:00:00.000'
+        },
+        appealSubmitted: {
+          event: 'appealSubmitted',
+          date: '2020-02-08T16:00:00.000'
+        },
+        submitReasonsForAppeal: {
+          event: 'submitReasonsForAppeal',
+          date: '2020-02-18T16:00:00.000'
+        }
+      };
 
-    const currentAppealStatus = 'reasonsForAppealSubmitted';
-    const result = getDeadline(currentAppealStatus, directions, history);
+      const currentAppealStatus = 'reasonsForAppealSubmitted';
+      const result = getDeadline(currentAppealStatus, directions, history);
 
-    expect(result).to.be.equal('03 March 2020');
+      expect(result).to.be.equal('03 March 2020');
+    });
   });
 });

--- a/types/caseData.d.ts
+++ b/types/caseData.d.ts
@@ -31,6 +31,7 @@ interface CaseData {
   reasonsForAppealDecision: string;
   reasonsForAppealDocuments: SupportingEvidenceCollection[];
   respondentDocuments: RespondentEvidenceCollection[];
+  directions: DirectionCollection[];
 }
 
 interface Nationality {
@@ -62,6 +63,20 @@ interface SupportingEvidenceCollection {
 interface RespondentEvidenceCollection {
   id?: number;
   value: RespondentEvidenceDocument;
+}
+
+interface DirectionValue {
+  tag: string;
+  dateDue: string;
+  parties: string;
+  dateSent: string;
+  explanation: string;
+  previousDates: string[];
+}
+
+interface DirectionCollection {
+  id?: number;
+  value: DirectionValue;
 }
 
 interface Subscription {

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -52,6 +52,13 @@ interface DocumentUploadResponse {
   name: string;
 }
 
+interface Direction {
+  tag: string;
+  parties: string;
+  dueDate: string;
+  dateSent: string;
+}
+
 interface Appeal {
   appealStatus?: string;
   appealCreatedDate?: string;
@@ -62,6 +69,7 @@ interface Appeal {
   hearingRequirements: HearingRequirements;
   respondentDocuments?: RespondentDocument[];
   documentMap?: DocumentMap[];
+  directions?: Direction[];
   history?: HistoryEvent[];
 }
 


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/RIA-2810

### Change description ###
**RIA-2810:** 
- Removes the TBC place holder in deadlines set by TCW's.
- Loads directions into the session.
- This is needed in order to display deadlines set by tcw's on directions.

Requires CCD Definition:
https://github.com/hmcts/ia-ccd-definitions/pull/100

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ x] No
```
