### PR TITLE
RIA-3216 Fix answer layout on CYA pages

### DIFF
--- a/app/controllers/appeal-application/check-and-send.ts
+++ b/app/controllers/appeal-application/check-and-send.ts
@@ -7,6 +7,7 @@ import { appealOutOfTimeMiddleware } from '../../middleware/outOfTime-middleware
 import { paths } from '../../paths';
 import UpdateAppealService from '../../service/update-appeal-service';
 import { addSummaryRow, Delimiter } from '../../utils/summary-list';
+import { formatTextForCYA } from '../../utils/utils';
 import { statementOfTruthValidation } from '../../utils/validations/fields-validations';
 
 function createSummaryRowsFrom(appealApplication: AppealApplication) {
@@ -64,7 +65,7 @@ function createSummaryRowsFrom(appealApplication: AppealApplication) {
   ];
 
   if (appealApplication.isAppealLate) {
-    const lateAppealValue = [ appealApplication.lateAppeal.reason ];
+    const lateAppealValue = [ formatTextForCYA(appealApplication.lateAppeal.reason) ];
     if (appealApplication.lateAppeal.evidence) {
       const urlHtml = `<p class="govuk-!-font-weight-bold">${i18n.pages.checkYourAnswers.rowTitles.supportingEvidence}</p><a class='govuk-link' target='_blank' rel='noopener noreferrer' href='${paths.common.detailsViewers.document}/${appealApplication.lateAppeal.evidence.fileId}'>${appealApplication.lateAppeal.evidence.name}</a>`;
       lateAppealValue.push(urlHtml);

--- a/app/controllers/ask-for-more-time/ask-for-more-time.ts
+++ b/app/controllers/ask-for-more-time/ask-for-more-time.ts
@@ -8,7 +8,7 @@ import UpdateAppealService from '../../service/update-appeal-service';
 import { getNextPage } from '../../utils/save-for-later-utils';
 import { addSummaryRow, Delimiter } from '../../utils/summary-list';
 import { getConditionalRedirectUrl } from '../../utils/url-utils';
-import { nowIsoDate } from '../../utils/utils';
+import { formatTextForCYA, nowIsoDate } from '../../utils/utils';
 import { askForMoreTimeValidation } from '../../utils/validations/fields-validations';
 import {
   EvidenceUploadConfig,
@@ -131,7 +131,7 @@ function postSubmitEvidence(updateAppealService: UpdateAppealService) {
 
 function getCheckAndSend(req: Request, res: Response, next: NextFunction) {
   try {
-    const reasonFormattingPreserved = `<span class='answer'>${req.session.appeal.askForMoreTime.reason}</span>`;
+    const reasonFormattingPreserved = formatTextForCYA(req.session.appeal.askForMoreTime.reason);
     const summaryRows = [
       addSummaryRow(i18n.common.cya.questionRowTitle, [i18n.pages.askForMoreTimePage.textAreaText], null),
       addSummaryRow(i18n.common.cya.answerRowTitle, [ reasonFormattingPreserved ], paths.common.askForMoreTime.reason)

--- a/app/controllers/reasons-for-appeal/check-and-send.ts
+++ b/app/controllers/reasons-for-appeal/check-and-send.ts
@@ -7,16 +7,18 @@ import UpdateAppealService from '../../service/update-appeal-service';
 import { shouldValidateWhenSaveForLater } from '../../utils/save-for-later-utils';
 import { addSummaryRow, Delimiter } from '../../utils/summary-list';
 import { getConditionalRedirectUrl } from '../../utils/url-utils';
-import { nowIsoDate } from '../../utils/utils';
+import { formatTextForCYA, nowIsoDate } from '../../utils/utils';
 
 function getCheckAndSend(req: Request, res: Response, next: NextFunction): void {
   try {
     const editParameter: string = '?edit';
     let previousPage: string = paths.awaitingReasonsForAppeal.supportingEvidence;
 
+    const formattedReason = formatTextForCYA(req.session.appeal.reasonsForAppeal.applicationReason);
+
     const summaryRows = [
       addSummaryRow(i18n.common.cya.questionRowTitle, [ i18n.pages.reasonForAppeal.heading ], null),
-      addSummaryRow(i18n.common.cya.answerRowTitle, [ req.session.appeal.reasonsForAppeal.applicationReason ], paths.awaitingReasonsForAppeal.decision + editParameter)
+      addSummaryRow(i18n.common.cya.answerRowTitle, [ formattedReason ], paths.awaitingReasonsForAppeal.decision + editParameter)
     ];
 
     if (_.has(req.session.appeal.reasonsForAppeal, 'evidences')) {

--- a/app/utils/utils.ts
+++ b/app/utils/utils.ts
@@ -1,3 +1,5 @@
+import nl2br from 'nl2br';
+
 /**
  * Translate primitive values to Boolean value
  * @param value the primitive value to be translated into a boolean
@@ -42,4 +44,8 @@ export function hasInflightTimeExtension(appeal: Appeal) {
     }).length > 0;
   }
   return false;
+}
+
+export function formatTextForCYA(text: string) {
+  return nl2br(text.replace(/ /g, '&nbsp;'));
 }

--- a/package.json
+++ b/package.json
@@ -69,6 +69,7 @@
     "mini-css-extract-plugin": "^0.9.0",
     "moment": "^2.24.0",
     "multer": "^1.4.2",
+    "nl2br": "^0.0.3",
     "nunjucks": "^3.2.0",
     "optimize-css-assets-webpack-plugin": "^5.0.3",
     "otp": "^0.1.3",

--- a/test/e2e-test/pages/ask-for-more-time/ask-for-more-time.ts
+++ b/test/e2e-test/pages/ask-for-more-time/ask-for-more-time.ts
@@ -1,4 +1,5 @@
 import { paths } from '../../../../app/paths';
+import { formatTextForCYA } from '../../../../app/utils/utils';
 
 const config = require('config');
 
@@ -30,7 +31,7 @@ module.exports = {
     });
 
     Then(/^I should see the reasons for appeal$/, async () => {
-      I.seeInSource('Reason for time extension');
+      I.seeInSource(formatTextForCYA('Reason for time extension'));
     });
 
     Then(/^I should see uploaded evidence$/, async () => {

--- a/test/unit/controllers/ask-for-more-time.test.ts
+++ b/test/unit/controllers/ask-for-more-time.test.ts
@@ -13,6 +13,7 @@ import { Events } from '../../../app/data/events';
 import { paths } from '../../../app/paths';
 import UpdateAppealService from '../../../app/service/update-appeal-service';
 import Logger from '../../../app/utils/logger';
+import { formatTextForCYA } from '../../../app/utils/utils';
 import { expect, sinon } from '../../utils/testUtils';
 
 describe('Ask for more time Controller', function () {
@@ -154,7 +155,7 @@ describe('Ask for more time Controller', function () {
           }, {
             actions: { items: [{ href: '/ask-for-more-time', text: 'Change' }] },
             key: { text: 'Answer' },
-            value: { html: `<span class='answer'>${req.session.appeal.askForMoreTime.reason}</span>` }
+            value: { html: formatTextForCYA(req.session.appeal.askForMoreTime.reason) }
           }]
         });
     });
@@ -178,7 +179,7 @@ describe('Ask for more time Controller', function () {
           }, {
             actions: { items: [{ href: '/ask-for-more-time', text: 'Change' }] },
             key: { text: 'Answer' },
-            value: { html: `<span class='answer'>${req.session.appeal.askForMoreTime.reason}</span>` }
+            value: { html: formatTextForCYA(req.session.appeal.askForMoreTime.reason) }
           }, {
             actions: { items: [{ href: paths.common.askForMoreTime.supportingEvidenceUpload, text: 'Change' }] },
             key: { text: 'Supporting evidence' },

--- a/test/unit/controllers/check-and-send.test.ts
+++ b/test/unit/controllers/check-and-send.test.ts
@@ -9,6 +9,7 @@ import { paths } from '../../../app/paths';
 import UpdateAppealService from '../../../app/service/update-appeal-service';
 import Logger from '../../../app/utils/logger';
 import { addSummaryRow } from '../../../app/utils/summary-list';
+import { formatTextForCYA } from '../../../app/utils/utils';
 import { expect, sinon } from '../../utils/testUtils';
 import { createDummyAppealApplication } from '../mockData/mock-appeal';
 
@@ -70,7 +71,7 @@ describe('createSummaryRowsFrom', () => {
     };
 
     const rows: any[] = createSummaryRowsFrom(appeal.application);
-    const appealLateRow = addSummaryRow('Reason for late appeal', [ appeal.application.lateAppeal.reason ], paths.appealStarted.appealLate);
+    const appealLateRow = addSummaryRow('Reason for late appeal', [ formatTextForCYA(appeal.application.lateAppeal.reason) ], paths.appealStarted.appealLate);
     const mockedRows: SummaryRow[] = getMockedSummaryRows();
     mockedRows.push(appealLateRow);
     expect(rows).to.be.deep.equal(mockedRows);

--- a/test/unit/controllers/reasons-for-appeal/check-and-send.test.ts
+++ b/test/unit/controllers/reasons-for-appeal/check-and-send.test.ts
@@ -8,6 +8,7 @@ import { Events } from '../../../../app/data/events';
 import { paths } from '../../../../app/paths';
 import UpdateAppealService from '../../../../app/service/update-appeal-service';
 import { addSummaryRow, Delimiter } from '../../../../app/utils/summary-list';
+import { formatTextForCYA } from '../../../../app/utils/utils';
 import i18n from '../../../../locale/en.json';
 import { expect, sinon } from '../../../utils/testUtils';
 
@@ -65,7 +66,7 @@ describe('Reasons For Appeal - Check and send Controller', () => {
     it('should render reasons-for-appeal/check-and-send-page.njk with supporting evidences', () => {
       const summaryRows = [
         addSummaryRow(i18n.common.cya.questionRowTitle, [ i18n.pages.reasonForAppeal.heading ], null),
-        addSummaryRow(i18n.common.cya.answerRowTitle, [ req.session.appeal.reasonsForAppeal.applicationReason ], paths.awaitingReasonsForAppeal.decision + editParameter),
+        addSummaryRow(i18n.common.cya.answerRowTitle, [ formatTextForCYA(req.session.appeal.reasonsForAppeal.applicationReason) ], paths.awaitingReasonsForAppeal.decision + editParameter),
         addSummaryRow(i18n.common.cya.supportingEvidenceRowTitle, [
           '<a class=\'govuk-link\' target=\'_blank\' rel=\'noopener noreferrer\' href=\'/view/document/1234\'>File1.png</a>',
           '<a class=\'govuk-link\' target=\'_blank\' rel=\'noopener noreferrer\' href=\'/view/document/1234\'>File2.png</a>'
@@ -91,7 +92,7 @@ describe('Reasons For Appeal - Check and send Controller', () => {
     it('should render reasons-for-appeal/check-and-send-page.njk without supporting evidences', () => {
       const summaryRows = [
         addSummaryRow(i18n.common.cya.questionRowTitle, [ i18n.pages.reasonForAppeal.heading ], null),
-        addSummaryRow(i18n.common.cya.answerRowTitle, [ req.session.appeal.reasonsForAppeal.applicationReason ], paths.awaitingReasonsForAppeal.decision + editParameter)
+        addSummaryRow(i18n.common.cya.answerRowTitle, [ formatTextForCYA(req.session.appeal.reasonsForAppeal.applicationReason) ], paths.awaitingReasonsForAppeal.decision + editParameter)
       ];
 
       getCheckAndSend(req as Request, res as Response, next);

--- a/test/unit/utils/utils.test.ts
+++ b/test/unit/utils/utils.test.ts
@@ -1,4 +1,4 @@
-import { asBooleanValue, hasInflightTimeExtension, nowAppealDate, toIsoDate } from '../../../app/utils/utils';
+import { asBooleanValue, formatTextForCYA, hasInflightTimeExtension, nowAppealDate, toIsoDate } from '../../../app/utils/utils';
 import { expect } from '../../utils/testUtils';
 
 describe('utils', () => {
@@ -116,6 +116,23 @@ describe('utils', () => {
         appealStatus: 'currentState'
       } as Appeal);
       expect(inflightTimeExtension).to.be.eq(true);
+    });
+  });
+
+  describe('formatTextForCYA', () => {
+    it('converts \n to <br/>', () => {
+      const actualText = formatTextForCYA('A_string\nwith_a_new_line');
+      expect(actualText).to.be.eq('A_string<br />\nwith_a_new_line');
+    });
+
+    it('converts spaces', () => {
+      const actualText = formatTextForCYA('A string');
+      expect(actualText).to.be.eq('A&nbsp;string');
+    });
+
+    it('converts indents', () => {
+      const actualText = formatTextForCYA('A string\n  with an indent');
+      expect(actualText).to.be.eq('A&nbsp;string<br />\n&nbsp;&nbsp;with&nbsp;an&nbsp;indent');
     });
   });
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -1459,9 +1459,9 @@ acorn@^7.1.1:
   integrity sha512-add7dgA5ppRPxCFJoAGfMDi7PIBXq1RtGo7BhbLaxwrXPOmw8gq48Y9ozT01hUKy9byMjlR20EJhu5zlkErEkg==
 
 adm-zip@~0.4.3:
-  version "0.4.14"
-  resolved "https://registry.yarnpkg.com/adm-zip/-/adm-zip-0.4.14.tgz#2cf312bcc9f8875df835b0f6040bd89be0a727a9"
-  integrity sha512-/9aQCnQHF+0IiCl0qhXoK7qs//SwYE7zX8lsr/DNk1BRAHYxeLZPL4pguwK29gUEqasYQjqPtEpDRSWEkdHn9g==
+  version "0.4.13"
+  resolved "https://registry.yarnpkg.com/adm-zip/-/adm-zip-0.4.13.tgz#597e2f8cc3672151e1307d3e95cddbc75672314a"
+  integrity sha512-fERNJX8sOXfel6qCBCMPvZLzENBEhZTzKqg6vrOW5pvoEaQuJhRU4ndTAh6lHOxn1I6jnz2NHra56ZODM751uw==
 
 agent-base@^4.3.0:
   version "4.3.0"
@@ -2678,9 +2678,9 @@ code-point-at@^1.0.0:
   integrity sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=
 
 codeceptjs@^2.6.2:
-  version "2.6.2"
-  resolved "https://registry.yarnpkg.com/codeceptjs/-/codeceptjs-2.6.2.tgz#aba58c7872ef4de01fe04a3e924694f431cef4b5"
-  integrity sha512-wVH+NpL2umtsart++rrNuVY8itsNBEnr+naXbFC3Owkc3RJ4Bhd9L7Re9OJHUIaqxZ8P8pFbLexIicD/cuRXDw==
+  version "2.6.5"
+  resolved "https://registry.yarnpkg.com/codeceptjs/-/codeceptjs-2.6.5.tgz#fde1e544d91151d4676d20667810e093921a09ec"
+  integrity sha512-v0Lrbr3BtbzNHPPQi07cVDx/fiwVsukiXRdMkqU0qMdCEQIyVRjNIxn2l2pD/LzevTCq2jrfGjesbcDGeP3GcA==
   dependencies:
     "@codeceptjs/configure" "^0.4.0"
     allure-js-commons "^1.3.2"
@@ -6879,6 +6879,11 @@ nise@^4.0.1:
     "@sinonjs/text-encoding" "^0.7.1"
     just-extend "^4.0.2"
     path-to-regexp "^1.7.0"
+
+nl2br@^0.0.3:
+  version "0.0.3"
+  resolved "https://registry.yarnpkg.com/nl2br/-/nl2br-0.0.3.tgz#7778d6138979e051866ade0b3bf600f7c46324ee"
+  integrity sha1-d3jWE4l54FGGat4LO/YA98RjJO4=
 
 no-case@^2.2.0:
   version "2.3.2"


### PR DESCRIPTION
An appellant can add new lines and space indents to an answer in a
textarea. When this was being displayed on the CYA page it lost that
formatting. This has been fixed for
- reasons for appeal
- reason for time extension
- reasons for late appeal

### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/RIA-3216

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
