### PR TITLE
RIA-2312: Anything else question for clarifying questions

### DIFF
--- a/app/assets/scss/_task-list.scss
+++ b/app/assets/scss/_task-list.scss
@@ -16,13 +16,14 @@ ol.task-list {
       }
       > li.task-list__item {
         box-sizing: border-box;
-        height: 4rem;
+        min-height: 4rem;
         display: flex;
         justify-content: space-between;
         padding: 1rem 0;
         margin: 0;
         border-bottom: 1px solid $govuk-border-colour;
         .govuk-tag {
+          max-height: 0.9375rem;
           padding: .5rem 1rem;
           background-color: $govuk-secondary-text-colour;
         }

--- a/app/controllers/appeal-application/confirmation-page.ts
+++ b/app/controllers/appeal-application/confirmation-page.ts
@@ -5,19 +5,15 @@ import moment from 'moment';
 const daysToWaitAfterSubmission = config.get('daysToWait.afterSubmission');
 
 import { paths } from '../../paths';
-import { dayMonthYearFormat } from '../../utils/date-formats';
+import { addDaysToDate } from '../../utils/date-utils';
 
-export const daysToWaitUntilContact = (days: number) => {
-  const date = moment().add(days,'days').format(dayMonthYearFormat);
-  return date;
-};
 function getConfirmationPage(req: Request, res: Response, next: NextFunction) {
   try {
     const { application } = req.session.appeal;
     const isLate = () => application.isAppealLate ;
 
     res.render('confirmation-page.njk', {
-      date: daysToWaitUntilContact(daysToWaitAfterSubmission),
+      date: addDaysToDate(daysToWaitAfterSubmission),
       late: isLate()
     });
   } catch (e) {

--- a/app/controllers/clarifying-questions/anything-else-answer.ts
+++ b/app/controllers/clarifying-questions/anything-else-answer.ts
@@ -1,0 +1,76 @@
+import { NextFunction, Request, Response, Router } from 'express';
+import i18n from '../../../locale/en.json';
+import { CQ_NOTHING_ELSE } from '../../data/constants';
+import { Events } from '../../data/events';
+import { paths } from '../../paths';
+import UpdateAppealService from '../../service/update-appeal-service';
+import { textAreaValidation } from '../../utils/validations/fields-validations';
+
+function getAnythingElseAnswerPage(req: Request, res: Response, next: NextFunction) {
+  try {
+    const { draftClarifyingQuestionsAnswers } = req.session.appeal;
+    const anythingElseQuestion: ClarifyingQuestion<Evidence> = draftClarifyingQuestionsAnswers[draftClarifyingQuestionsAnswers.length - 1];
+    res.render('templates/textarea-question-page.njk', {
+      previousPage: paths.awaitingClarifyingQuestionsAnswers.questionsList,
+      formAction: paths.awaitingClarifyingQuestionsAnswers.anythingElseAnswerPage,
+      pageTitle: anythingElseQuestion.value.question,
+      question: {
+        name: 'anything-else',
+        title: anythingElseQuestion.value.question,
+        description: i18n.pages.clarifyingQuestionAnythingElseAnswer.description,
+        hint: i18n.pages.clarifyingQuestionAnythingElseAnswer.hint,
+        value: anythingElseQuestion.value.answer === CQ_NOTHING_ELSE ? '' : anythingElseQuestion.value.answer
+      },
+      supportingEvidence: true,
+      timeExtensionAllowed: true
+    });
+  } catch (e) {
+    next(e);
+  }
+}
+
+function postAnythingElseAnswerPage(updateAppealService: UpdateAppealService) {
+  return async (req: Request, res: Response, next: NextFunction) => {
+    try {
+      const { draftClarifyingQuestionsAnswers } = req.session.appeal;
+      const anythingElseQuestion: ClarifyingQuestion<Evidence> = draftClarifyingQuestionsAnswers[draftClarifyingQuestionsAnswers.length - 1];
+      const validationErrors = textAreaValidation(req.body['anything-else'], 'anything-else', i18n.validationErrors.clarifyingQuestions.anythingElseEmptyAnswer);
+      if (validationErrors) {
+        res.render('templates/textarea-question-page.njk', {
+          previousPage: paths.awaitingClarifyingQuestionsAnswers.questionsList,
+          formAction: paths.awaitingClarifyingQuestionsAnswers.anythingElseAnswerPage,
+          pageTitle: anythingElseQuestion.value.question,
+          question: {
+            name: 'anything-else',
+            title: anythingElseQuestion.value.question,
+            description: i18n.pages.clarifyingQuestionAnythingElseAnswer.description,
+            hint: i18n.pages.clarifyingQuestionAnythingElseAnswer.hint,
+            value: anythingElseQuestion.value.answer
+          },
+          supportingEvidence: true,
+          timeExtensionAllowed: true,
+          errorList: Object.values(validationErrors),
+          errors: validationErrors
+        });
+      }
+      anythingElseQuestion.value.answer = req.body['anything-else'];
+      await updateAppealService.submitEvent(Events.EDIT_CLARIFYING_QUESTION_ANSWERS, req);
+      res.redirect(paths.awaitingClarifyingQuestionsAnswers.questionsList);
+    } catch (e) {
+      next(e);
+    }
+  };
+}
+
+function setupCQAnythingElseAnswerController(middleware: Middleware[], updateAppealService: UpdateAppealService): Router {
+  const router: Router = Router();
+  router.get(paths.awaitingClarifyingQuestionsAnswers.anythingElseAnswerPage, getAnythingElseAnswerPage);
+  router.post(paths.awaitingClarifyingQuestionsAnswers.anythingElseAnswerPage, postAnythingElseAnswerPage(updateAppealService));
+  return router;
+}
+
+export {
+  getAnythingElseAnswerPage,
+  postAnythingElseAnswerPage,
+  setupCQAnythingElseAnswerController
+};

--- a/app/controllers/clarifying-questions/anything-else-question.ts
+++ b/app/controllers/clarifying-questions/anything-else-question.ts
@@ -1,0 +1,108 @@
+import { NextFunction, Request, Response, Router } from 'express';
+import i18n from '../../../locale/en.json';
+import { CQ_NOTHING_ELSE } from '../../data/constants';
+import { Events } from '../../data/events';
+import { paths } from '../../paths';
+import { documentIdToDocStoreUrl, DocumentManagementService } from '../../service/document-management-service';
+import UpdateAppealService from '../../service/update-appeal-service';
+import { yesOrNoRequiredValidation } from '../../utils/validations/fields-validations';
+
+function getAnythingElseQuestionPage(req: Request, res: Response, next: NextFunction) {
+  try {
+    const questionsLength: number = req.session.appeal.draftClarifyingQuestionsAnswers.length;
+    const anythingElseQuestion: ClarifyingQuestion<Evidence> = { ...req.session.appeal.draftClarifyingQuestionsAnswers[questionsLength - 1] };
+    const options = [
+      {
+        value: true,
+        text: 'Yes'
+      },
+      {
+        value: false,
+        text: 'No'
+      }
+    ];
+    res.render('templates/radio-question-page.njk', {
+      previousPage: paths.awaitingClarifyingQuestionsAnswers.questionsList,
+      pageTitle: anythingElseQuestion.value.question,
+      formAction: paths.awaitingClarifyingQuestionsAnswers.anythingElseQuestionPage,
+      question: {
+        title: anythingElseQuestion.value.question,
+        hint: i18n.pages.clarifyingQuestionAnythingElseQuestion.hint,
+        options
+      }
+    });
+  } catch (e) {
+    next(e);
+  }
+}
+
+function postAnythingElseQuestionPage(updateAppealService: UpdateAppealService, documentManagementService: DocumentManagementService) {
+  return async (req: Request, res: Response, next: NextFunction) => {
+    try {
+      const questionsLength: number = req.session.appeal.draftClarifyingQuestionsAnswers.length;
+      const anythingElseQuestion: ClarifyingQuestion<Evidence> = { ...req.session.appeal.draftClarifyingQuestionsAnswers[questionsLength - 1] };
+      const validationError = yesOrNoRequiredValidation(req.body, 'Select Yes if you want to tell us anything else about your case');
+      if (validationError) {
+        const options = [
+          {
+            value: true,
+            text: 'Yes'
+          },
+          {
+            value: false,
+            text: 'No'
+          }
+        ];
+        return res.render('templates/radio-question-page.njk', {
+          previousPage: paths.awaitingClarifyingQuestionsAnswers.questionsList,
+          pageTitle: 'the title',
+          formAction: paths.awaitingClarifyingQuestionsAnswers.anythingElseQuestionPage,
+          question: {
+            title: anythingElseQuestion.value.question,
+            hint: i18n.pages.clarifyingQuestionAnythingElseQuestion.hint,
+            options
+          },
+          errorList: Object.values(validationError),
+          error: validationError
+        });
+      } else {
+        const anythingElse = req.body['answer'];
+        if (anythingElse === 'true') {
+          res.redirect(paths.awaitingClarifyingQuestionsAnswers.anythingElseAnswerPage);
+        } else {
+          if (anythingElseQuestion.value.supportingEvidence) {
+            anythingElseQuestion.value.supportingEvidence.forEach(async (evidence: Evidence) => {
+              const targetUrl: string = documentIdToDocStoreUrl(evidence.id, req.session.appeal.documentMap);
+              await documentManagementService.deleteFile(req, targetUrl);
+            });
+          }
+          anythingElseQuestion.value = {
+            ...anythingElseQuestion.value,
+            answer: CQ_NOTHING_ELSE,
+            supportingEvidence: []
+          };
+          req.session.appeal.draftClarifyingQuestionsAnswers[questionsLength - 1] = {
+            ...anythingElseQuestion
+          };
+          await updateAppealService.submitEvent(Events.EDIT_CLARIFYING_QUESTION_ANSWERS, req);
+          res.redirect(paths.awaitingClarifyingQuestionsAnswers.questionsList);
+        }
+      }
+    } catch (e) {
+      next(e);
+    }
+  };
+}
+
+function setupCQAnythingElseQuestionController(middleware: Middleware[], updateAppealService: UpdateAppealService, documentManagementService: DocumentManagementService): Router {
+  const router: Router = Router();
+  router.get(paths.awaitingClarifyingQuestionsAnswers.anythingElseQuestionPage, middleware, getAnythingElseQuestionPage);
+  router.post(paths.awaitingClarifyingQuestionsAnswers.anythingElseQuestionPage, middleware, postAnythingElseQuestionPage(updateAppealService, documentManagementService));
+  return router;
+}
+
+export {
+  getAnythingElseQuestionPage,
+  postAnythingElseQuestionPage,
+  setupCQAnythingElseQuestionController
+};

--- a/app/controllers/clarifying-questions/check-and-send.ts
+++ b/app/controllers/clarifying-questions/check-and-send.ts
@@ -1,0 +1,103 @@
+import { NextFunction, Request, Response, Router } from 'express';
+import i18n from '../../../locale/en.json';
+import { CQ_NOTHING_ELSE } from '../../data/constants';
+import { Events } from '../../data/events';
+import { paths } from '../../paths';
+import UpdateAppealService from '../../service/update-appeal-service';
+import { addSummaryRow, Delimiter } from '../../utils/summary-list';
+
+function buildEvidencesList(evidences: Evidence[]) {
+  return evidences.map((evidence: Evidence) => {
+    return `<a class='govuk-link' target='_blank' rel='noopener noreferrer' href='${paths.common.detailsViewers.document}/${evidence.fileId}'>${evidence.name}</a>`;
+  });
+}
+
+function getCheckAndSendPage(req: Request, res: Response, next: NextFunction) {
+  try {
+    const previousPage: string = paths.awaitingClarifyingQuestionsAnswers.questionsList;
+    const clarifyingQuestions: ClarifyingQuestion<Evidence>[] = [ ...req.session.appeal.draftClarifyingQuestionsAnswers ];
+    const anythingElseQuestion: ClarifyingQuestion<Evidence> = clarifyingQuestions.pop();
+
+    const summaryLists: any[] = clarifyingQuestions.map((question: ClarifyingQuestion<Evidence>, index: number) => {
+      const summaryRows: SummaryRow[] = [];
+      summaryRows.push(
+        addSummaryRow(i18n.common.cya.questionRowTitle, [ `<pre>${question.value.question}</pre>` ])
+      );
+      summaryRows.push(
+        addSummaryRow(i18n.common.cya.answerRowTitle, [ `<pre>${question.value.answer}</pre>` ], paths.awaitingClarifyingQuestionsAnswers.question.replace(':id', `${index + 1}`))
+      );
+      if (question.value.supportingEvidence && question.value.supportingEvidence.length) {
+        const evidencesList = buildEvidencesList(question.value.supportingEvidence);
+        summaryRows.push(
+          addSummaryRow(
+            i18n.common.cya.supportingEvidenceRowTitle,
+            evidencesList,
+            paths.awaitingClarifyingQuestionsAnswers.supportingEvidenceUploadFile.replace(':id', `${index + 1}`),
+            Delimiter.BREAK_LINE
+          )
+        );
+      }
+      return {
+        title: `${i18n.common.cya.questionRowTitle} ${index + 1}`,
+        summaryRows
+      };
+    });
+    if (anythingElseQuestion.value.answer && anythingElseQuestion.value.answer !== CQ_NOTHING_ELSE) {
+      const summaryRows: SummaryRow[] = [
+        addSummaryRow(i18n.common.cya.answerRowTitle, [ `<pre>${anythingElseQuestion.value.answer}</pre>` ], paths.awaitingClarifyingQuestionsAnswers.anythingElseAnswerPage)
+      ];
+      if (anythingElseQuestion.value.supportingEvidence && anythingElseQuestion.value.supportingEvidence.length) {
+        const evidencesList = buildEvidencesList(anythingElseQuestion.value.supportingEvidence);
+        summaryRows.push(
+          addSummaryRow(
+            i18n.common.cya.supportingEvidenceRowTitle,
+            evidencesList,
+            '',
+            Delimiter.BREAK_LINE
+          )
+        );
+      }
+      summaryLists.push({
+        title: anythingElseQuestion.value.question,
+        summaryRows
+      });
+    }
+    res.render('templates/check-and-send.njk', {
+      pageTitle: i18n.pages.clarifyingQuestionsCYA.title,
+      formAction: paths.awaitingClarifyingQuestionsAnswers.checkAndSend,
+      previousPage,
+      summaryLists
+    });
+  } catch (e) {
+    next(e);
+  }
+}
+
+function postCheckAndSendPage(updateAppealService: UpdateAppealService) {
+  return async (req: Request, res: Response, next: NextFunction) => {
+    try {
+      const clarifyingQuestions: ClarifyingQuestion<Evidence>[] = [ ...req.session.appeal.draftClarifyingQuestionsAnswers ];
+      req.session.appeal.clarifyingQuestionsAnswers = [ ...clarifyingQuestions ];
+      delete req.session.appeal.draftClarifyingQuestionsAnswers;
+      const updatedAppeal = await updateAppealService.submitEvent(Events.SUBMIT_CLARIFYING_QUESTION_ANSWERS, req);
+      req.session.appeal.appealStatus = updatedAppeal.state;
+      res.redirect(paths.clarifyingQuestionsAnswersSubmitted.confirmation);
+    } catch (e) {
+      next(e);
+    }
+  };
+}
+
+function setupClarifyingQuestionsCheckSendController(middleware: Middleware[], updateAppealService: UpdateAppealService): Router {
+  const router: Router = Router();
+  router.get(paths.awaitingClarifyingQuestionsAnswers.checkAndSend, middleware, getCheckAndSendPage);
+  router.post(paths.awaitingClarifyingQuestionsAnswers.checkAndSend, middleware, postCheckAndSendPage(updateAppealService));
+  return router;
+}
+
+export {
+  buildEvidencesList,
+  getCheckAndSendPage,
+  postCheckAndSendPage,
+  setupClarifyingQuestionsCheckSendController
+};

--- a/app/controllers/clarifying-questions/confirmation-page.ts
+++ b/app/controllers/clarifying-questions/confirmation-page.ts
@@ -1,0 +1,27 @@
+import { NextFunction, Request, Response, Router } from 'express';
+import i18n from '../../../locale/en.json';
+import { paths } from '../../paths';
+import { addDaysToDate } from '../../utils/date-utils';
+
+function getConfirmationPage(req: Request, res: Response, next: NextFunction) {
+  try {
+    res.render('templates/confirmation-page.njk', {
+      title: i18n.pages.clarifyingQuestionsCYA.title,
+      whatNextListItems: i18n.pages.clarifyingQuestionsCYA.whatNextListItems,
+      date: addDaysToDate(7)
+    });
+  } catch (e) {
+    next(e);
+  }
+}
+
+function setupClarifyingQuestionsConfirmationPage(middleware: Middleware[]): Router {
+  const router: Router = Router();
+  router.get(paths.clarifyingQuestionsAnswersSubmitted.confirmation, middleware, getConfirmationPage);
+  return router;
+}
+
+export {
+  getConfirmationPage,
+  setupClarifyingQuestionsConfirmationPage
+};

--- a/app/controllers/clarifying-questions/questions-list.ts
+++ b/app/controllers/clarifying-questions/questions-list.ts
@@ -3,11 +3,15 @@ import { paths } from '../../paths';
 
 function getQuestionsList(req: Request, res: Response, next: NextFunction) {
   const questions = [ ...req.session.appeal.draftClarifyingQuestionsAnswers ];
+  const anythingElseQuestion: ClarifyingQuestion<Evidence> = questions.pop();
   const questionsCompleted: boolean = questions.reduce((acc, question) => acc && !!question.value.answer, true);
+  const anythingElseCompleted: boolean = !!anythingElseQuestion.value.answer;
   res.render('clarifying-questions/questions-list.njk', {
     previousPage: paths.common.overview,
     questions,
-    questionsCompleted
+    questionsCompleted,
+    anythingElseQuestion,
+    anythingElseCompleted
   });
 }
 

--- a/app/controllers/detail-viewers.ts
+++ b/app/controllers/detail-viewers.ts
@@ -12,7 +12,7 @@ import {
   documentToHtmlLink,
   toHtmlLink
 } from '../service/document-management-service';
-import { dayMonthYearFormat } from '../utils/date-formats';
+import { dayMonthYearFormat } from '../utils/date-utils';
 import { addSummaryRow, Delimiter } from '../utils/summary-list';
 import { timeExtensionIdToTimeExtensionData } from '../utils/timeline-utils';
 

--- a/app/controllers/reasons-for-appeal/reason-for-appeal.ts
+++ b/app/controllers/reasons-for-appeal/reason-for-appeal.ts
@@ -6,6 +6,7 @@ import { Events } from '../../data/events';
 import { paths } from '../../paths';
 import { documentIdToDocStoreUrl, DocumentManagementService } from '../../service/document-management-service';
 import UpdateAppealService from '../../service/update-appeal-service';
+import { addDaysToDate } from '../../utils/date-utils';
 import { getConditionalRedirectUrl } from '../../utils/url-utils';
 import { asBooleanValue, hasInflightTimeExtension, nowAppealDate } from '../../utils/utils';
 import {
@@ -13,7 +14,6 @@ import {
   reasonForAppealDecisionValidation,
   yesOrNoRequiredValidation
 } from '../../utils/validations/fields-validations';
-import { daysToWaitUntilContact } from '../appeal-application/confirmation-page';
 
 const askForMoreTimeFeatureEnabled: boolean = asBooleanValue(config.get('features.askForMoreTime'));
 
@@ -210,7 +210,7 @@ function getSupportingEvidenceDeleteFile(documentManagementService: DocumentMana
 function getConfirmationPage(req: Request, res: Response, next: NextFunction) {
   try {
     return res.render('reasons-for-appeal/confirmation-page.njk', {
-      date: daysToWaitUntilContact(14)
+      date: addDaysToDate(14)
     });
   } catch (e) {
     next(e);

--- a/app/data/constants.ts
+++ b/app/data/constants.ts
@@ -1,0 +1,1 @@
+export const CQ_NOTHING_ELSE: string = 'Nothing else';

--- a/app/paths.ts
+++ b/app/paths.ts
@@ -39,7 +39,12 @@ const paths = {
     supportingEvidenceDeleteFile: '/clarifying-questions/delete-evidence/:id/',
     supportingEvidenceSubmit: '/clarifying-questions/submit/:id',
     anythingElse: '/anything-else',
+    anythingElseQuestionPage: '/anything-else-question',
+    anythingElseAnswerPage: '/anything-else-answer',
     checkAndSend: '/check-your-answers'
+  },
+  clarifyingQuestionsAnswersSubmitted: {
+    confirmation: '/clarifying-questions-sent'
   },
   common: {
     // index, start, idam endpoints and overview

--- a/app/routes.ts
+++ b/app/routes.ts
@@ -12,6 +12,10 @@ import { setupTaskListController } from './controllers/appeal-application/task-l
 import { setupTypeOfAppealController } from './controllers/appeal-application/type-of-appeal';
 import { setupApplicationOverviewController } from './controllers/application-overview';
 import { setupAskForMoreTimeController } from './controllers/ask-for-more-time/ask-for-more-time';
+import { setupCQAnythingElseAnswerController } from './controllers/clarifying-questions/anything-else-answer';
+import { setupCQAnythingElseQuestionController } from './controllers/clarifying-questions/anything-else-question';
+import { setupClarifyingQuestionsCheckSendController } from './controllers/clarifying-questions/check-and-send';
+import { setupClarifyingQuestionsConfirmationPage } from './controllers/clarifying-questions/confirmation-page';
 import { setupClarifyingQuestionPageController } from './controllers/clarifying-questions/question-page';
 import { setupClarifyingQuestionsListController } from './controllers/clarifying-questions/questions-list';
 import { setupClarifyingQuestionsSupportingEvidenceUploadController } from './controllers/clarifying-questions/supporting-evidence';
@@ -78,6 +82,10 @@ const clarifyingQuestionsListController = setupClarifyingQuestionsListController
 const clarifyingQuestionPageController = setupClarifyingQuestionPageController(middleware, updateAppealService);
 const clarifyingQuestionsSupportingEvidenceController = setupSupportingEvidenceQuestionController(middleware, { updateAppealService, documentManagementService });
 const clarifyingQuestionsSupportingEvidenceUploadController = setupClarifyingQuestionsSupportingEvidenceUploadController(middleware, { updateAppealService, documentManagementService });
+const clarifyingQuestionsAnythingElseQuestionController = setupCQAnythingElseQuestionController(middleware, updateAppealService, documentManagementService);
+const clarifyingQuestionsAnythingElseAnswerController = setupCQAnythingElseAnswerController(middleware, updateAppealService);
+const clarifyingQuestionsCYAController = setupClarifyingQuestionsCheckSendController(middleware, updateAppealService);
+const clarifyingQuestionsConfirmationPageController = setupClarifyingQuestionsConfirmationPage(middleware);
 
 // not protected by idam
 router.use(indexController);
@@ -113,6 +121,10 @@ router.use(clarifyingQuestionsListController);
 router.use(clarifyingQuestionPageController);
 router.use(clarifyingQuestionsSupportingEvidenceController);
 router.use(clarifyingQuestionsSupportingEvidenceUploadController);
+router.use(clarifyingQuestionsAnythingElseQuestionController);
+router.use(clarifyingQuestionsAnythingElseAnswerController);
+router.use(clarifyingQuestionsCYAController);
+router.use(clarifyingQuestionsConfirmationPageController);
 router.use(detailViewersController);
 router.use(forbiddenController);
 

--- a/app/service/update-appeal-service.ts
+++ b/app/service/update-appeal-service.ts
@@ -1,5 +1,6 @@
 import { Request } from 'express';
 import * as _ from 'lodash';
+import i18n from '../../locale/en.json';
 import { toIsoDate } from '../utils/utils';
 import { AuthenticationService, SecurityHeaders } from './authentication-service';
 import { CcdService } from './ccd-service';
@@ -157,19 +158,18 @@ export default class UpdateAppealService {
         timeExtensions.push(timeExt);
 
       });
-
-      if (caseData.directions) {
-        directions = caseData.directions.map(d => {
-          return {
-            id: d.id,
-            tag: d.value.tag,
-            parties: d.value.parties,
-            dateDue: d.value.dateDue,
-            dateSent: d.value.dateSent
-          } as Direction;
-        });
-        requestClarifyingQuestionsDirection = caseData.directions.find(direction => direction.value.tag === 'requestClarifyingQuestions');
-      }
+    }
+    if (caseData.directions) {
+      directions = caseData.directions.map(d => {
+        return {
+          id: d.id,
+          tag: d.value.tag,
+          parties: d.value.parties,
+          dateDue: d.value.dateDue,
+          dateSent: d.value.dateSent
+        } as Direction;
+      });
+      requestClarifyingQuestionsDirection = caseData.directions.find(direction => direction.value.tag === 'requestClarifyingQuestions');
     }
 
     if (requestClarifyingQuestionsDirection && ccdCase.state === 'awaitingClarifyingQuestionsAnswers') {
@@ -190,6 +190,11 @@ export default class UpdateAppealService {
         });
       } else {
         draftClarifyingQuestionsAnswers = [ ...requestClarifyingQuestionsDirection.value.clarifyingQuestions ];
+        draftClarifyingQuestionsAnswers.push({
+          value: {
+            question: i18n.pages.clarifyingQuestionAnythingElseQuestion.question
+          }
+        });
       }
     }
 
@@ -228,9 +233,7 @@ export default class UpdateAppealService {
       timeExtensionEventsMap: timeExtensionEventsMap,
       timeExtensions: timeExtensions,
       draftClarifyingQuestionsAnswers
-
     };
-
     req.session.appeal.askForMoreTime = {};
   }
 
@@ -384,23 +387,29 @@ export default class UpdateAppealService {
     }
 
     if (appeal.draftClarifyingQuestionsAnswers) {
-      caseData.draftClarifyingQuestionsAnswers = appeal.draftClarifyingQuestionsAnswers.map((answer: ClarifyingQuestion<Evidence>): ClarifyingQuestion<Collection<SupportingDocument>> => {
-        let question: ClarifyingQuestion<Collection<SupportingDocument>>;
-        let supportingEvidence: Collection<SupportingDocument>[];
-        if (answer.value.supportingEvidence) {
-          supportingEvidence = answer.value.supportingEvidence.map(evidence => this.mapEvidenceToSupportingDocument(evidence, appeal));
-        }
-        question = {
-          ...answer,
-          value: {
-            ...answer.value,
-            supportingEvidence
-          }
-        };
-        return question;
-      });
+      caseData.draftClarifyingQuestionsAnswers = this.mapAppealClarifyingQuestionsToCcd(appeal.draftClarifyingQuestionsAnswers, appeal.documentMap);
+    }
+
+    if (appeal.clarifyingQuestionsAnswers) {
+      caseData.clarifyingQuestionsAnswers = this.mapAppealClarifyingQuestionsToCcd(appeal.clarifyingQuestionsAnswers, appeal.documentMap);
     }
     return caseData;
+  }
+
+  private mapAppealClarifyingQuestionsToCcd(clarifyingQuestions: ClarifyingQuestion<Evidence>[], documentMap: DocumentMap[]): ClarifyingQuestion<Collection<SupportingDocument>>[] {
+    return clarifyingQuestions.map((answer: ClarifyingQuestion<Evidence>): ClarifyingQuestion<Collection<SupportingDocument>> => {
+      let supportingEvidence: Collection<SupportingDocument>[];
+      if (answer.value.supportingEvidence) {
+        supportingEvidence = answer.value.supportingEvidence.map(evidence => this.mapEvidenceToSupportingDocument(evidence, documentMap));
+      }
+      return {
+        ...answer,
+        value: {
+          ...answer.value,
+          supportingEvidence
+        }
+      };
+    });
   }
 
   private addCcdTimeExtension(askForMoreTime, appeal, caseData) {
@@ -423,8 +432,8 @@ export default class UpdateAppealService {
     };
   }
 
-  private mapEvidenceToSupportingDocument(evidence: Evidence, appeal: Appeal): Collection<SupportingDocument> {
-    const documentUrl: string = documentIdToDocStoreUrl(evidence.fileId, appeal.documentMap);
+  private mapEvidenceToSupportingDocument(evidence: Evidence, documentMap: DocumentMap[]): Collection<SupportingDocument> {
+    const documentUrl: string = documentIdToDocStoreUrl(evidence.fileId, documentMap);
     return {
       value: {
         document_filename: evidence.name,

--- a/app/utils/date-utils.ts
+++ b/app/utils/date-utils.ts
@@ -1,7 +1,13 @@
+import moment from 'moment';
+
 /**
  * Main format used within the app should format the date to: "21 April 2020"
  */
 const dayMonthYearFormat = 'DD MMMM YYYY';
+
+export const addDaysToDate = (days: number) => {
+  return moment().add(days,'days').format(dayMonthYearFormat);
+};
 
 export {
   dayMonthYearFormat

--- a/app/utils/event-deadline-date-finder.ts
+++ b/app/utils/event-deadline-date-finder.ts
@@ -1,7 +1,7 @@
 import config from 'config';
 import { Request } from 'express';
 import moment from 'moment';
-import { dayMonthYearFormat } from './date-formats';
+import { dayMonthYearFormat } from './date-utils';
 
 const daysToWaitAfterSubmission = config.get('daysToWait.afterSubmission');
 const daysToWaitAfterReasonsForAppeal = config.get('daysToWait.afterReasonsForAppeal');

--- a/app/utils/progress-bar-utils.ts
+++ b/app/utils/progress-bar-utils.ts
@@ -6,7 +6,7 @@ function buildProgressBarStages(state: string) {
       activeStatus: [ 'appealStarted', 'appealSubmitted', 'awaitingRespondentEvidence' ]
     },
     yourAppealArgument: {
-      activeStatus: [ 'awaitingReasonsForAppeal', 'reasonsForAppealSubmitted', 'awaitingClarifyingQuestionsAnswers' ]
+      activeStatus: [ 'awaitingReasonsForAppeal', 'reasonsForAppealSubmitted', 'awaitingClarifyingQuestionsAnswers', 'clarifyingQuestionsAnswersSubmitted' ]
     },
     yourHearingDetails: {
       activeStatus: []

--- a/app/utils/summary-list.ts
+++ b/app/utils/summary-list.ts
@@ -5,7 +5,7 @@ export enum Delimiter {
   BREAK_LINE = '<br>'
 }
 
-export function addSummaryRow(key: string, values: (number | string | string[] | any)[], href: string, delimiter?: Delimiter) {
+export function addSummaryRow(key: string, values: (number | string | string[] | any)[], href?: string, delimiter?: Delimiter) {
   const separator = delimiter || '';
   let row: SummaryRow = {
     key: {

--- a/locale/en.json
+++ b/locale/en.json
@@ -1022,8 +1022,7 @@
           "itemTitle": "Answer question"
         },
         "otherInformation": {
-          "header": "Other information",
-          "itemTitle": "Do you want to tell us anything else about your case?"
+          "header": "Other information"
         },
         "checkAndSend": {
           "header": "Check and send",
@@ -1041,6 +1040,21 @@
         "needMoreTime": "Need more time?",
         "saveAndAskMoreTime": "Save your answer and ask for more time"
       }
+    },
+    "clarifyingQuestionAnythingElseQuestion": {
+      "hint": "This could be something you haven't already told us or any new information that might affect your case.",
+      "question": "Do you want to tell us anything else about your case?"
+    },
+    "clarifyingQuestionAnythingElseAnswer": {
+      "description": "This could be something you haven't already told us or any new information that might affect your case.",
+      "hint": "Tell us anything else about your case"
+    },
+    "clarifyingQuestionsCYA": {
+      "title": "You have answered the Tribunal's questions",
+      "whatNextListItems": [
+        "A tribunal Caseworker will look at your answers and contact you to tell you what to do next",
+        "This should be by <b>{{ date }}</b> but it might take longer than that"
+      ]
     }
   },
   "error": {
@@ -1130,7 +1144,8 @@
     },
     "askForMoreTime": "Enter how much time you need and why you need it",
     "clarifyingQuestions": {
-      "emptyAnswer": "Please enter an answer for the question"
+      "emptyAnswer": "Please enter an answer for the question",
+      "anythingElseEmptyAnswer": "Enter any other information you want tell us about your case"
     }
   },
   "components": {

--- a/test/e2e-test/pages/appeal-sent/appeal-sent.ts
+++ b/test/e2e-test/pages/appeal-sent/appeal-sent.ts
@@ -1,6 +1,6 @@
 import moment from 'moment';
 import { paths } from '../../../../app/paths';
-import { dayMonthYearFormat } from '../../../../app/utils/date-formats';
+import { dayMonthYearFormat } from '../../../../app/utils/date-utils';
 
 module.exports = {
   appealSent(I) {

--- a/test/e2e-test/pages/clarifying-questions/clarifying-questions.ts
+++ b/test/e2e-test/pages/clarifying-questions/clarifying-questions.ts
@@ -3,5 +3,9 @@ module.exports = {
     Then(/^I see clarifying question "([^"]*)" saved$/, async (selector: string) => {
       await I.see('SAVED',`//ol/li[1]/ul/li[${selector}]/strong`);
     });
+
+    Then(/^I see anything else clarifying question saved$/, async (selector: string) => {
+      await I.see('SAVED',`//ol/li[2]/ul/li/strong`);
+    });
   }
 };

--- a/test/e2e-test/pages/reasons-for-appeal/reasons-for-appeal-confirmation.ts
+++ b/test/e2e-test/pages/reasons-for-appeal/reasons-for-appeal-confirmation.ts
@@ -1,6 +1,6 @@
 import moment from 'moment';
 import { paths } from '../../../../app/paths';
-import { dayMonthYearFormat } from '../../../../app/utils/date-formats';
+import { dayMonthYearFormat } from '../../../../app/utils/date-utils';
 const config = require('config');
 
 const testUrl = config.get('testUrl');

--- a/test/functional/features/clarifying-questions.feature
+++ b/test/functional/features/clarifying-questions.feature
@@ -1,4 +1,4 @@
-Feature: Clarifying questions
+Feature: Clarifying questions @only
   In order to complete my appeal
   As a citizen
   I want to be able to answer clarifying questions
@@ -17,8 +17,11 @@ Feature: Clarifying questions
     Then I fill textarea with "my answer"
     Then I click "Save and continue" button
     Then I see "Do you want to provide supporting evidence?" in title
-    Then I click "No" button
+    Then I click "Yes" button
     Then I click "Continue" button
+    Then I see "Provide supporting evidence" in title
+    Then I choose a file that is "VALID" and click the "Upload file" button
+    Then I click "Save and continue" button
     Then I see "Questions about your appeal" in title
     And I see clarifying question "1" saved
 
@@ -32,3 +35,20 @@ Feature: Clarifying questions
     Then I see "Questions about your appeal" in title
     And I see clarifying question "2" saved
     And I see "Do you want to tell us anything else about your case?" link
+
+    When I click "Do you want to tell us anything else about your case?" link
+    Then I see "Do you want to tell us anything else about your case?" in title
+    Then I click "Yes" button
+    Then I click "Continue" button
+    Then I see "Do you want to tell us anything else about your case?" in title
+    Then I fill textarea with "my answer for anything else question"
+    Then I click "Save and continue" button
+    Then I see anything else clarifying question saved
+    And I see "Check and send your answers" link
+
+    When I click "Check and send your answers" link
+    Then I see "You have answered the Tribunal's questions" in title
+    Then I click "Send" button
+    And I see "You have answered the Tribunal's questions" in title
+    Then I click "See your appeal progress" button
+    And I see "Pablo Jimenez" in title

--- a/test/mock/ccd/mock-case-data/data/clarifying-questions.js
+++ b/test/mock/ccd/mock-case-data/data/clarifying-questions.js
@@ -46,7 +46,7 @@ const clarifyingQuestionsCaseData = {
               {
                 "id": "947398d5-bd81-4e7f-b3ed-1be73be5ba56",
                 "value": {
-                  "question": "Give us some more information about:\n- What are their ages?\n- What are their names?"
+                  "question": "Give us some more information about:\n- What are their ages?\n  - What are their names?"
                 }
               },
               {

--- a/test/mock/ccd/services/otherEventStartEvent.js
+++ b/test/mock/ccd/services/otherEventStartEvent.js
@@ -14,6 +14,8 @@ function getCurrentState(params) {
       return 'awaitingReasonsForAppeal';
     case 'editClarifyingQuestionAnswers':
       return 'awaitingClarifyingQuestionsAnswers'
+    case 'submitClarifyingQuestionAnswers':
+      return 'clarifyingQuestionsAnswersSubmitted';
     default:
       throw `Event type ${params.eventType} no current state set`
   }

--- a/test/mock/ccd/services/otherEventSubmitEvent.js
+++ b/test/mock/ccd/services/otherEventSubmitEvent.js
@@ -14,6 +14,8 @@ function getNextState(body) {
       return 'awaitingReasonsForAppeal';
     case 'editClarifyingQuestionAnswers':
       return 'awaitingClarifyingQuestionsAnswers'
+    case 'submitClarifyingQuestionAnswers':
+      return 'clarifyingQuestionsAnswersSubmitted';
     default:
       throw `Event type ${body.eventType} no next state set`
   }

--- a/test/unit/controllers/application-overview.test.ts
+++ b/test/unit/controllers/application-overview.test.ts
@@ -1,6 +1,5 @@
 import config from 'config';
 import { NextFunction, Request, Response } from 'express';
-import moment from 'moment';
 import {
   getAppealRefNumber,
   getApplicationOverview,
@@ -10,7 +9,6 @@ import { paths } from '../../../app/paths';
 import { AuthenticationService } from '../../../app/service/authentication-service';
 import { CcdService } from '../../../app/service/ccd-service';
 import UpdateAppealService from '../../../app/service/update-appeal-service';
-import { dayMonthYearFormat } from '../../../app/utils/date-formats';
 import Logger from '../../../app/utils/logger';
 import { expect, sinon } from '../../utils/testUtils';
 import { expectedMultipleEventsData } from '../mockData/events/expectations';

--- a/test/unit/controllers/clarifying-questions/anything-else-answer.test.ts
+++ b/test/unit/controllers/clarifying-questions/anything-else-answer.test.ts
@@ -1,0 +1,105 @@
+import express, { NextFunction, Request, Response } from 'express';
+import { getAnythingElseAnswerPage, postAnythingElseAnswerPage, setupCQAnythingElseAnswerController } from '../../../../app/controllers/clarifying-questions/anything-else-answer';
+import { Events } from '../../../../app/data/events';
+import { paths } from '../../../../app/paths';
+import UpdateAppealService from '../../../../app/service/update-appeal-service';
+import i18n from '../../../../locale/en.json';
+import { expect, sinon } from '../../../utils/testUtils';
+
+describe('Clarifying Questions: Anything else answer controller', () => {
+  let sandbox: sinon.SinonSandbox;
+  let req: Partial<Request>;
+  let res: Partial<Response>;
+  let next: NextFunction;
+  let updateAppealService: Partial<UpdateAppealService>;
+  const clarifyingQuestions: ClarifyingQuestion<Evidence>[] = [
+    {
+      id: 'id1',
+      value: {
+        question: 'Tell us more about your children'
+      }
+    },
+    {
+      id: 'id2',
+      value: {
+        question: 'Tell us more about your health issues',
+        answer: 'an answer to the question'
+      }
+    }
+  ];
+
+  beforeEach(() => {
+    sandbox = sinon.createSandbox();
+    req = {
+      body: {},
+      params: {},
+      session: {
+        appeal: {
+          draftClarifyingQuestionsAnswers: [ ...clarifyingQuestions ]
+        }
+      }
+    } as Partial<Request>;
+    res = {
+      render: sandbox.stub(),
+      redirect: sandbox.spy()
+    } as Partial<Response>;
+    next = sandbox.stub() as NextFunction;
+    updateAppealService = { submitEvent: sandbox.stub() } as Partial<UpdateAppealService>;
+  });
+
+  afterEach(() => {
+    sandbox.restore();
+  });
+
+  describe('setupCQAnythingElseAnswerController', () => {
+    it('should setup the routes', () => {
+      const routerGetStub: sinon.SinonStub = sandbox.stub(express.Router as never, 'get');
+      const routerPostStub: sinon.SinonStub = sandbox.stub(express.Router as never, 'post');
+      const middleware: Middleware[] = [];
+
+      setupCQAnythingElseAnswerController(middleware, updateAppealService as UpdateAppealService);
+      expect(routerGetStub).to.have.been.calledWith(`${paths.awaitingClarifyingQuestionsAnswers.anythingElseAnswerPage}`);
+      expect(routerPostStub).to.have.been.calledWith(`${paths.awaitingClarifyingQuestionsAnswers.anythingElseAnswerPage}`);
+    });
+  });
+
+  describe('getAnythingElseAnswerPage', () => {
+    it('should render template', () => {
+      getAnythingElseAnswerPage(req as Request, res as Response, next);
+      expect(res.render).to.have.been.calledWith('templates/textarea-question-page.njk');
+    });
+
+    it('should catch error and call next with error', () => {
+      const error = new Error('an error');
+      res.render = sandbox.stub().throws(error);
+
+      getAnythingElseAnswerPage(req as Request, res as Response, next);
+      expect(next).to.have.been.calledOnce.calledWith(error);
+    });
+  });
+
+  describe('postAnythingElseAnswerPage', () => {
+    it('should fail validation and render template with errors', async () => {
+      await postAnythingElseAnswerPage(updateAppealService as UpdateAppealService)(req as Request, res as Response, next);
+
+      expect(res.render).to.have.been.calledWith('templates/textarea-question-page.njk');
+    });
+
+    it('should validate and redirect to questions list', async () => {
+      req.body['anything-else'] = 'the answer here';
+      await postAnythingElseAnswerPage(updateAppealService as UpdateAppealService)(req as Request, res as Response, next);
+
+      expect(updateAppealService.submitEvent).to.have.been.calledWith(Events.EDIT_CLARIFYING_QUESTION_ANSWERS, req);
+      expect(res.redirect).to.have.been.calledWith(paths.awaitingClarifyingQuestionsAnswers.questionsList);
+    });
+
+    it('should catch error and call next with error', async () => {
+      const error = new Error('an error');
+      res.render = sandbox.stub().throws(error);
+
+      await postAnythingElseAnswerPage(updateAppealService as UpdateAppealService)(req as Request, res as Response, next);
+      expect(next).to.have.been.calledOnce.calledWith(error);
+    });
+  });
+
+});

--- a/test/unit/controllers/clarifying-questions/anything-else-question.test.ts
+++ b/test/unit/controllers/clarifying-questions/anything-else-question.test.ts
@@ -1,0 +1,152 @@
+import express, { NextFunction, Request, Response } from 'express';
+import {
+  getAnythingElseQuestionPage,
+  postAnythingElseQuestionPage,
+  setupCQAnythingElseQuestionController
+} from '../../../../app/controllers/clarifying-questions/anything-else-question';
+import { Events } from '../../../../app/data/events';
+import { paths } from '../../../../app/paths';
+import { DocumentManagementService } from '../../../../app/service/document-management-service';
+import UpdateAppealService from '../../../../app/service/update-appeal-service';
+import i18n from '../../../../locale/en.json';
+import { expect, sinon } from '../../../utils/testUtils';
+
+describe('Clarifying Questions: Anything else question-page controller', () => {
+  let sandbox: sinon.SinonSandbox;
+  let req: Partial<Request>;
+  let res: Partial<Response>;
+  let next: NextFunction;
+  let updateAppealService: Partial<UpdateAppealService>;
+  let documentManagementService: Partial<DocumentManagementService>;
+  const clarifyingQuestions: ClarifyingQuestion<Evidence>[] = [
+    {
+      id: 'id1',
+      value: {
+        question: 'Tell us more about your children'
+      }
+    },
+    {
+      id: 'id2',
+      value: {
+        question: 'Tell us more about your health issues'
+      }
+    }
+  ];
+
+  beforeEach(() => {
+    sandbox = sinon.createSandbox();
+    req = {
+      body: {},
+      params: {},
+      session: {
+        appeal: {
+          draftClarifyingQuestionsAnswers: [ ...clarifyingQuestions ],
+          documentMap: [{
+            id: 'id2',
+            url: 'theDocumentUrl'
+          }]
+        } as Partial<Appeal>
+      }
+    } as Partial<Request>;
+    res = {
+      render: sandbox.stub(),
+      redirect: sandbox.spy()
+    } as Partial<Response>;
+    next = sandbox.stub() as NextFunction;
+    updateAppealService = { submitEvent: sandbox.stub() } as Partial<UpdateAppealService>;
+    documentManagementService = { deleteFile: sandbox.stub() } as Partial<DocumentManagementService>;
+  });
+
+  afterEach(() => {
+    sandbox.restore();
+  });
+
+  describe('setupCQAnythingElseQuestionController', () => {
+    it('should setup routes', () => {
+      const routerGetStub: sinon.SinonStub = sandbox.stub(express.Router as never, 'get');
+      const routerPostStub: sinon.SinonStub = sandbox.stub(express.Router as never, 'post');
+      const middleware: Middleware[] = [];
+
+      setupCQAnythingElseQuestionController(middleware, updateAppealService as UpdateAppealService, documentManagementService as DocumentManagementService);
+      expect(routerGetStub).to.have.been.calledWith(`${paths.awaitingClarifyingQuestionsAnswers.anythingElseQuestionPage}`);
+      expect(routerPostStub).to.have.been.calledWith(`${paths.awaitingClarifyingQuestionsAnswers.anythingElseQuestionPage}`);
+    });
+  });
+
+  describe('getAnythingElseQuestionPage', () => {
+    it('should render template page', () => {
+      const anythingElseQuestion: ClarifyingQuestion<Evidence> = req.session.appeal.draftClarifyingQuestionsAnswers[1];
+      const options = [
+        {
+          value: true,
+          text: 'Yes'
+        },
+        {
+          value: false,
+          text: 'No'
+        }
+      ];
+      getAnythingElseQuestionPage(req as Request, res as Response, next);
+
+      expect(res.render).to.have.been.calledWith('templates/radio-question-page.njk',
+        {
+          previousPage: paths.awaitingClarifyingQuestionsAnswers.questionsList,
+          pageTitle: anythingElseQuestion.value.question,
+          formAction: paths.awaitingClarifyingQuestionsAnswers.anythingElseQuestionPage,
+          question: {
+            title: anythingElseQuestion.value.question,
+            hint: i18n.pages.clarifyingQuestionAnythingElseQuestion.hint,
+            options
+          }
+        }
+      );
+    });
+
+    it('should catch error and call next with error', () => {
+      const error = new Error('an error');
+      res.render = sandbox.stub().throws(error);
+
+      getAnythingElseQuestionPage(req as Request, res as Response, next);
+      expect(next).to.have.been.calledOnce.calledWith(error);
+    });
+  });
+
+  describe('postAnythingElseQuestionPage @only', () => {
+    it('should fail validation and render template with errors', async () => {
+      await postAnythingElseQuestionPage(updateAppealService as UpdateAppealService, documentManagementService as DocumentManagementService)(req as Request, res as Response, next);
+
+      expect(res.render).to.have.been.calledWith('templates/radio-question-page.njk');
+    });
+
+    it('should validate and redirect to answer page if appellant answer yes', async () => {
+      req.body['answer'] = 'true';
+      await postAnythingElseQuestionPage(updateAppealService as UpdateAppealService, documentManagementService as DocumentManagementService)(req as Request, res as Response, next);
+
+      expect(res.redirect).to.have.been.calledWith(paths.awaitingClarifyingQuestionsAnswers.anythingElseAnswerPage);
+    });
+
+    it('should validate and redirect to questions list page', async () => {
+      const evidences: Evidence[] = [
+        {
+          fileId: 'aFileId',
+          name: 'fileName'
+        }
+      ];
+      req.session.appeal.draftClarifyingQuestionsAnswers[1].value.supportingEvidence = [ ...evidences ];
+      req.body['answer'] = 'false';
+      await postAnythingElseQuestionPage(updateAppealService as UpdateAppealService, documentManagementService as DocumentManagementService)(req as Request, res as Response, next);
+
+      expect(documentManagementService.deleteFile).to.have.been.calledOnce;
+      expect(updateAppealService.submitEvent).to.have.been.calledWith(Events.EDIT_CLARIFYING_QUESTION_ANSWERS, req);
+      expect(res.redirect).to.have.been.calledWith(paths.awaitingClarifyingQuestionsAnswers.questionsList);
+    });
+
+    it('should catch error and call next with error', async () => {
+      const error = new Error('an error');
+      res.render = sandbox.stub().throws(error);
+
+      await postAnythingElseQuestionPage(updateAppealService as UpdateAppealService, documentManagementService as DocumentManagementService)(req as Request, res as Response, next);
+      expect(next).to.have.been.calledOnce.calledWith(error);
+    });
+  });
+});

--- a/test/unit/controllers/clarifying-questions/check-and-send.test.ts
+++ b/test/unit/controllers/clarifying-questions/check-and-send.test.ts
@@ -1,0 +1,137 @@
+import express, { NextFunction, Request, Response } from 'express';
+import {
+  buildEvidencesList,
+  getCheckAndSendPage,
+  postCheckAndSendPage,
+  setupClarifyingQuestionsCheckSendController
+} from '../../../../app/controllers/clarifying-questions/check-and-send';
+import { Events } from '../../../../app/data/events';
+import { paths } from '../../../../app/paths';
+import UpdateAppealService from '../../../../app/service/update-appeal-service';
+import i18n from '../../../../locale/en.json';
+import { expect, sinon } from '../../../utils/testUtils';
+
+import * as summaryListUtils from '../../../../app/utils/summary-list';
+
+describe('Clarifying Questions Check and Send controller', () => {
+  let sandbox: sinon.SinonSandbox;
+  let req: Partial<Request>;
+  let res: Partial<Response>;
+  let next: NextFunction;
+  let updateAppealService: Partial<UpdateAppealService>;
+  let addSummaryRowStub: sinon.SinonStub;
+  const clarifyingQuestions: ClarifyingQuestion<Evidence>[] = [
+    {
+      id: 'id1',
+      value: {
+        question: 'Tell us more about your children'
+      }
+    },
+    {
+      id: 'id2',
+      value: {
+        question: 'Tell us more about your health issues',
+        answer: 'an answer to the question'
+      }
+    }
+  ];
+
+  beforeEach(() => {
+    sandbox = sinon.createSandbox();
+    req = {
+      body: {},
+      params: {},
+      session: {
+        appeal: {
+          draftClarifyingQuestionsAnswers: [ ...clarifyingQuestions ],
+          clarifyingQuestionsAnswers: null
+        }
+      }
+    } as Partial<Request>;
+    res = {
+      render: sandbox.stub(),
+      redirect: sandbox.spy()
+    } as Partial<Response>;
+    next = sandbox.stub() as NextFunction;
+    updateAppealService = { submitEvent: sandbox.stub().returns({ state: 'newState' }) } as Partial<UpdateAppealService>;
+    addSummaryRowStub = sandbox.stub(summaryListUtils, 'addSummaryRow');
+  });
+
+  afterEach(() => {
+    sandbox.restore();
+  });
+
+  describe('setupClarifyingQuestionsCheckSendController', () => {
+    it('should setup the routes', () => {
+      const routerGetStub: sinon.SinonStub = sandbox.stub(express.Router as never, 'get');
+      const routerPostStub: sinon.SinonStub = sandbox.stub(express.Router as never, 'post');
+      const middleware: Middleware[] = [];
+
+      setupClarifyingQuestionsCheckSendController(middleware, updateAppealService as UpdateAppealService);
+      expect(routerGetStub).to.have.been.calledWith(`${paths.awaitingClarifyingQuestionsAnswers.checkAndSend}`);
+      expect(routerPostStub).to.have.been.calledWith(`${paths.awaitingClarifyingQuestionsAnswers.checkAndSend}`);
+    });
+  });
+
+  describe('getCheckAndSendPage', () => {
+    it('should render CYA template page', () => {
+      getCheckAndSendPage(req as Request, res as Response, next);
+      expect(res.render).to.have.been.calledWith('templates/check-and-send.njk');
+    });
+
+    it('should render CYA template page with evidences', () => {
+      const evidences: Evidence[] = [
+        {
+          fileId: 'aFileId',
+          name: 'fileName'
+        }
+      ];
+      req.session.appeal.draftClarifyingQuestionsAnswers[0].value.supportingEvidence = [ ...evidences ];
+      req.session.appeal.draftClarifyingQuestionsAnswers[1].value.supportingEvidence = [ ...evidences ];
+      const evidenceList = buildEvidencesList(evidences);
+      getCheckAndSendPage(req as Request, res as Response, next);
+
+      expect(addSummaryRowStub.thirdCall).to.have.been.calledWith(
+        i18n.common.cya.supportingEvidenceRowTitle,
+        evidenceList,
+        paths.awaitingClarifyingQuestionsAnswers.supportingEvidenceUploadFile.replace(':id', `1`),
+        '<br>'
+      );
+      expect(addSummaryRowStub.getCall(4)).to.have.been.calledWith(
+        i18n.common.cya.supportingEvidenceRowTitle,
+        evidenceList,
+        '',
+        '<br>'
+      );
+      expect(res.render).to.have.been.calledWith('templates/check-and-send.njk');
+    });
+
+    it('should call next with error', () => {
+      const error = new Error('an error');
+      res.render = sandbox.stub().throws(error);
+
+      getCheckAndSendPage(req as Request, res as Response, next);
+      expect(next).to.have.been.calledOnce.calledWith(error);
+    });
+  });
+
+  describe('postCheckAndSendPage', () => {
+    it('should submit CQ and redirect to confirmation page', async () => {
+      await postCheckAndSendPage(updateAppealService as UpdateAppealService)(req as Request, res as Response, next);
+
+      expect(req.session.appeal.clarifyingQuestionsAnswers).to.eql(clarifyingQuestions);
+      expect(req.session.appeal.draftClarifyingQuestionsAnswers).to.be.undefined;
+      expect(updateAppealService.submitEvent).to.have.been.calledWith(Events.SUBMIT_CLARIFYING_QUESTION_ANSWERS, req);
+      expect(req.session.appeal.appealStatus).to.be.equal('newState');
+      expect(res.redirect).to.have.been.calledWith(paths.clarifyingQuestionsAnswersSubmitted.confirmation);
+    });
+
+    it('should catch error and call next with error', async () => {
+      const error = new Error('an error');
+      res.redirect = sandbox.stub().throws(error);
+
+      await postCheckAndSendPage(updateAppealService as UpdateAppealService)(req as Request, res as Response, next);
+      expect(next).to.have.been.calledOnce.calledWith(error);
+    });
+  });
+});

--- a/test/unit/controllers/clarifying-questions/confirmation-page.test.ts
+++ b/test/unit/controllers/clarifying-questions/confirmation-page.test.ts
@@ -1,0 +1,56 @@
+import express, { NextFunction, Request, Response } from 'express';
+import { getConfirmationPage, setupClarifyingQuestionsConfirmationPage } from '../../../../app/controllers/clarifying-questions/confirmation-page';
+import { paths } from '../../../../app/paths';
+import { expect, sinon } from '../../../utils/testUtils';
+
+describe('ClarifyingQuestions Confirmation Controller', () => {
+  let sandbox: sinon.SinonSandbox;
+  let req: Partial<Request>;
+  let res: Partial<Response>;
+  let next: NextFunction;
+
+  beforeEach(() => {
+    sandbox = sinon.createSandbox();
+    req = {
+      body: {},
+      params: {},
+      session: {
+        appeal: {}
+      }
+    } as Partial<Request>;
+    res = {
+      render: sandbox.stub(),
+      redirect: sandbox.spy()
+    } as Partial<Response>;
+    next = sandbox.stub() as NextFunction;
+  });
+
+  afterEach(() => {
+    sandbox.restore();
+  });
+
+  describe('setupClarifyingQuestionsConfirmationPage', () => {
+    it('should set the routes', () => {
+      const routerGetStub: sinon.SinonStub = sandbox.stub(express.Router as never, 'get');
+      const middleware: Middleware[] = [];
+
+      setupClarifyingQuestionsConfirmationPage(middleware);
+      expect(routerGetStub).to.have.been.calledWith(`${paths.clarifyingQuestionsAnswersSubmitted.confirmation}`);
+    });
+  });
+
+  describe('getConfirmationPage', () => {
+    it('should render CYA template', () => {
+      getConfirmationPage(req as Request, res as Response, next);
+      expect(res.render).to.have.been.calledWith('templates/confirmation-page.njk');
+    });
+
+    it('should call next with error', () => {
+      const error = new Error('an error');
+      res.render = sandbox.stub().throws(error);
+
+      getConfirmationPage(req as Request, res as Response, next);
+      expect(next).to.have.been.calledOnce.calledWith(error);
+    });
+  });
+});

--- a/test/unit/controllers/clarifying-questions/questions-list.test.ts
+++ b/test/unit/controllers/clarifying-questions/questions-list.test.ts
@@ -64,8 +64,10 @@ describe('Questions-list controller', () => {
         'clarifying-questions/questions-list.njk',
         {
           previousPage: paths.common.overview,
-          questions: [ ...clarifyingQuestions ],
-          questionsCompleted: false
+          questions: [ clarifyingQuestions[0] ],
+          questionsCompleted: false,
+          anythingElseQuestion: clarifyingQuestions[1],
+          anythingElseCompleted: false
         }
       );
     });
@@ -87,8 +89,10 @@ describe('Questions-list controller', () => {
         'clarifying-questions/questions-list.njk',
         {
           previousPage: paths.common.overview,
-          questions: [ ...questionsAnswered ],
-          questionsCompleted: true
+          questions: [ questionsAnswered[0] ],
+          questionsCompleted: true,
+          anythingElseQuestion: questionsAnswered[1],
+          anythingElseCompleted: true
         }
       );
     });

--- a/test/unit/controllers/confirmation-page.test.ts
+++ b/test/unit/controllers/confirmation-page.test.ts
@@ -1,10 +1,10 @@
 import { NextFunction, Request, Response } from 'express';
 import {
-  daysToWaitUntilContact,
   getConfirmationPage,
   setConfirmationController
 } from '../../../app/controllers/appeal-application/confirmation-page';
 import { paths } from '../../../app/paths';
+import { addDaysToDate } from '../../../app/utils/date-utils';
 import Logger from '../../../app/utils/logger';
 import { expect, sinon } from '../../utils/testUtils';
 
@@ -96,7 +96,7 @@ describe('Confirmation Page Controller', () => {
 
     getConfirmationPage(req as Request, res as Response, next);
     expect(res.render).to.have.been.calledOnce.calledWith('confirmation-page.njk', {
-      date: daysToWaitUntilContact(28),
+      date: addDaysToDate(28),
       late: true
     });
   });

--- a/test/unit/controllers/reasons-for-appeal/confirmation-page.test.ts
+++ b/test/unit/controllers/reasons-for-appeal/confirmation-page.test.ts
@@ -1,11 +1,11 @@
 import { NextFunction, Request, Response } from 'express';
-import { daysToWaitUntilContact } from '../../../../app/controllers/appeal-application/confirmation-page';
 import {
   getConfirmationPage,
   setupReasonsForAppealController
 } from '../../../../app/controllers/reasons-for-appeal/reason-for-appeal';
 import { paths } from '../../../../app/paths';
 import UpdateAppealService from '../../../../app/service/update-appeal-service';
+import { addDaysToDate } from '../../../../app/utils/date-utils';
 import Logger from '../../../../app/utils/logger';
 import { expect, sinon } from '../../../utils/testUtils';
 
@@ -65,7 +65,7 @@ describe('Confirmation Page Controller', () => {
   it('getConfirmationPage should render confirmation.njk', () => {
     getConfirmationPage(req as Request, res as Response, next);
     expect(res.render).to.have.been.calledOnce.calledWith('reasons-for-appeal/confirmation-page.njk', {
-      date: daysToWaitUntilContact(14)
+      date: addDaysToDate(14)
     });
   });
 

--- a/types/caseData.d.ts
+++ b/types/caseData.d.ts
@@ -45,6 +45,7 @@ interface CaseData {
   draftClarifyingQuestionsAnswers: ClarifyingQuestion<Collection<SupportingDocument>>[];
   submitTimeExtensionReason?: string;
   submitTimeExtensionEvidence?: TimeExtensionEvidenceCollection[];
+  clarifyingQuestionsAnswers: ClarifyingQuestion<Collection<SupportingDocument>>[];
 }
 
 interface Collection<T> {

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -77,6 +77,7 @@ interface Appeal {
   timeExtensionEventsMap?: TimeExtensionEventMap[];
   directions?: Direction[];
   draftClarifyingQuestionsAnswers?: ClarifyingQuestion<Evidence>[];
+  clarifyingQuestionsAnswers?:  ClarifyingQuestion<Evidence>[];
 }
 
 interface AskForMoreTime {
@@ -201,7 +202,7 @@ interface Direction {
 }
 
 interface ClarifyingQuestion<T> {
-  id: string;
+  id?: string;
   value: {
     question: string;
     answer?: string;

--- a/views/clarifying-questions/questions-list.njk
+++ b/views/clarifying-questions/questions-list.njk
@@ -26,9 +26,14 @@
       <ul class="govuk-list">
         <li class="govuk-!-font-size-24 task-list__item">
           {% if questionsCompleted %}
-            <a href={{ paths.awaitingClarifyingQuestionsAnswers.anythingElse }}>{{ i18n.pages.clarifyingQuestionsList.sections.otherInformation.itemTitle }}</a>
+            <a href="{{ paths.awaitingClarifyingQuestionsAnswers.anythingElseQuestionPage }}">{{ anythingElseQuestion.value.question }}</a>
+            {% if anythingElseQuestion.value.answer %}
+              {{ govukTag({
+                  text: "SAVED"
+              }) }}
+            {% endif %}
           {% else %}
-            {{ i18n.pages.clarifyingQuestionsList.sections.otherInformation.itemTitle }}
+            {{ anythingElseQuestion.value.question }}
           {% endif %}
         </li>
       </ul>
@@ -37,7 +42,7 @@
       <h2 class="govuk-heading-m">{{ i18n.pages.clarifyingQuestionsList.sections.checkAndSend.header }}</h2>
       <ul class="govuk-list">
         <li class="govuk-!-font-size-24 task-list__item">
-          {% if questionsCompleted and false %}
+          {% if questionsCompleted and anythingElseCompleted %}
             <a href={{ paths.awaitingClarifyingQuestionsAnswers.checkAndSend }}>{{ i18n.pages.clarifyingQuestionsList.sections.checkAndSend.itemTitle }}</a>
           {% else %}
             {{ i18n.pages.clarifyingQuestionsList.sections.checkAndSend.itemTitle }}

--- a/views/components/summary-list.njk
+++ b/views/components/summary-list.njk
@@ -1,0 +1,50 @@
+{% macro govukSummaryList(params) %}
+  {%- macro _actionLink(action) %}
+    <a class="govuk-link {%- if action.classes %} {{ action.classes }}{% endif %}" href="{{ action.href }}" {%- for attribute, value in action.attributes %} {{attribute}}="{{value}}"{% endfor %}>
+      {{ action.html | safe if action.html else action.text }}
+      {%- if action.visuallyHiddenText -%}
+        <span class="govuk-visually-hidden"> {{ action.visuallyHiddenText }}</span>
+      {% endif -%}
+    </a>
+  {% endmacro -%}
+
+  {# Determine if we need 2 or 3 columns #}
+  {% set anyRowHasActions = false %}
+  {% for row in params.rows %}
+    {% set anyRowHasActions = true if row.actions.items | length else anyRowHasActions %}
+  {% endfor -%}
+
+  <dl class="govuk-summary-list {%- if params.classes %} {{ params.classes }}{% endif %}"{% for attribute, value in params.attributes %} {{attribute}}="{{value}}"{% endfor %}>
+    {% for row in params.rows %}
+      {% if row %}
+        <div class="govuk-summary-list__row {%- if row.classes %} {{ row.classes }}{% endif %}">
+          <dt class="govuk-summary-list__key {%- if row.key.classes %} {{ row.key.classes }}{% endif %}">
+            {{ row.key.html | trim | safe if row.key.html else row.key.text }}
+          </dt>
+          <dd class="govuk-summary-list__value {%- if row.value.classes %} {{ row.value.classes }}{% endif %}">
+            {{ row.value.html | trim | safe if row.value.html else row.value.text }}
+          </dd>
+          {% if row.actions.items.length %}
+            <dd class="govuk-summary-list__actions {%- if row.actions.classes %} {{ row.actions.classes }}{% endif %}">
+              {% if row.actions.items.length == 1 %}
+                {{ _actionLink(row.actions.items[0]) | indent(12) | trim }}
+              {% else %}
+                <ul class="govuk-summary-list__actions-list">
+                  {% for action in row.actions.items %}
+                    <li class="govuk-summary-list__actions-list-item">
+                      {{ _actionLink(action) | indent(18) | trim }}
+                    </li>
+                  {% endfor %}
+                </ul>
+              {% endif %}
+            </dd>
+          {% elseif anyRowHasActions %}
+            {# Add dummy column to extend border #}
+            <span class="govuk-summary-list__actions"></span>
+          {% endif %}
+        </div>
+      {% endif %}
+    {% endfor %}
+  </dl>
+
+{% endmacro %}

--- a/views/layout.njk
+++ b/views/layout.njk
@@ -23,17 +23,17 @@
   {% endif %}
 {% endmacro %}
 
-{% macro saveButtons() %}
+{% macro saveButtons(button1, button2) %}
   <div class="save-buttons__container">
     {{ govukButton({
-      name: 'saveAndContinue',
-      text: i18n.common.buttons.saveAndContinue,
+      name: button1.name if button1.name else 'saveAndContinue',
+      text: button1.text if button1.text else i18n.common.buttons.saveAndContinue,
       classes: "govuk-!-margin-right-1"
     }) }}
 
     {{ govukButton({
-      text: i18n.common.buttons.saveForLater,
-      name: "saveForLater",
+      text: button2.text if button2.text else i18n.common.buttons.saveForLater,
+      name: button2.name if button2.name else "saveForLater",
       value: "saveForLater",
       classes: "govuk-button--secondary"
     }) }}

--- a/views/templates/check-and-send.njk
+++ b/views/templates/check-and-send.njk
@@ -1,0 +1,31 @@
+{% set pageTitleName = pageTitle %}
+{% extends "layout.njk" %}
+{% from "components/summary-list.njk" import govukSummaryList %}
+
+{% block content %}
+  {% if errorList %}
+    {{ govukErrorSummary({
+      titleText: i18n.validationErrors.errorSummary,
+      errorList: errorList
+    }) }}
+  {% endif %}
+
+  <h1 class="govuk-heading-xl">{{ pageTitle }}</h1>
+
+  {% for summaryList in summaryLists %}
+    {% if summaryList.title %}
+      <h2 class="govuk-heading-l">{{ summaryList.title }}</h2>
+    {% endif %}
+    {{ govukSummaryList({
+      rows: summaryList.summaryRows
+    }) }}
+  {% endfor %}
+
+  {% if formAction %}
+    <form method="post" action="{{ formAction }}">
+      <input type="hidden" name="_csrf" value="{{ csrfToken }}">
+      {{ saveButtons({name: 'send', text: 'Send'}) }}
+    </form>
+  {% endif %}
+  {{ contactUs() }}
+{% endblock %}

--- a/views/templates/confirmation-page.njk
+++ b/views/templates/confirmation-page.njk
@@ -1,0 +1,22 @@
+{% extends "layout.njk" %}
+{% from "govuk/components/panel/macro.njk" import govukPanel %}
+{% set pageTitleName = title %}
+
+{% block content %}
+  {{ govukPanel({
+    titleText: title,
+    classes: mainClasses
+  }) }}
+  <h2 class="govuk-heading-m">{{ i18n.pages.successPage.whatHappensNext }}</h2>
+  <div>
+    <ul class="govuk-list govuk-list--bullet">
+      {% for item in whatNextListItems %}
+        <li>{{ item | eval | safe }}</li>
+      {% endfor %}
+    </ul>
+  {{ govukButton({
+    text: i18n.pages.successPage.seeProgress,
+    href: paths.common.overview
+  }) }}
+  {{ contactUs() }}
+{% endblock %}

--- a/views/templates/radio-question-page.njk
+++ b/views/templates/radio-question-page.njk
@@ -1,0 +1,28 @@
+{% set pageTitleName = pageTitle %}
+{% from "components/radio-button-question.njk" import radioButtonQuestion %}
+
+{% extends "layout.njk" %}
+
+{% block content %}
+  {% if errorList %}
+    {{ govukErrorSummary({
+      titleText: i18n.error.summary.title,
+      descriptionText: i18n.error.summary.descriptionText,
+      errorList: errorList
+    }) }}
+  {% endif %}
+  <form action="{{ formAction }}" method="post">
+    <input type="hidden" name="_csrf" value="{{ csrfToken }}">
+    {{ radioButtonQuestion(
+        question.name or 'answer',
+        question.options,
+        question.title,
+        question.titleIsheading or true,
+        question.hint,
+        error[question.name].text
+      )
+    }}
+    {{ continueButton() }}
+  </form>
+  {{ contactUs() }}
+{% endblock %}

--- a/views/templates/textarea-question-page.njk
+++ b/views/templates/textarea-question-page.njk
@@ -1,0 +1,73 @@
+{% set pageTitleName = pageTitle %}
+{% extends "layout.njk" %}
+{% from "govuk/components/fieldset/macro.njk" import govukFieldset %}
+{% from "govuk/components/textarea/macro.njk" import govukTextarea %}
+
+{% block content %}
+  {% if errorList %}
+    {{ govukErrorSummary({
+      titleText: i18n.validationErrors.errorSummary,
+      errorList: errorList
+    }) }}
+  {% endif %}
+  <form action={{ formAction }} method='post'>
+    <input type="hidden" name="_csrf" value="{{ csrfToken }}">
+    {% call govukFieldset({
+    legend: {
+      text: question.title,
+      classes: "govuk-fieldset__legend--l",
+      isPageHeading: true
+    }
+    }) %}
+
+      {{ govukTextarea({
+        name: question.name,
+        id: question.name,
+        label: {
+          text: question.description
+        } if (question.description),
+        hint: {
+          text: question.hint
+        } if (question.hint),
+        value: question.value,
+        errorMessage: {
+          text: errors[question.name].text
+        } if errors[question.name]
+      }) }}
+
+      {% set supportingEvidenceContent %}
+        <h2 class="govuk-heading-s">
+          {{ i18n.pages.clarifyingQuestionPage.panel.supportingEvidence }}
+        </h2>
+        <p>{{ i18n.pages.clarifyingQuestionPage.panel.ableToAddEvidence }}</p>
+      {% endset %}
+
+      {% set timeExtensionContent %}
+        <h2 class="govuk-heading-s">
+          {{ i18n.pages.clarifyingQuestionPage.panel.needMoreTime }}
+        </h2>
+        <ul class="govuk-list govuk-list--bullet">
+          <li>
+            <a href={{ paths.common.askForMoreTime }} class="govuk-link">
+              {{ i18n.pages.clarifyingQuestionPage.panel.saveAndAskMoreTime }}
+            </a>
+          </li>
+        </ul>
+      {% endset %}
+
+      {% if supportingEvidence or timeExtensionAllowed %}
+        <div class="panel-background">
+          {% if supportingEvidence %}
+            {{ supportingEvidenceContent | safe }}
+          {% endif %}
+          {% if timeExtensionAllowed %}
+            {{ timeExtensionContent | safe }}
+          {% endif %}
+        </div>
+      {% endif %}
+
+      {{ saveButtons() }}
+    {% endcall %}
+  </form>
+  {{ contactUs() }}
+{% endblock %}


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/RIA-2312


### Change description ###
- Added 'anything else' question for Clarifying questions
- questions list page amends to open 'anything else' and 'cya' sections
- Added CYA page for CQ
- CQ can now be submitted and visible on CCD
- Added confirmation page once CQ have been submitted


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ X ] No
```
