### PR TITLE
RIA-3144 Appellant documents on Documents tab

### DIFF
--- a/app/service/update-appeal-service.ts
+++ b/app/service/update-appeal-service.ts
@@ -397,6 +397,7 @@ export default class UpdateAppealService {
             value: {
               dateUploaded: toIsoDate(evidence.dateUploaded),
               description: evidence.description,
+              tag: 'additionalEvidence',
               document: {
                 document_filename: evidence.name,
                 document_url: documentLocationUrl,

--- a/test/unit/service/update-appeal-service.test.ts
+++ b/test/unit/service/update-appeal-service.test.ts
@@ -774,8 +774,7 @@ describe('update-appeal-service', () => {
                     month: 1,
                     day: 1
                   },
-                  description: 'Some evidence 1',
-                  tag: 'additionalEvidence'
+                  description: 'Some evidence 1'
                 },
                 {
                   fileId: '00000000-0000-0000-0000-000000000002',
@@ -785,8 +784,7 @@ describe('update-appeal-service', () => {
                     month: 2,
                     day: 2
                   },
-                  description: 'Some evidence 2',
-                  tag: 'additionalEvidence'
+                  description: 'Some evidence 2'
                 }
               ] as Evidence[]
             },

--- a/test/unit/service/update-appeal-service.test.ts
+++ b/test/unit/service/update-appeal-service.test.ts
@@ -733,7 +733,8 @@ describe('update-appeal-service', () => {
                     'month': 1,
                     'day': 1
                   },
-                  'description': 'Some evidence 1'
+                  'description': 'Some evidence 1',
+                  'tag': 'additionalEvidence'
                 }
               },
               personalDetails: {
@@ -773,7 +774,8 @@ describe('update-appeal-service', () => {
                     month: 1,
                     day: 1
                   },
-                  description: 'Some evidence 1'
+                  description: 'Some evidence 1',
+                  tag: 'additionalEvidence'
                 },
                 {
                   fileId: '00000000-0000-0000-0000-000000000002',
@@ -783,7 +785,8 @@ describe('update-appeal-service', () => {
                     month: 2,
                     day: 2
                   },
-                  description: 'Some evidence 2'
+                  description: 'Some evidence 2',
+                  tag: 'additionalEvidence'
                 }
               ] as Evidence[]
             },
@@ -878,6 +881,7 @@ describe('update-appeal-service', () => {
             value: {
               dateUploaded: '2020-01-01',
               description: 'Some evidence 1',
+              tag: 'additionalEvidence',
               document: {
                 document_url: 'http://dm-store:4506/documents/00000000-0000-0000-0000-000000000001',
                 document_filename: 'File1.png',
@@ -889,6 +893,7 @@ describe('update-appeal-service', () => {
             value: {
               dateUploaded: '2020-02-02',
               description: 'Some evidence 2',
+              tag: 'additionalEvidence',
               document: {
                 document_url: 'http://dm-store:4506/documents/00000000-0000-0000-0000-000000000002',
                 document_filename: 'File2.png',

--- a/types/caseData.d.ts
+++ b/types/caseData.d.ts
@@ -8,6 +8,7 @@ interface DocumentWithMetaData {
   suppliedBy?: string;
   description?: string;
   dateUploaded?: string;
+  tag?: string;
   document: SupportingDocument;
 }
 


### PR DESCRIPTION
Set the document tag on evidence for reasons for appeal

### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/RIA-3144