### PR TITLE
Ria 6151 nightly build security scan issue

### DIFF
--- a/Jenkinsfile_CNP
+++ b/Jenkinsfile_CNP
@@ -44,9 +44,6 @@ withPipeline("nodejs", product, component) {
 
   loadVaultSecrets(secrets)
 
-  env.TEST_URL = 'https://immigration-appeal.aat.platform.hmcts.net'
-  enableSecurityScan()
-
   enableAksStagingDeployment()
   disableLegacyDeployment()
 

--- a/Jenkinsfile_CNP
+++ b/Jenkinsfile_CNP
@@ -42,16 +42,19 @@ withPipeline("nodejs", product, component) {
   after('checkout') { sh 'yarn cache clean' }
   after('build') { sh 'yarn build' }
 
+  loadVaultSecrets(secrets)
 
-loadVaultSecrets(secrets)
+  env.TEST_URL = 'https://immigration-appeal.aat.platform.hmcts.net'
+  enableSecurityScan()
+
   enableAksStagingDeployment()
   disableLegacyDeployment()
 
-env.S2S_MICROSERVICE_NAME = 'iac'
-env.S2S_URL = 'http://rpe-service-auth-provider-aat.service.core-compute-aat.internal'
-env.CCD_API_URL = 'http://ccd-data-store-api-aat.service.core-compute-aat.internal'
+  env.S2S_MICROSERVICE_NAME = 'iac'
+  env.S2S_URL = 'http://rpe-service-auth-provider-aat.service.core-compute-aat.internal'
+  env.CCD_API_URL = 'http://ccd-data-store-api-aat.service.core-compute-aat.internal'
 
- before("functionalTest") {
-   env.IDAM_API_URL = 'https://idam-api.aat.platform.hmcts.net'
- }
+  before("functionalTest") {
+    env.IDAM_API_URL = 'https://idam-api.aat.platform.hmcts.net'
+  }
 }

--- a/security.sh
+++ b/security.sh
@@ -9,7 +9,7 @@ fi
 export LC_ALL=C.UTF-8
 export LANG=C.UTF-8
 
-zap-x.sh -d -host 0.0.0.0 -port 1001 -config database.newsession=3 -config database.newsessionprompt=false -config globalexcludeurl.url_list.url.regex='^https?:\/\/.*\/(?:.*login.*)+$' -config api.disablekey=true -config scanner.attackOnStart=true -config view.mode=attack -config connection.dnsTtlSuccessfulQueries=-1 -config api.addrs.addr.name=.* -config api.addrs.addr.regex=true /dev/null 2>&1 &
+zap-x.sh -daemon -host 0.0.0.0 -port 1001 -config database.newsession=3 -config database.newsessionprompt=false -config globalexcludeurl.url_list.url.regex='^https?:\/\/.*\/(?:.*login.*)+$' -config api.disablekey=true -config scanner.attackOnStart=true -config view.mode=attack -config connection.dnsTtlSuccessfulQueries=-1 -config api.addrs.addr.name=.* -config api.addrs.addr.regex=true &
 i=0
 while !(curl -s http://0.0.0.0:1001) > /dev/null
   do
@@ -30,7 +30,7 @@ while !(curl -s http://0.0.0.0:1001) > /dev/null
   curl --fail http://0.0.0.0:1001/OTHER/core/other/jsonreport/?formMethod=GET --output report.json
   cp *.html functional-output/
   cp activescanReport.xml functional-output/
-  zap-cli --zap-url http://0.0.0.0 -p 1001 alerts -l Informational --exit-code False
+  zap-cli --zap-url http://0.0.0.0 -p 1001 alerts -l Medium --exit-code False
 
 echo
 echo ZAP Security vulnerabilities were found that were not ignored

--- a/security.sh
+++ b/security.sh
@@ -9,7 +9,7 @@ fi
 export LC_ALL=C.UTF-8
 export LANG=C.UTF-8
 
-zap-x.sh -d -host 0.0.0.0 -port 1001 -config api.disablekey=true -config scanner.attackOnStart=true -config view.mode=attack -config connection.dnsTtlSuccessfulQueries=-1 -config api.addrs.addr.name=.* -config api.addrs.addr.regex=true /dev/null 2>&1 &
+zap-x.sh -d -host 0.0.0.0 -port 1001 -config database.newsession=3 -config database.newsessionprompt=false -config globalexcludeurl.url_list.url.regex='^https?:\/\/.*\/(?:.*login.*)+$' -config api.disablekey=true -config scanner.attackOnStart=true -config view.mode=attack -config connection.dnsTtlSuccessfulQueries=-1 -config api.addrs.addr.name=.* -config api.addrs.addr.regex=true /dev/null 2>&1 &
 i=0
 while !(curl -s http://0.0.0.0:1001) > /dev/null
   do


### PR DESCRIPTION
Command line -d switch is obsolete, caused error on latest run, it's replaced with -daemon 
Also removed /dev/null output redirect, causing error on the local run although not stopping the run
Severity for console output set to Medium