### PR TITLE
RIA-2976 & RIA-3153 & RIA-3157: Time Extensions for CMARequirements & Clarifying Questions

### DIFF
--- a/app/controllers/ask-for-more-time/ask-for-more-time.ts
+++ b/app/controllers/ask-for-more-time/ask-for-more-time.ts
@@ -163,7 +163,10 @@ function postCheckAndSend(updateAppealService: UpdateAppealService) {
     try {
       req.session.appeal.askForMoreTime.reviewTimeExtensionRequired = 'Yes';
       await updateAppealService.submitEvent(Events.SUBMIT_TIME_EXTENSION, req);
-      req.session.appeal.askForMoreTime = {};
+
+      req.session.appeal.askForMoreTime = {
+        inFlight: true
+      };
 
       res.redirect(paths.common.askForMoreTime.confirmation);
     } catch (e) {

--- a/app/data/states.ts
+++ b/app/data/states.ts
@@ -18,5 +18,9 @@ export const States = {
   REASONS_FOR_APPEAL_SUBMITTED: {
     id: 'reasonsForAppealSubmitted',
     name: 'Reasons for appeal submitted'
+  },
+  AWAITING_CLARIFYING_QUESTIONS: {
+    id: 'awaitingClarifyingQuestionsAnswers',
+    name: 'Awaiting Clarifying Questions'
   }
 };

--- a/app/service/update-appeal-service.ts
+++ b/app/service/update-appeal-service.ts
@@ -58,7 +58,7 @@ export default class UpdateAppealService {
     const subscriptions = caseData.subscriptions || [];
     let outOfTimeAppeal: LateAppeal = null;
     let respondentDocuments: RespondentDocument[] = null;
-    let timeExtensions: TimeExtension[] = null;
+    let timeExtensions: TimeExtension[] = [];
     let directions: Direction[] = null;
     let reasonsForAppealDocumentUploads: Evidence[] = null;
     let requestClarifyingQuestionsDirection;

--- a/app/service/update-appeal-service.ts
+++ b/app/service/update-appeal-service.ts
@@ -162,19 +162,19 @@ export default class UpdateAppealService {
         timeExtensions.push(timeExt);
 
       });
+    }
 
-      if (caseData.directions) {
-        directions = caseData.directions.map(d => {
-          return {
-            id: d.id,
-            tag: d.value.tag,
-            parties: d.value.parties,
-            dateDue: d.value.dateDue,
-            dateSent: d.value.dateSent
-          } as Direction;
-        });
-        requestClarifyingQuestionsDirection = caseData.directions.find(direction => direction.value.tag === 'requestClarifyingQuestions');
-      }
+    if (caseData.directions) {
+      directions = caseData.directions.map(d => {
+        return {
+          id: d.id,
+          tag: d.value.tag,
+          parties: d.value.parties,
+          dateDue: d.value.dateDue,
+          dateSent: d.value.dateSent
+        } as Direction;
+      });
+      requestClarifyingQuestionsDirection = caseData.directions.find(direction => direction.value.tag === 'requestClarifyingQuestions');
     }
 
     if (requestClarifyingQuestionsDirection && ccdCase.state === 'awaitingClarifyingQuestionsAnswers') {

--- a/app/service/update-appeal-service.ts
+++ b/app/service/update-appeal-service.ts
@@ -240,7 +240,10 @@ export default class UpdateAppealService {
       timeExtensions: timeExtensions,
       draftClarifyingQuestionsAnswers
     };
-    req.session.appeal.askForMoreTime = {};
+
+    req.session.appeal.askForMoreTime = {
+      inFlight: hasInflightTimeExtension
+    };
   }
 
   private getDate(ccdDate): AppealDate {

--- a/app/service/update-appeal-service.ts
+++ b/app/service/update-appeal-service.ts
@@ -63,6 +63,7 @@ export default class UpdateAppealService {
     let reasonsForAppealDocumentUploads: Evidence[] = null;
     let requestClarifyingQuestionsDirection;
     let draftClarifyingQuestionsAnswers: ClarifyingQuestion<Evidence>[];
+    let hasInflightTimeExtension = false;
 
     const appellantContactDetails = subscriptions.reduce((contactDetails, subscription) => {
       const value = subscription.value;
@@ -132,6 +133,10 @@ export default class UpdateAppealService {
       timeExtensions = [];
 
       caseData.timeExtensions.forEach(timeExtension => {
+        if (timeExtension.value.status === 'submitted' && timeExtension.value.state === ccdCase.state) {
+          hasInflightTimeExtension = true;
+        }
+
         let timeExt: TimeExtension = {
           id: timeExtension.id,
           requestDate: timeExtension.value.requestDate,
@@ -232,6 +237,7 @@ export default class UpdateAppealService {
     };
 
     req.session.appeal.askForMoreTime = {};
+    req.session.appeal.askForMoreTime.inFlight = hasInflightTimeExtension;
   }
 
   private getDate(ccdDate): AppealDate {

--- a/app/utils/application-state-utils.ts
+++ b/app/utils/application-state-utils.ts
@@ -3,6 +3,7 @@ import _ from 'lodash';
 import i18n from '../../locale/en.json';
 import { paths } from '../paths';
 import { getDeadline } from './event-deadline-date-finder';
+import { hasInflightTimeExtension } from './utils';
 
 const APPEAL_STATE = {
   'appealStarted': {
@@ -151,6 +152,11 @@ function getAppealApplicationNextStep(req: Request) {
   }
 
   let doThisNextSection = APPEAL_STATE[currentAppealStatus];
+
+  // Override if the user is allowed to ask for more time if it has an in-flight time extension already
+  if (_.get(doThisNextSection, 'allowedAskForMoreTime', false)) {
+    doThisNextSection.allowedAskForMoreTime = !hasInflightTimeExtension(req.session.appeal);
+  }
 
   // Added the following to avoid app crashing on events that are to be implemented.
   if (doThisNextSection === undefined) {

--- a/app/utils/application-state-utils.ts
+++ b/app/utils/application-state-utils.ts
@@ -157,11 +157,6 @@ function getAppealApplicationNextStep(req: Request) {
 
   let doThisNextSection = APPEAL_STATE[currentAppealStatus];
 
-  // Override if the user is allowed to ask for more time if it has an in-flight time extension already
-  if (_.get(doThisNextSection, 'allowedAskForMoreTime', false)) {
-    doThisNextSection.allowedAskForMoreTime = !hasInflightTimeExtension(req.session.appeal);
-  }
-
   // Added the following to avoid app crashing on events that are to be implemented.
   if (doThisNextSection === undefined) {
     doThisNextSection = {

--- a/app/utils/application-state-utils.ts
+++ b/app/utils/application-state-utils.ts
@@ -110,10 +110,14 @@ const APPEAL_STATE = {
     descriptionParagraphs: [
       i18n.pages.overviewPage.doThisNext.clarifyingQuestions.description
     ],
+    descriptionParagraphsAskForMoreTime: [
+      i18n.pages.overviewPage.doThisNext.clarifyingQuestions.descriptionAskForMoreTime
+    ],
     info: null,
     cta: {
       url: paths.awaitingClarifyingQuestionsAnswers.questionsList,
-      respondByText: i18n.pages.overviewPage.doThisNext.clarifyingQuestions.respondByText
+      respondByText: i18n.pages.overviewPage.doThisNext.clarifyingQuestions.respondByText,
+      respondByTextAskForMoreTime: i18n.pages.overviewPage.doThisNext.clarifyingQuestions.respondByTextAskForMoreTime
     },
     allowedAskForMoreTime: true
   }

--- a/app/utils/application-state-utils.ts
+++ b/app/utils/application-state-utils.ts
@@ -3,7 +3,6 @@ import _ from 'lodash';
 import i18n from '../../locale/en.json';
 import { paths } from '../paths';
 import { getDeadline } from './event-deadline-date-finder';
-import { hasInflightTimeExtension } from './utils';
 
 const APPEAL_STATE = {
   'appealStarted': {

--- a/app/utils/timeline-utils.ts
+++ b/app/utils/timeline-utils.ts
@@ -94,7 +94,7 @@ async function getAppealApplicationHistory(req: Request, updateAppealService: Up
   const appealDetailsSection = [ Events.SUBMIT_APPEAL ];
 
   return {
-    appealArgumentSection: constructSection(appealArgumentSection, history, [ States.REASONS_FOR_APPEAL_SUBMITTED, States.AWAITING_REASONS_FOR_APPEAL ], req),
+    appealArgumentSection: constructSection(appealArgumentSection, history, [ States.REASONS_FOR_APPEAL_SUBMITTED, States.AWAITING_REASONS_FOR_APPEAL, States.AWAITING_CLARIFYING_QUESTIONS ], req),
     appealDetailsSection: constructSection(appealDetailsSection, history, null, req)
   };
 }

--- a/app/utils/utils.ts
+++ b/app/utils/utils.ts
@@ -1,3 +1,4 @@
+import _ from 'lodash';
 import nl2br from 'nl2br';
 
 /**
@@ -36,14 +37,8 @@ export function nowAppealDate(): AppealDate {
   } as AppealDate;
 }
 
-export function hasInflightTimeExtension(appeal: Appeal) {
-  if (appeal.timeExtensions) {
-    return appeal.timeExtensions.filter(askForMoreTime => {
-      return askForMoreTime.status === 'submitted' &&
-        askForMoreTime.state === appeal.appealStatus;
-    }).length > 0;
-  }
-  return false;
+export function hasInflightTimeExtension(appeal: Appeal): boolean {
+  return _.get(appeal, 'askForMoreTime.inFlight', false);
 }
 
 export function formatTextForCYA(text: string) {

--- a/locale/en.json
+++ b/locale/en.json
@@ -353,6 +353,8 @@
         },
         "clarifyingQuestions": {
           "description": "You need to answer some questions about your appeal.",
+          "descriptionAskForMoreTime": "You might not get more time. You should still try to answer the Tribunal’s question by <span class=\"govuk-!-font-weight-bold\">{{ applicationNextStep.deadline }}</span> if you can.",
+          "respondByTextAskForMoreTime": "It’s important to respond by the deadline but, if you can’t answer fully, you will be able to provide more information about your appeal later.",
           "respondByText": "You need to respond by {{ applicationNextStep.deadline }}."
         }
       },

--- a/locale/en.json
+++ b/locale/en.json
@@ -353,6 +353,8 @@
         },
         "clarifyingQuestions": {
           "description": "You need to answer some questions about your appeal.",
+          "descriptionAskForMoreTime": "You might not get more time. You should still try to answer the Tribunal’s questions by <span class=\"govuk-!-font-weight-bold\">{{ applicationNextStep.deadline }}</span> if you can.",
+          "respondByTextAskForMoreTime": "It’s important to respond by the deadline but, if you can’t answer fully, you will be able to provide more information about your appeal later.",
           "respondByText": "You need to respond by {{ applicationNextStep.deadline }}."
         },
         "awaitingCmaRequirements": {

--- a/locale/en.json
+++ b/locale/en.json
@@ -353,7 +353,7 @@
         },
         "clarifyingQuestions": {
           "description": "You need to answer some questions about your appeal.",
-          "descriptionAskForMoreTime": "You might not get more time. You should still try to answer the Tribunal’s question by <span class=\"govuk-!-font-weight-bold\">{{ applicationNextStep.deadline }}</span> if you can.",
+          "descriptionAskForMoreTime": "You might not get more time. You should still try to answer the Tribunal’s questions by <span class=\"govuk-!-font-weight-bold\">{{ applicationNextStep.deadline }}</span> if you can.",
           "respondByTextAskForMoreTime": "It’s important to respond by the deadline but, if you can’t answer fully, you will be able to provide more information about your appeal later.",
           "respondByText": "You need to respond by {{ applicationNextStep.deadline }}."
         }

--- a/test/e2e-test/pages/overview-page/overview-page.ts
+++ b/test/e2e-test/pages/overview-page/overview-page.ts
@@ -47,7 +47,7 @@ module.exports = {
       I.seeInSource(`${i18n.pages.overviewPage.askedForMoreTime }`);
 
       I.seeInSource(`${i18n.pages.overviewPage.doThisNext.clarifyingQuestions.description}`);
-      I.seeInSource(`<p>${i18n.pages.overviewPage.doThisNext.clarifyingQuestions.respondByText}</p>`.replace('{{ applicationNextStep.deadline }}', respondByDate).trim());
+      I.seeInSource(`${i18n.pages.overviewPage.doThisNext.clarifyingQuestions.respondByText}`.replace('{{ applicationNextStep.deadline }}', respondByDate).trim());
     });
 
     Then(/^I should see the 'do this next section' for 'Saved - Awaiting reasons for appeal'$/, () => {

--- a/test/e2e-test/pages/overview-page/overview-page.ts
+++ b/test/e2e-test/pages/overview-page/overview-page.ts
@@ -46,8 +46,8 @@ module.exports = {
 
       I.seeInSource(`${i18n.pages.overviewPage.askedForMoreTime }`);
 
-      I.seeInSource(`${i18n.pages.overviewPage.doThisNext.clarifyingQuestions.description}`);
-      I.seeInSource(`${i18n.pages.overviewPage.doThisNext.clarifyingQuestions.respondByText}`.replace('{{ applicationNextStep.deadline }}', respondByDate).trim());
+      I.seeInSource(`${i18n.pages.overviewPage.doThisNext.clarifyingQuestions.descriptionAskForMoreTime}`.replace('{{ applicationNextStep.deadline }}', respondByDate).trim());
+      I.seeInSource(`${i18n.pages.overviewPage.doThisNext.clarifyingQuestions.respondByTextAskForMoreTime}`);
     });
 
     Then(/^I should see the 'do this next section' for 'Saved - Awaiting reasons for appeal'$/, () => {

--- a/test/e2e-test/pages/overview-page/overview-page.ts
+++ b/test/e2e-test/pages/overview-page/overview-page.ts
@@ -41,6 +41,15 @@ module.exports = {
       I.seeInSource(`${i18n.pages.overviewPage.doThisNext.awaitingReasonsForAppeal.new.respondByTextAskForMoreTime}`);
     });
 
+    Then(/^I should see the 'do this next section' for 'Awaiting clarifying questions with time extensions' with respond by date '([^"]*)'$/, async (respondByDate) => {
+      I.see(i18n.pages.overviewPage.doThisNext.toDo, '//h2[1]');
+
+      I.seeInSource(`${i18n.pages.overviewPage.askedForMoreTime }`);
+
+      I.seeInSource(`${i18n.pages.overviewPage.doThisNext.clarifyingQuestions.description}`);
+      I.seeInSource(`<p>${i18n.pages.overviewPage.doThisNext.clarifyingQuestions.respondByText}</p>`.replace('{{ applicationNextStep.deadline }}', respondByDate).trim());
+    });
+
     Then(/^I should see the 'do this next section' for 'Saved - Awaiting reasons for appeal'$/, () => {
       I.see(i18n.pages.overviewPage.doThisNext.toDo, '//h2[1]');
       I.seeInSource(`<p>${i18n.pages.overviewPage.doThisNext.awaitingReasonsForAppeal.partial.description}</p>`);

--- a/test/e2e-test/pages/sign-in.ts
+++ b/test/e2e-test/pages/sign-in.ts
@@ -67,9 +67,14 @@ module.exports = {
           break;
         }
         case 'awaitingReasonsForAppeal with time extensions': {
-          signInForUser('awaiting-reasons-for-appeal-with-time_extension@example.com');
+          signInForUser('awaitingReasonsForAppeal-with-time_extension@example.com');
           break;
         }
+        case 'awaitingClarifyingQuestionsAnswers with time extensions': {
+          signInForUser('awaitingClarifyingQuestions-with-time_extension@example.com');
+          break;
+        }
+
         case 'awaitingClarifyingQuestionsAnswers': {
           signInForUser('clarifying-questions@example.com');
           break;

--- a/test/functional/features/ask-for-more-time.feature
+++ b/test/functional/features/ask-for-more-time.feature
@@ -3,7 +3,7 @@ Feature: Ask for more time page
   As a citizen
   I want to be able to fill in why I will need extra time
 
-  Scenario: AFMT without evidence
+  Scenario: AFMT - Awaiting Reasons For Appeal with evidence
     Given I have logged in as an appellant in state "awaitingReasonsForAppeal"
     When I visit the overview page
     Then I click Ask for more time
@@ -30,7 +30,7 @@ Feature: Ask for more time page
     When I click "See your appeal progress" button
     Then I am on the overview page
 
-  Scenario: AFMT without evidence
+  Scenario: AFMT - Reasons For Appeal without evidence
     Given I have logged in as an appellant in state "awaitingReasonsForAppeal"
     When I visit the overview page
     Then I click Ask for more time
@@ -46,7 +46,24 @@ Feature: Ask for more time page
     When I click "See your appeal progress" button
     Then I am on the overview page
 
-  Scenario: AFMT without evidence
+  Scenario: AFMT - Awaiting Clarifying questions without evidence
+    Given I have logged in as an appellant in state "awaitingClarifyingQuestionsAnswers"
+    When I visit the overview page
+    Then I click Ask for more time
+    Then I should see the ask-for-more-time page
+    When I enter a time extensions reason
+    And I click continue
+    Then I should see do you want to upload evidence page
+    When I select No and click continue
+    Then I should see the ask for more time check you answers page
+    And I should see the reasons for appeal
+    When I click send
+    Then I see Your request for more time has been sent screen
+    When I click "See your appeal progress" button
+    Then I am on the overview page
+
+
+  Scenario: AFMT - Awaiting Clarifying questions with evidence
     Given I have logged in as an appellant in state "awaitingClarifyingQuestionsAnswers"
     When I visit the overview page
     Then I click Ask for more time
@@ -66,66 +83,6 @@ Feature: Ask for more time page
     Then I should see error summary
     When I choose a file that is "VALID" and click the "Upload file" button
     And I click continue
-    Then I should see the ask for more time check you answers page
-    And I should see the reasons for appeal
-    When I click send
-    Then I see Your request for more time has been sent screen
-    When I click "See your appeal progress" button
-    Then I am on the overview page
-
-  Scenario: AFMT without evidence
-    Given I have logged in as an appellant in state "awaitingClarifyingQuestionsAnswers"
-    When I visit the overview page
-    Then I click Ask for more time
-    Then I should see the ask-for-more-time page
-    When I enter a time extensions reason
-    And I click continue
-    Then I should see do you want to upload evidence page
-    When I select No and click continue
-    Then I should see the ask for more time check you answers page
-    And I should see the reasons for appeal
-    When I click send
-    Then I see Your request for more time has been sent screen
-    When I click "See your appeal progress" button
-    Then I am on the overview page
-
-
-  Scenario: AFMT without evidence
-    Given I have logged in as an appellant in state "awaitingClarifyingQuestionsAnswers"
-    When I visit the overview page
-    Then I click Ask for more time
-    Then I should see the ask-for-more-time page
-    When I click continue
-    Then I should see error summary
-    When I enter a time extensions reason
-    And I click continue
-    Then I should see do you want to upload evidence page
-    When I select Yes and click continue
-    Then I am on the evidence upload page
-    When I click "Upload file" button
-    Then I should see error summary
-    When I choose a file that is "INVALID_TOO_BIG" and click the "Upload file" button
-    Then I should see error summary
-    When I choose a file that is "INVALID_FORMAT" and click the "Upload file" button
-    Then I should see error summary
-    When I choose a file that is "VALID" and click the "Upload file" button
-    And I click continue
-    Then I should see the ask for more time check you answers page
-    And I should see the reasons for appeal
-    When I click send
-    Then I see Your request for more time has been sent screen
-    When I click "See your appeal progress" button
-    Then I am on the overview page
-
-  Scenario: AFMT without evidence
-    Given I have logged in as an appellant in state "awaitingClarifyingQuestionsAnswers"
-    When I visit the overview page
-    Then I click Ask for more time
-    Then I should see the ask-for-more-time page
-    When I enter a time extensions reason
-    And I click continue
-    Then I should see do you want to upload evidence page
-    When I select No and click continue
     Then I should see the ask for more time check you answers page
     And I should see the reasons for appeal
     When I click send

--- a/test/functional/features/ask-for-more-time.feature
+++ b/test/functional/features/ask-for-more-time.feature
@@ -45,3 +45,90 @@ Feature: Ask for more time page
     Then I see Your request for more time has been sent screen
     When I click "See your appeal progress" button
     Then I am on the overview page
+
+  Scenario: AFMT without evidence
+    Given I have logged in as an appellant in state "awaitingClarifyingQuestionsAnswers"
+    When I visit the overview page
+    Then I click Ask for more time
+    Then I should see the ask-for-more-time page
+    When I click continue
+    Then I should see error summary
+    When I enter a time extensions reason
+    And I click continue
+    Then I should see do you want to upload evidence page
+    When I select Yes and click continue
+    Then I am on the evidence upload page
+    When I click "Upload file" button
+    Then I should see error summary
+    When I choose a file that is "INVALID_TOO_BIG" and click the "Upload file" button
+    Then I should see error summary
+    When I choose a file that is "INVALID_FORMAT" and click the "Upload file" button
+    Then I should see error summary
+    When I choose a file that is "VALID" and click the "Upload file" button
+    And I click continue
+    Then I should see the ask for more time check you answers page
+    And I should see the reasons for appeal
+    When I click send
+    Then I see Your request for more time has been sent screen
+    When I click "See your appeal progress" button
+    Then I am on the overview page
+
+  Scenario: AFMT without evidence
+    Given I have logged in as an appellant in state "awaitingClarifyingQuestionsAnswers"
+    When I visit the overview page
+    Then I click Ask for more time
+    Then I should see the ask-for-more-time page
+    When I enter a time extensions reason
+    And I click continue
+    Then I should see do you want to upload evidence page
+    When I select No and click continue
+    Then I should see the ask for more time check you answers page
+    And I should see the reasons for appeal
+    When I click send
+    Then I see Your request for more time has been sent screen
+    When I click "See your appeal progress" button
+    Then I am on the overview page
+
+
+  Scenario: AFMT without evidence
+    Given I have logged in as an appellant in state "awaitingClarifyingQuestionsAnswers"
+    When I visit the overview page
+    Then I click Ask for more time
+    Then I should see the ask-for-more-time page
+    When I click continue
+    Then I should see error summary
+    When I enter a time extensions reason
+    And I click continue
+    Then I should see do you want to upload evidence page
+    When I select Yes and click continue
+    Then I am on the evidence upload page
+    When I click "Upload file" button
+    Then I should see error summary
+    When I choose a file that is "INVALID_TOO_BIG" and click the "Upload file" button
+    Then I should see error summary
+    When I choose a file that is "INVALID_FORMAT" and click the "Upload file" button
+    Then I should see error summary
+    When I choose a file that is "VALID" and click the "Upload file" button
+    And I click continue
+    Then I should see the ask for more time check you answers page
+    And I should see the reasons for appeal
+    When I click send
+    Then I see Your request for more time has been sent screen
+    When I click "See your appeal progress" button
+    Then I am on the overview page
+
+  Scenario: AFMT without evidence
+    Given I have logged in as an appellant in state "awaitingClarifyingQuestionsAnswers"
+    When I visit the overview page
+    Then I click Ask for more time
+    Then I should see the ask-for-more-time page
+    When I enter a time extensions reason
+    And I click continue
+    Then I should see do you want to upload evidence page
+    When I select No and click continue
+    Then I should see the ask for more time check you answers page
+    And I should see the reasons for appeal
+    When I click send
+    Then I see Your request for more time has been sent screen
+    When I click "See your appeal progress" button
+    Then I am on the overview page

--- a/test/functional/features/overview-page.feature
+++ b/test/functional/features/overview-page.feature
@@ -57,4 +57,4 @@ Feature: Overview page
   Scenario: Awaiting Clarifying Questions appeal with time extension
     Given I have logged in as an appellant in state "awaitingClarifyingQuestionsAnswers with time extensions"
     When I visit the overview page
-    Then I should see the 'do this next section' for 'Awaiting clarifying questions with time extensions' with respond by date '01 May 2020'
+    Then I should see the 'do this next section' for 'Awaiting clarifying questions with time extensions' with respond by date '02 May 2020'

--- a/test/functional/features/overview-page.feature
+++ b/test/functional/features/overview-page.feature
@@ -57,4 +57,4 @@ Feature: Overview page
   Scenario: Awaiting Clarifying Questions appeal with time extension
     Given I have logged in as an appellant in state "awaitingClarifyingQuestionsAnswers with time extensions"
     When I visit the overview page
-    Then I should see the 'do this next section' for 'Awaiting clarifying questions with time extensions' with respond by date '01 June 2020'
+    Then I should see the 'do this next section' for 'Awaiting clarifying questions with time extensions' with respond by date '01 May 2020'

--- a/test/functional/features/overview-page.feature
+++ b/test/functional/features/overview-page.feature
@@ -53,3 +53,8 @@ Feature: Overview page
     Given I have logged in as an appellant in state "awaitingReasonsForAppeal with time extensions"
     When I visit the overview page
     Then I should see the 'do this next section' for 'Awaiting reasons for appeal with time extensions' with respond by date '01 January 2020'
+
+  Scenario: Awaiting Clarifying Questions appeal with time extension
+    Given I have logged in as an appellant in state "awaitingClarifyingQuestionsAnswers with time extensions"
+    When I visit the overview page
+    Then I should see the 'do this next section' for 'Awaiting clarifying questions with time extensions' with respond by date '01 June 2020'

--- a/test/mock/ccd/mock-case-data/data/clarifying-questions-with-time-extensions.js
+++ b/test/mock/ccd/mock-case-data/data/clarifying-questions-with-time-extensions.js
@@ -47,7 +47,7 @@ const clarifyingQuestionsCaseData = {
           "id": "3",
           "value": {
             "tag": "requestClarifyingQuestions",
-            "dateDue": "2020-05-01",
+            "dateDue": "2020-05-02",
             "parties": "appellant",
             "dateSent": "2020-04-23",
             "explanation": "You need to answer some questions about your appeal.",

--- a/test/mock/ccd/mock-case-data/data/clarifying-questions-with-time-extensions.js
+++ b/test/mock/ccd/mock-case-data/data/clarifying-questions-with-time-extensions.js
@@ -1,0 +1,115 @@
+const clarifyingQuestionsCaseData = {
+    'id': 6,
+    'jurisdiction': 'IA',
+    'state': 'awaitingClarifyingQuestionsAnswers',
+    'version': 12,
+    'case_type_id': 'Asylum',
+    'created_date': '2020-02-07T16:39:39.894',
+    'last_modified': '2020-02-11T12:18:39.813',
+    'case_data': {
+      "appellantHasFixedAddress": "Yes",
+      "subscriptions": [
+        {
+          "id": "ff6cfb21-eab8-44f5-ba0a-6e9d5667c22a",
+          "value": {
+            "email": "test@email.com",
+            "wantsSms": "No",
+            "subscriber": "appellant",
+            "wantsEmail": "Yes"
+          }
+        }
+      ],
+      "appellantDateOfBirth": "1980-01-01",
+      "appellantAddress": {
+        "County": "",
+        "Country": "United Kingdom",
+        "PostCode": "W1J 7NT",
+        "PostTown": "LONDON",
+        "AddressLine1": "149 PICCADILLY",
+        "AddressLine2": ""
+      },
+      "applicationOutOfTimeExplanation": "My reason for being late",
+      "appealReferenceNumber": "PA/50005/2020",
+      "appellantGivenNames": "Pablo",
+      "timeExtensions": [
+        {
+          "id": "88adad33-061a-4c86-83d8-2defd1e935d1",
+          "value": {
+            "state": "awaitingClarifyingQuestionsAnswers",
+            "reason": "I need more time",
+            "status": "submitted",
+            "requestDate": "2020-04-30"
+          }
+        }
+      ],
+      "directions": [
+        {
+          "id": "3",
+          "value": {
+            "tag": "requestClarifyingQuestions",
+            "dateDue": "2020-05-01",
+            "parties": "appellant",
+            "dateSent": "2020-04-23",
+            "explanation": "You need to answer some questions about your appeal.",
+            "previousDates": [],
+            "clarifyingQuestions": [
+              {
+                "id": "947398d5-bd81-4e7f-b3ed-1be73be5ba56",
+                "value": {
+                  "question": "Give us some more information about:\n- What are their ages?\n- What are their names?"
+                }
+              },
+              {
+                "id": "ddc8a194-30b3-40d9-883e-d034a7451170",
+                "value": {
+                  "question": "Tell us more about your health issues\n- How long have you suffered from this problem?\n- How does it affect your daily life?"
+                }
+              }
+            ]
+          }
+        },
+        {
+          "id": "2",
+          "value": {
+            "tag": "requestReasonsForAppeal",
+            "dateDue": "2020-05-21",
+            "parties": "appellant",
+            "dateSent": "2020-04-23",
+            "explanation": "You must now tell us why you think the Home Office decision to refuse your claim is wrong.",
+            "previousDates": [],
+            "clarifyingQuestions": []
+          }
+        },
+        {
+          "id": "1",
+          "value": {
+            "tag": "respondentEvidence",
+            "dateDue": "2020-05-07",
+            "parties": "respondent",
+            "dateSent": "2020-04-23",
+            "explanation": "A notice of appeal has been lodged against this asylum decision.\n\nYou must now send all documents to the case officer. The case officer will send them to the other party. You have 14 days to supply these documents.\n\nYou must include:\n- the notice of decision\n- any other document provided to the appellant giving reasons for that decision\n- any statements of evidence\n- the application form\n- any record of interview with the appellant in relation to the decision being appealed\n- any other unpublished documents on which you rely\n- the notice of any other appealable decision made in relation to the appellant",
+            "previousDates": [],
+            "clarifyingQuestions": []
+          }
+        }
+      ],
+      "journeyType": "aip",
+      "appealType": "protection",
+      "appellantFamilyName": "Jimenez",
+      "reasonsForAppealDecision": "I think HO decision is wrong, my reason below:\nbla bla",
+      "appellantNationalities": [
+        {
+          "id": "5eb39d73-eff3-46d8-a27c-25143f27d3b9",
+          "value": {
+            "code": "AO"
+          }
+        }
+      ],
+      "homeOfficeDecisionDate": "2020-01-01",
+      "searchPostcode": "W1J 7NT",
+      "submissionOutOfTime": "Yes",
+      "homeOfficeReferenceNumber": "A1234567"
+    }
+  };
+
+  module.exports = { ...clarifyingQuestionsCaseData };

--- a/test/mock/ccd/mock-case-data/data/clarifying-questions-with-time-extensions.js
+++ b/test/mock/ccd/mock-case-data/data/clarifying-questions-with-time-extensions.js
@@ -1,5 +1,5 @@
 const clarifyingQuestionsCaseData = {
-    'id': 6,
+    'id': 7,
     'jurisdiction': 'IA',
     'state': 'awaitingClarifyingQuestionsAnswers',
     'version': 12,

--- a/test/mock/ccd/mock-case-data/index.js
+++ b/test/mock/ccd/mock-case-data/index.js
@@ -4,13 +4,14 @@ const awaitingReasonsForAppealCaseDataWithTimeExtension = require('./data/awaiti
 const partialAppealStartedCaseData = require('./data/partial-appeal-started');
 const partialAwaitingReasonsForAppealCaseData = require('./data/partial-awaiting-reasons-for-appeal');
 const clarifyingQuestionsCaseData = require('./data/clarifying-questions');
+const clarifyingQuestionsCaseDataWithTimeExtensions = require('./data/clarifying-questions-with-time-extensions');
 
 module.exports = {
   appealSubmittedCaseData,
   partialAppealStartedCaseData,
   awaitingReasonsForAppealCaseData,
   partialAwaitingReasonsForAppealCaseData,
-  partialAwaitingReasonsForAppealCaseData,
   awaitingReasonsForAppealCaseDataWithTimeExtension,
-  clarifyingQuestionsCaseData
+  clarifyingQuestionsCaseData,
+  clarifyingQuestionsCaseDataWithTimeExtensions
 };

--- a/test/mock/ccd/services/loadCases.js
+++ b/test/mock/ccd/services/loadCases.js
@@ -8,7 +8,8 @@ const usersToCaseData = {
   '4': [ mockData.awaitingReasonsForAppealCaseData ],
   '5': [ mockData.partialAwaitingReasonsForAppealCaseData ],
   '6': [ mockData.clarifyingQuestionsCaseData],
-  '7': [ mockData.awaitingReasonsForAppealCaseDataWithTimeExtension ]
+  '7': [ mockData.awaitingReasonsForAppealCaseDataWithTimeExtension ],
+  '8': [ mockData.clarifyingQuestionsCaseDataWithTimeExtensions ]
 };
 
 module.exports = {

--- a/test/mock/idam/services/getDetails.js
+++ b/test/mock/idam/services/getDetails.js
@@ -7,7 +7,8 @@ const emailToUserId = {
   'appeal-submitted@example.com': '3',
   'awaiting-reasons-for-appeal@example.com': '4',
   'partial-awaiting-reasons-for-appeal@example.com': '4',
-  'awaiting-reasons-for-appeal-with-time_extension@example.com': '7',
+  'awaitingReasonsForAppeal-with-time_extension@example.com': '7',
+  'awaitingClarifyingQuestions-with-time_extension@example.com': '8',
   'setupcase@example.com': '999'
 };
 

--- a/test/mock/idam/services/getODetails.js
+++ b/test/mock/idam/services/getODetails.js
@@ -8,7 +8,8 @@ const emailToUserId = {
   'awaiting-reasons-for-appeal@example.com': '4',
   'partial-awaiting-reasons-for-appeal@example.com': '5',
   'clarifying-questions@example.com': '6',
-  'awaiting-reasons-for-appeal-with-time_extension@example.com': '7',
+  'awaitingReasonsForAppeal-with-time_extension@example.com': '7',
+  'awaitingClarifyingQuestions-with-time_extension@example.com': '8',
   'setupcase@example.com': '999'
 };
 

--- a/test/unit/middleware/journeyAllowed-middleware.test.ts
+++ b/test/unit/middleware/journeyAllowed-middleware.test.ts
@@ -75,24 +75,21 @@ describe('isJourneyAllowedMiddleware', () => {
 
   it('should render forbidden if time extension in progress', () => {
     req.session.appeal.appealStatus = 'awaitingReasonsForAppeal';
-    req.session.appeal.timeExtensions = [ ({
-      state: 'awaitingReasonsForAppeal',
-      status: 'submitted',
-      requestDate: '2020-01-01',
-      reason: 'reason'
-    }) ];
+    req.session.appeal.askForMoreTime = { inFlight: true };
     isTimeExtensionsInProgress(req as Request, res as Response, next);
     expect(res.redirect).to.have.been.called.calledWith(paths.common.forbidden);
   });
 
+  it('should allow access to page if inFlight is not defined', () => {
+    req.session.appeal.appealStatus = 'awaitingReasonsForAppeal';
+    req.session.appeal.askForMoreTime = { };
+    isTimeExtensionsInProgress(req as Request, res as Response, next);
+    expect(next).to.have.been.called;
+  });
+
   it('should allow access to page if no time extension in progress', () => {
     req.session.appeal.appealStatus = 'awaitingReasonsForAppeal';
-    req.session.appeal.timeExtensions = [ ({
-      state: 'awaitingReasonsForAppeal',
-      status: 'rejected',
-      requestDate: '2020-01-01',
-      reason: 'reason'
-    }) ];
+    req.session.appeal.askForMoreTime = { inFlight: false };
     isTimeExtensionsInProgress(req as Request, res as Response, next);
     expect(next).to.have.been.called;
   });

--- a/test/unit/service/update-appeal-service.test.ts
+++ b/test/unit/service/update-appeal-service.test.ts
@@ -200,7 +200,7 @@ describe('update-appeal-service', () => {
       expect(req.session.appeal.respondentDocuments[0].evidence).to.exist;
       validateUuid(req.session.appeal.respondentDocuments[0].evidence.fileId);
       expect(req.session.appeal.respondentDocuments[0].evidence.name).to.be.eq('Screenshot.png');
-      expect(req.session.appeal.askForMoreTime).to.deep.eq({});
+      expect(req.session.appeal.askForMoreTime).to.deep.eq({ inFlight: false });
     });
 
     it('load time extensions when no time extensions', async () => {
@@ -215,24 +215,8 @@ describe('update-appeal-service', () => {
         });
       await updateAppealService.loadAppeal(req as Request);
 
-      expect(req.session.appeal.askForMoreTime).to.be.eql({});
-    });
-
-    it('load time extensions when no inProgress time extensions', async () => {
-      expectedCaseData.timeExtensions = [
-        { value: aTimeExtension('some reason', 'expected_time_extension_evidence.png', 'submitted') }
-      ];
-
-      ccdServiceMock.expects('loadOrCreateCase')
-        .withArgs(userId, { userToken, serviceToken })
-        .resolves({
-          id: caseId,
-          state: 'awaitingReasonsForAppeal',
-          case_data: expectedCaseData
-        });
-      await updateAppealService.loadAppeal(req as Request);
-
-      expect(req.session.appeal.askForMoreTime).to.be.eql({});
+      expect(req.session.appeal.askForMoreTime).to.be.eql(
+        { inFlight: false });
     });
 
     it('load draftClarifyingQuestion @only', async () => {

--- a/test/unit/utils/utils.test.ts
+++ b/test/unit/utils/utils.test.ts
@@ -96,24 +96,26 @@ describe('utils', () => {
       expect(inflightTimeExtension).to.be.eq(false);
     });
 
-    it('does not have inflight appeals if previous time extension not submitted', () => {
-      const inflightTimeExtension = hasInflightTimeExtension({
-        timeExtensions: [{
-          status: 'rejected',
-          state: 'currentState'
-        }],
-        appealStatus: 'currentState'
-      } as Appeal);
+    it('should return default value if undefined', () => {
+      const inflightTimeExtension = hasInflightTimeExtension({} as Appeal);
+      expect(inflightTimeExtension).to.be.eq(false);
+    });
+
+    it('does not have inflight appeals', () => {
+      const inflightTimeExtension = hasInflightTimeExtension(
+        {
+          askForMoreTime: {
+            inFlight: false
+          }
+        } as Appeal);
       expect(inflightTimeExtension).to.be.eq(false);
     });
 
     it('has inflight appeal', () => {
       const inflightTimeExtension = hasInflightTimeExtension({
-        timeExtensions: [{
-          status: 'submitted',
-          state: 'currentState'
-        }],
-        appealStatus: 'currentState'
+        askForMoreTime: {
+          inFlight: true
+        }
       } as Appeal);
       expect(inflightTimeExtension).to.be.eq(true);
     });

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -80,6 +80,7 @@ interface Appeal {
 }
 
 interface AskForMoreTime {
+  inFlight?: boolean;
   reason?: string;
   evidence?: Evidence[];
   reviewTimeExtensionRequired?: 'Yes' | 'No';

--- a/views/clarifying-questions/question-page.njk
+++ b/views/clarifying-questions/question-page.njk
@@ -44,7 +44,7 @@
         </h2>
         <ul class="govuk-list govuk-list--bullet">
           <li>
-            <a href={{ paths.common.askForMoreTime }} class="govuk-link">
+            <a href="{{ paths.common.askForMoreTime.reason }}" class="govuk-link">
               {{ i18n.pages.clarifyingQuestionPage.panel.saveAndAskMoreTime }}
             </a>
           </li>

--- a/views/templates/textarea-question-page.njk
+++ b/views/templates/textarea-question-page.njk
@@ -48,7 +48,7 @@
         </h2>
         <ul class="govuk-list govuk-list--bullet">
           <li>
-            <a href={{ paths.common.askForMoreTime }} class="govuk-link">
+            <a href={{ paths.common.askForMoreTime.reason }} class="govuk-link">
               {{ i18n.pages.clarifyingQuestionPage.panel.saveAndAskMoreTime }}
             </a>
           </li>


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/RIA-2976
https://tools.hmcts.net/jira/browse/RIA-3153
https://tools.hmcts.net/jira/browse/RIA-3157

### Change description ###

Removes unnecessary array filtering every time a page that contained …ask for more time was loaded.

Moved inflight ask for more time to the update appeal service so it's loaded whenever loadAppeal is called, this will become useful when we update the session after a submit event using the loadAppeal() and the object returned by CCD.

Fixes and updates tests


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x ] No
```
