### PR TITLE
RIA-3256 Reduce the number of calls to idam as it is unreliable

### DIFF
--- a/app/controllers/idam.ts
+++ b/app/controllers/idam.ts
@@ -37,7 +37,6 @@ function authenticateMiddleware(req: Request, res: Response, next: NextFunction)
 
 function setupIdamController(): Router {
   const router = Router();
-  router.use(idamExpressMiddleware.userDetails(idamConfig));
   router.get(paths.common.login, authenticateMiddleware, getLogin);
   router.get(paths.common.redirectUrl, idamExpressMiddleware.landingPage(idamConfig), initSession, getRedirectUrl);
   router.use(idamExpressMiddleware.protect(idamConfig), checkSession(idamConfig));


### PR DESCRIPTION
The idamExpressMiddleware.protect call also loads the user details so
don't think we need to call them both as login and redirecturl don't
use the user details. This reduces the number of calls to idam from 2
to 1 for every request.

### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/RIA-3256
