### PR TITLE
Moved to Bitnami charts Repository and upgraded redis to version 10.0.0

### DIFF
--- a/charts/ia-aip-frontend/Chart.yaml
+++ b/charts/ia-aip-frontend/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
 name: ia-aip-frontend
 home: https://github.com/hmcts/ia-aip-frontend
-version: 0.0.11
+version: 0.0.12
 description: IA AIP Frontend

--- a/charts/ia-aip-frontend/requirements.yaml
+++ b/charts/ia-aip-frontend/requirements.yaml
@@ -3,8 +3,8 @@ dependencies:
     version: ~1.8.0
     repository: '@hmctspublic'
   - name: redis
-    version: "5.1.2"
-    repository: "@stable"
+    version: "10.0.0"
+    repository: "https://charts.bitnami.com/bitnami"
     tags:
       - pr
   - name: idam-pr


### PR DESCRIPTION
### JIRA link (if applicable) ###

N/A

### Change description ###

- Bumped ia-aip-frontend chart version
- Moved to bitnami charts repository and upgraded redis to version 10.0.0


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ x] No
```
