### PR TITLE
RIA-2790: Content Security Policy was refusing to apply inline style

### DIFF
--- a/app/app.ts
+++ b/app/app.ts
@@ -85,7 +85,11 @@ function configureHelmet(app) {
       styleSrc: [
         '\'self\'',
         'tagmanager.google.com',
-        'fonts.googleapis.com/'
+        'fonts.googleapis.com/',
+        (req, res) =>
+          req.url.includes('/view/document/')
+            ? `'unsafe-inline'`
+            : `'nonce-${res.locals.nonce}'`
       ],
       connectSrc: [ '\'self\'', 'www.gov.uk' ],
       mediaSrc: [ '\'self\'' ],

--- a/app/app.ts
+++ b/app/app.ts
@@ -19,9 +19,17 @@ import { router } from './routes';
 import { setupSession } from './session';
 import { getUrl } from './utils/url-utils';
 
+const uuid = require('uuid');
+
 function createApp() {
   const app: express.Application = express();
   const environment: string = process.env.NODE_ENV;
+
+  // Inject nonce Id on every request.
+  app.use((req, res, next) => {
+    res.locals.nonce = uuid.v4();
+    next();
+  });
 
   configureHelmet(app);
 


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/RIA-2790

### Change description ###
Fixes an issue where:
Content Security Policy was refusing to apply inline style because:
"it violates the following Content Security Policy directive: "style-src 'self'". "
This commit adds he 'unsafe-inline' to the style-src content security policy

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x ] No
```
