### PR TITLE
Ria 2894: CQ submitted timeline

### DIFF
--- a/app/data/events.ts
+++ b/app/data/events.ts
@@ -53,6 +53,10 @@ export const Events = {
     id: 'submitCmaRequirements',
     summary: 'Submit CMA requirements',
     description: 'Submit CMA requirements'
+  },
+  SEND_DIRECTION_WITH_QUESTIONS: {
+    id: 'sendDirectionWithQuestions',
+    summary: 'Direct the appellant to answer clarifying questions',
+    description: 'Direct the appellant to answer clarifying questions'
   }
-
 };

--- a/app/data/states.ts
+++ b/app/data/states.ts
@@ -26,5 +26,9 @@ export const States = {
   AWAITING_CMA_REQUIREMENTS: {
     id: 'awaitingCmaRequirements',
     name: 'Awaiting CMA Requirements'
+  },
+  CLARIFYING_QUESTIONS_SUBMITTED: {
+    id: 'clarifyingQuestionsAnswersSubmitted',
+    name: 'Clarifying Questions submitted'
   }
 };

--- a/app/paths.ts
+++ b/app/paths.ts
@@ -66,6 +66,7 @@ const paths = {
     start: '/start-appeal',
     overview: '/appeal-overview',
     fileNotFound: '/file-not-found',
+    yourCQanswers: '/your-answers',
 
     // Health endpoints
     health: '/health',

--- a/app/service/update-appeal-service.ts
+++ b/app/service/update-appeal-service.ts
@@ -223,7 +223,7 @@ export default class UpdateAppealService {
     }
 
     if (requestClarifyingQuestionsDirection && ccdCase.state === 'awaitingClarifyingQuestionsAnswers') {
-      if (caseData.draftClarifyingQuestionsAnswers) {
+      if (caseData.draftClarifyingQuestionsAnswers && caseData.draftClarifyingQuestionsAnswers.length > 0) {
         draftClarifyingQuestionsAnswers = caseData.draftClarifyingQuestionsAnswers.map((answer): ClarifyingQuestion<Evidence> => {
           let evidencesList: Evidence[] = [];
           if (answer.value.supportingEvidence) {

--- a/app/utils/application-state-utils.ts
+++ b/app/utils/application-state-utils.ts
@@ -141,8 +141,8 @@ const APPEAL_STATE = {
   },
   'clarifyingQuestionsAnswersSubmitted': {
     descriptionParagraphs: [
-      'A Tribunal Caseworker is looking at your answers and will contact you to tell you what to do next.',
-      'This should be by [five working days from submission date] but it might take longer than that.'
+      i18n.pages.overviewPage.doThisNext.clarifyingQuestionsAnswersSubmitted.description,
+      i18n.pages.overviewPage.doThisNext.clarifyingQuestionsAnswersSubmitted.dueDate
     ],
     cta: null,
     allowedAskForMoreTime: false

--- a/app/utils/application-state-utils.ts
+++ b/app/utils/application-state-utils.ts
@@ -138,6 +138,14 @@ const APPEAL_STATE = {
       respondByTextAskForMoreTime: i18n.pages.overviewPage.doThisNext.awaitingCmaRequirements.respondByTextAskForMoreTime
     },
     allowedAskForMoreTime: true
+  },
+  'clarifyingQuestionsAnswersSubmitted': {
+    descriptionParagraphs: [
+      'A Tribunal Caseworker is looking at your answers and will contact you to tell you what to do next.',
+      'This should be by [five working days from submission date] but it might take longer than that.'
+    ],
+    cta: null,
+    allowedAskForMoreTime: false
   }
 };
 
@@ -179,7 +187,7 @@ function getAppealApplicationNextStep(req: Request) {
   if (doThisNextSection === undefined) {
     doThisNextSection = {
       descriptionParagraphs: [
-        `Description for event <b>${currentAppealStatus}</b> not found`
+        `Description for appeal status <b>${currentAppealStatus}</b> not found`
       ]
     };
   }

--- a/app/utils/event-deadline-date-finder.ts
+++ b/app/utils/event-deadline-date-finder.ts
@@ -5,6 +5,7 @@ import { dayMonthYearFormat } from './date-utils';
 
 const daysToWaitAfterSubmission = config.get('daysToWait.afterSubmission');
 const daysToWaitAfterReasonsForAppeal = config.get('daysToWait.afterReasonsForAppeal');
+const daysToWaitAfterCQSubmission = config.get('daysToWait.afterCQSubmission');
 
 /**
  * Finds a targeted direction, retrieves it's due date and returns it as a string with the correct date format
@@ -74,6 +75,10 @@ function getDeadline(currentAppealStatus: string, req: Request) {
     }
     case 'awaitingClarifyingQuestionsAnswers': {
       formattedDeadline = getFormattedDirectionDueDate(req.session.appeal.directions, 'requestClarifyingQuestions');
+      break;
+    }
+    case 'clarifyingQuestionsAnswersSubmitted': {
+      formattedDeadline = getFormattedEventHistoryDate(history, 'submitClarifyingQuestionAnswers', daysToWaitAfterCQSubmission);
       break;
     }
     case 'awaitingCmaRequirements': {

--- a/app/utils/timeline-utils.ts
+++ b/app/utils/timeline-utils.ts
@@ -90,11 +90,11 @@ async function getAppealApplicationHistory(req: Request, updateAppealService: Up
 
   req.session.appeal.history = history;
 
-  const appealArgumentSection = [ Events.SUBMIT_REASONS_FOR_APPEAL, Events.SUBMIT_TIME_EXTENSION, Events.REVIEW_TIME_EXTENSION ];
+  const appealArgumentSection = [ Events.SUBMIT_CLARIFYING_QUESTION_ANSWERS, Events.SUBMIT_REASONS_FOR_APPEAL, Events.SUBMIT_TIME_EXTENSION, Events.REVIEW_TIME_EXTENSION ];
   const appealDetailsSection = [ Events.SUBMIT_APPEAL ];
 
   return {
-    appealArgumentSection: constructSection(appealArgumentSection, history, [ States.REASONS_FOR_APPEAL_SUBMITTED, States.AWAITING_REASONS_FOR_APPEAL, States.AWAITING_CLARIFYING_QUESTIONS ], req),
+    appealArgumentSection: constructSection(appealArgumentSection, history, [ States.CLARIFYING_QUESTIONS_SUBMITTED, States.REASONS_FOR_APPEAL_SUBMITTED, States.AWAITING_REASONS_FOR_APPEAL, States.AWAITING_CLARIFYING_QUESTIONS ], req),
     appealDetailsSection: constructSection(appealDetailsSection, history, null, req)
   };
 }

--- a/config/default.json
+++ b/config/default.json
@@ -68,7 +68,8 @@
   },
   "daysToWait": {
     "afterSubmission": 28,
-    "afterReasonsForAppeal": 14
+    "afterReasonsForAppeal": 14,
+    "afterCQSubmission": 7
   },
   "features": {
     "askForMoreTime": false,

--- a/locale/en.json
+++ b/locale/en.json
@@ -366,6 +366,10 @@
             "title": "Helpful Information",
             "url": "<a href='{{ paths.common.homeOfficeDocuments }}'>What to expect at a case management appointment</a>"
           }
+        },
+        "clarifyingQuestionsAnswersSubmitted": {
+          "description": "A Tribunal Caseworker is looking at your answers and will contact you to tell you what to do next.",
+          "dueDate": "This should be by <b>{{ applicationNextStep.deadline }}</b> but it might take longer than that."
         }
       },
       "timeline": {

--- a/locale/en.json
+++ b/locale/en.json
@@ -428,6 +428,16 @@
               "href": "{{ paths.common.detailsViewers.timeExtensionDecision }}"
             }
           ]
+        },
+        "submitClarifyingQuestionAnswers": {
+          "text": "You answered some questions about your appeal.",
+          "links": [
+            {
+              "title": "What you sent",
+              "text": "Your answers",
+              "href": "{{ paths.common.yourCQanswers }}"
+            }
+          ]
         }
       }
     },

--- a/test/e2e-test/features/basic.feature
+++ b/test/e2e-test/features/basic.feature
@@ -84,9 +84,9 @@ Feature: Business rules
     Given I sign in as the Appellant
     When I visit the overview page
     Then I should see the 'do this next section' for 'Awaiting reasons for appeal'
+#    Reenable when ask for more time flag is on by default
 #    Then I should see the 'ask for more time' link
 
-#    Reenable when ask for more time flag is on by default
 #    When I click 'ask for more time'
 #    Then I should see the ask-for-more-time page
 #    When I enter a time extensions reason
@@ -110,3 +110,54 @@ Feature: Business rules
     When I click "Send" button
     Then I should see the reasons for appeal confirmation page
     And I see the respond by date is 2 weeks in the future
+
+    # Case Progression
+    Then I sign in as a Case Officer and send directions with Clarifying Questions
+
+    # Appellant
+    Given I sign in as the Appellant
+    When I visit the overview page
+    Then I see "You need to answer some questions about your appeal." description in overview banner
+    Then I click "Continue" button
+    Then I see "Questions about your appeal" in title
+    Then I see "Answer question 1" item in list
+    Then I see "Answer question 2" item in list
+
+    When I click "Answer question 1" link
+    Then I see "Question 1" in title
+    Then I fill textarea with "my answer for question 1"
+    Then I click "Save and continue" button
+    Then I see "Do you want to provide supporting evidence?" in title
+    Then I click "No" button
+    Then I click "Continue" button
+    Then I see "Questions about your appeal" in title
+    And I see clarifying question "1" saved
+
+    When I click "Answer question 2" link
+    Then I see "Question 2" in title
+    Then I fill textarea with "my answer for question 2"
+    Then I click "Save and continue" button
+    Then I see "Do you want to provide supporting evidence?" in title
+    Then I click "No" button
+    Then I click "Continue" button
+    Then I see "Questions about your appeal" in title
+    Then I see clarifying question "2" saved
+    And I see "Do you want to tell us anything else about your case?" link
+
+    When I click "Do you want to tell us anything else about your case?" link
+    Then I see "Do you want to tell us anything else about your case?" in title
+    Then I click "Yes" button
+    Then I click "Continue" button
+    Then I see "Do you want to tell us anything else about your case?" in title
+    Then I fill textarea with "my answer for anything else question"
+    Then I click "Save and continue" button
+    Then I see "Questions about your appeal" in title
+    Then I see anything else clarifying question saved
+    And I see "Check and send your answers" link
+
+    When I click "Check and send your answers" link
+    Then I see "You have answered the Tribunal's questions" in title
+    Then I click "Send" button
+    And I see "You have answered the Tribunal's questions" in title
+    Then I click "See your appeal progress" button
+    And I see "A Tribunal Caseworker is looking at your answers and will contact you to tell you what to do next" description in overview banner

--- a/test/e2e-test/pages/common/common.ts
+++ b/test/e2e-test/pages/common/common.ts
@@ -293,6 +293,10 @@ module.exports = {
       await I.see(title, 'a');
     });
 
+    Then(/^I see "([^"]*)" description in overview banner$/, async (title: string) => {
+      await I.see(title, '.overview-banner');
+    });
+
     Then(/^I fill textarea with "([^"]*)"$/, async (title: string) => {
       await I.fillField('textarea', title);
     });

--- a/test/e2e-test/service/case-progression-service.ts
+++ b/test/e2e-test/service/case-progression-service.ts
@@ -1,3 +1,4 @@
+import { Events } from '../../../app/data/events';
 import { paths } from '../../../app/paths';
 import { CcdService } from '../../../app/service/ccd-service';
 import { AuthenticationService } from './authentication-service';
@@ -147,6 +148,35 @@ module.exports = {
       };
 
       await updateAppeal(requestRespondentEvidence, userId, caseDetails[0], securityHeaders);
+    });
+
+    Then(/^I sign in as a Case Officer and send directions with Clarifying Questions$/, async () => {
+      let caseDetails: any = await fetchAipUserCaseData();
+      const userToken = await authenticationService.signInAsCaseOfficer();
+      const userId = await getUserId(userToken);
+      const serviceToken = await getS2sToken();
+      const securityHeaders = { userToken, serviceToken };
+      caseDetails[0].case_data = {
+        'sendDirectionExplanation': 'You must now tell us why you think the Home Office decision to refuse your claim is wrong.',
+        'sendDirectionDateDue': '2021-03-26',
+        'sendDirectionParties': 'appellant',
+        'sendDirectionQuestions': [
+          {
+            'id': '1',
+            'value': {
+              'question': 'Give us some more information about:\n- What are their ages?\n  - What are their names?'
+            }
+          },
+          {
+            'id': '2',
+            'value': {
+              'question': 'Tell us more about your health issues\n- How long have you suffered from this problem?\n- How does it affect your daily life?'
+            }
+          }
+        ],
+        ...caseDetails[0].case_data
+      };
+      await updateAppeal(Events.SEND_DIRECTION_WITH_QUESTIONS, userId, caseDetails[0], securityHeaders);
     });
   }
 };

--- a/test/e2e-test/service/ccd-service.ts
+++ b/test/e2e-test/service/ccd-service.ts
@@ -66,7 +66,6 @@ async function updateAppeal(event, userId: string, caseDetails: CcdCaseDetails, 
   } else {
     submitUpdateAppealResponse = await rp.post(submitUpdateAppealOptions);
   }
-
   return submitUpdateAppealResponse;
 }
 

--- a/test/functional/features/clarifying-questions.feature
+++ b/test/functional/features/clarifying-questions.feature
@@ -1,4 +1,5 @@
-Feature: Clarifying questions @only
+@clarifyingQuestions
+Feature: Clarifying questions
   In order to complete my appeal
   As a citizen
   I want to be able to answer clarifying questions
@@ -53,6 +54,7 @@ Feature: Clarifying questions @only
     And I see "You have answered the Tribunal's questions" in title
     Then I click "See your appeal progress" button
     And I see "Pablo Jimenez" in title
+    And I see "A Tribunal Caseworker is looking at your answers and will contact you to tell you what to do next" description in overview banner
 
   Scenario: Answering Clarifying questions save for later
     Given I have logged in as an appellant in state "awaitingClarifyingQuestionsAnswers"

--- a/test/unit/utils/application-state-utils.test.ts
+++ b/test/unit/utils/application-state-utils.test.ts
@@ -78,7 +78,7 @@ describe('application-state-utils', () => {
         {
           deadline: 'TBC',
           descriptionParagraphs: [
-            'Description for event <b>unknown</b> not found'
+            'Description for appeal status <b>unknown</b> not found'
           ]
         }
       );


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/RIA-2894


### Change description ###
- To do next to include a description when appellant has sent answers for CQ
- Timeline includes now link to 'Your answers'
- CYA page to include 'Your answers'

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ X ] No
```
