### PR TITLE
RIA-6368: Fixed csp error highlighted by Dynatrace report.

### DIFF
--- a/app/app.ts
+++ b/app/app.ts
@@ -104,7 +104,7 @@ function configureHelmet(app) {
             ? `'unsafe-inline'`
             : `'nonce-${res.locals.nonce}'`
       ],
-      connectSrc: [ '\'self\'', 'www.gov.uk', 'www.google-analytics.com' ],
+      connectSrc: [ '\'self\'', '*.gov.uk', '*.google-analytics.com' ],
       mediaSrc: [ '\'self\'' ],
       frameSrc: [
         '\'self\'',


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/RIA-6368

### Change description ###

Updated CSP headers to loosen allowed domains for gov.uk and GA

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
