### PR TITLE
Enable prod builds by removing the config from Jenkinsfile_CNP that stops them.

### DIFF
--- a/Jenkinsfile_CNP
+++ b/Jenkinsfile_CNP
@@ -42,9 +42,4 @@ withPipeline("nodejs", product, component) {
     before("functionalTest") {
         env.IDAM_API_URL = 'http://idam-api.aat.platform.hmcts.net'
     }
-    before('buildinfra:prod') {
-        currentBuild.result = 'Success'
-        currentBuild.description = "Success"
-        error 'ia aip projects are not authorised to be in production environments yet.'
-    }
 }


### PR DESCRIPTION
Enable prod builds by removing the config from Jenkinsfile_CNP that stops them.