### PR TITLE
RIA-6562: AIP Payment - AIP returns to homepage after appeal submitted

### DIFF
--- a/app/controllers/application-overview.ts
+++ b/app/controllers/application-overview.ts
@@ -118,7 +118,7 @@ function showHearingRequests(appealStatus: string, featureEnabled: boolean) {
 }
 
 function isAppealInProgress(appealStatus: string) {
-  return appealStatus !== States.APPEAL_STARTED.id && appealStatus !== States.ENDED.id;
+  return appealStatus !== States.APPEAL_STARTED.id && appealStatus !== States.PENDING_PAYMENT.id && appealStatus !== States.ENDED.id;
 }
 
 function getApplicationOverview(updateAppealService: UpdateAppealService) {

--- a/app/utils/application-state-utils.ts
+++ b/app/utils/application-state-utils.ts
@@ -21,11 +21,15 @@ interface DoThisNextSection {
     url: string;
   };
   cta?: {
-    url?: string;
+    link?: {
+      text: string,
+      url: string
+    },
+    url?: string,
     respondBy?: string,
     respondByText?: string,
-    respondByTextAskForMoreTime?: string;
-    ctaTitle?: string;
+    respondByTextAskForMoreTime?: string,
+    ctaTitle?: string
   };
   allowedAskForMoreTime?: boolean;
   deadline?: string;
@@ -522,6 +526,22 @@ async function getAppealApplicationNextStep(req: Request) {
           url: i18n.pages.overviewPage.doThisNext.decided.info.url
         },
         cta: {},
+        allowedAskForMoreTime: false
+      };
+      break;
+    case 'pendingPayment':
+      doThisNextSection = {
+        descriptionParagraphs: [
+          i18n.pages.overviewPage.doThisNext.pendingPayment.detailsSent,
+          i18n.pages.overviewPage.doThisNext.pendingPayment.dueDate,
+          i18n.pages.overviewPage.doThisNext.pendingPayment.dueDate1
+        ],
+        cta: {
+          link: {
+            text: i18n.pages.overviewPage.payForAppeal,
+            url: paths.common.payLater
+          }
+        },
         allowedAskForMoreTime: false
       };
       break;

--- a/app/utils/event-deadline-date-finder.ts
+++ b/app/utils/event-deadline-date-finder.ts
@@ -6,6 +6,7 @@ import { dayMonthYearFormat } from './date-utils';
 const daysToWaitAfterSubmission = config.get('daysToWait.afterSubmission');
 const daysToWaitAfterReasonsForAppeal = config.get('daysToWait.afterReasonsForAppeal');
 const daysToWaitAfterCQSubmission = config.get('daysToWait.afterCQSubmission');
+const daysToWaitPendingPayment = config.get('daysToWait.pendingPayment');
 
 /**
  * Finds a targeted direction, retrieves it's due date and returns it as a string with the correct date format
@@ -76,6 +77,10 @@ function getDeadline(currentAppealStatus: string, req: Request): string {
     case 'lateAppealSubmitted':
     case 'awaitingRespondentEvidence': {
       formattedDeadline = getFormattedEventHistoryDate(history, 'submitAppeal', daysToWaitAfterSubmission);
+      break;
+    }
+    case 'pendingPayment': {
+      formattedDeadline = getFormattedEventHistoryDate(history, 'submitAppeal', daysToWaitPendingPayment);
       break;
     }
     case 'awaitingReasonsForAppeal':

--- a/app/utils/progress-bar-utils.ts
+++ b/app/utils/progress-bar-utils.ts
@@ -6,6 +6,7 @@ function buildProgressBarStages(state: string) {
     yourAppealDetails: {
       activeStatus: [
         States.APPEAL_STARTED.id,
+        States.PENDING_PAYMENT.id,
         States.APPEAL_SUBMITTED.id,
         States.AWAITING_RESPONDENT_EVIDENCE.id
       ]

--- a/locale/en.json
+++ b/locale/en.json
@@ -1399,6 +1399,8 @@
         "title": "Your appointment needs",
         "accessNeedsTitle": "1. Access needs",
         "InterpreterTitle": "Interpreter",
+        "stepFreeAccessTitle": "Step free access",
+        "hearingLoopTitle": "Hearing loop",
         "datesToAvoidTitle": "3. Dates to avoid",
         "otherNeedsTitle": "2. Other needs",
         "multiMediaViewTitle": "Multimedia evidence",

--- a/locale/en.json
+++ b/locale/en.json
@@ -767,6 +767,11 @@
             "url": "<a class='govuk-link' href='{{ paths.common.tribunalCaseworker }}'>What is a Tribunal Caseworker?</a>"
           }
         },
+        "pendingPayment": {
+          "detailsSent": "Your appeal details have been sent to the Tribunal.",
+          "dueDate": "You must pay for your appeal by <span class='govuk-body govuk-!-font-weight-bold'>{{ applicationNextStep.deadline }}</span>.",
+          "dueDate1": "The Tribunal may end your appeal if you do not pay."
+        },
         "appealTakenOffline": {
           "description": "Your appeal was removed from the online service on <date of removal>. The reason for this is:",
           "reason": "",
@@ -1394,8 +1399,6 @@
         "title": "Your appointment needs",
         "accessNeedsTitle": "1. Access needs",
         "InterpreterTitle": "Interpreter",
-        "stepFreeAccessTitle": "Step free access",
-        "hearingLoopTitle": "Hearing loop",
         "datesToAvoidTitle": "3. Dates to avoid",
         "otherNeedsTitle": "2. Other needs",
         "multiMediaViewTitle": "Multimedia evidence",

--- a/test/e2e-test/pages/common/common.ts
+++ b/test/e2e-test/pages/common/common.ts
@@ -351,6 +351,10 @@ module.exports = {
       await I.amOnPage(`${testUrl}/health`);
     });
 
+    When(/^I visit the overview page$/, async () => {
+      await I.amOnPage(`${testUrl}/appeal-overview`);
+    });
+
     Then(/^I click continue$/, async () => {
       await I.click('Continue');
     });

--- a/test/functional/features/submission-page.feature
+++ b/test/functional/features/submission-page.feature
@@ -27,3 +27,7 @@ Feature: submission
     Then I am on the appeal details sent page
     And I see "Your appeal has been submitted" in title
     And I see the pay by date is 14 days in the future
+    When I visit the overview page
+    Then I see "Pay for your appeal" link
+    And I see "Your appeal details have been sent to the Tribunal" description in overview banner
+    And I see "The Tribunal may end your appeal if you do not pay" description in overview banner

--- a/test/unit/utils/application-state-utils.test.ts
+++ b/test/unit/utils/application-state-utils.test.ts
@@ -63,6 +63,10 @@ describe('application-state-utils', () => {
               'createdDate': '2020-02-08T16:00:00.000'
             },
             {
+              'id': 'pendingPayment',
+              'createdDate': '2020-02-08T16:00:00.000'
+            },
+            {
               'id': 'submitReasonsForAppeal',
               'createdDate': '2020-02-18T16:00:00.000'
             },
@@ -166,6 +170,27 @@ describe('application-state-utils', () => {
           url: "<a class='govuk-link' href='{{ paths.common.tribunalCaseworker }}'>What is a Tribunal Caseworker?</a>"
         },
         allowedAskForMoreTime: false
+      });
+    });
+
+    it('get correct \'Do This next section\' when application status is pendingPayment', async () => {
+      req.session.appeal.appealStatus = 'pendingPayment';
+      const result = await getAppealApplicationNextStep(req as Request);
+
+      expect(result).to.eql({
+        descriptionParagraphs: [
+          i18n.pages.overviewPage.doThisNext.pendingPayment.detailsSent,
+          i18n.pages.overviewPage.doThisNext.pendingPayment.dueDate,
+          i18n.pages.overviewPage.doThisNext.pendingPayment.dueDate1
+        ],
+        cta: {
+          link: {
+            text: i18n.pages.overviewPage.payForAppeal,
+            url: paths.common.payLater
+          }
+        },
+        allowedAskForMoreTime: false,
+        deadline: '22 February 2020'
       });
     });
 

--- a/test/unit/utils/event-deadline-date-finder.test.ts
+++ b/test/unit/utils/event-deadline-date-finder.test.ts
@@ -61,6 +61,10 @@ describe('event-deadline-date-finder', () => {
               'createdDate': '2020-02-08T16:00:00.000'
             },
             {
+              'id': 'pendingPayment',
+              'createdDate': '2020-02-08T16:00:00.000'
+            },
+            {
               'id': 'submitReasonsForAppeal',
               'createdDate': '2020-02-18T16:00:00.000'
             },
@@ -111,12 +115,20 @@ describe('event-deadline-date-finder', () => {
       expect(result).to.be.null;
     });
 
-    it('appealSubmitted should return a formatted date with 14 days offset from the appealSubmission date', () => {
+    it('appealSubmitted should return a formatted date with 5 days offset from the appealSubmission date', () => {
 
       const currentAppealStatus = 'appealSubmitted';
       const result = getDeadline(currentAppealStatus, req as Request);
 
       expect(result).to.be.equal('13 February 2020');
+    });
+
+    it('pendingPayment should return a formatted date with 14 days offset from the appealSubmission date', () => {
+
+      const currentAppealStatus = 'pendingPayment';
+      const result = getDeadline(currentAppealStatus, req as Request);
+
+      expect(result).to.be.equal('22 February 2020');
     });
 
     it('awaitingRespondentEvidence should return a formatted date with 14 days offset from the appealSubmission date', () => {

--- a/test/unit/utils/payments-utils.test.ts
+++ b/test/unit/utils/payments-utils.test.ts
@@ -1,0 +1,118 @@
+import { expect } from 'chai';
+import { Request } from 'express';
+import { getFee, payLaterForApplicationNeeded, payNowForApplicationNeeded } from '../../../app/utils/payments-utils';
+import { sinon } from '../../utils/testUtils';
+
+describe('payment-utils', () => {
+  let sandbox: sinon.SinonSandbox;
+  let req: Partial<Request>;
+
+  beforeEach(() => {
+    sandbox = sinon.createSandbox();
+    req = {
+      body: {},
+      cookies: {},
+      session: {
+        appeal: {
+          'appealStatus': 'appealSubmitted',
+          'paymentStatus': 'NotPaid',
+          'application': {
+            'appealType': 'protection',
+            'decisionHearingFeeOption': 'decisionWithHearing'
+          },
+          'paAppealTypeAipPaymentOption': 'payNow',
+          'feeWithHearing': '140',
+          'feeCode': 'FEE0238',
+          'feeVersion': '2'
+        }
+      }
+    } as Partial<Request>;
+  });
+
+  afterEach(() => {
+    sandbox.restore();
+  });
+
+  describe('getFee', () => {
+    it('should return correct appeal fee information', () => {
+      const result = getFee(req.session.appeal);
+
+      expect(result).to.eql(
+        {
+          calculated_amount: '140',
+          code: 'FEE0238',
+          version: '2'
+        }
+      );
+    });
+    it('should throw error when fee is not provided', () => {
+      const application = {
+        ...req.session.appeal.application,
+        decisionHearingFeeOption: 'decisionWithoutHearing'
+      };
+      req.session.appeal.application = {
+        ...application
+      };
+
+      expect(() => {
+        getFee(req.session.appeal);
+      }).to.throw('Fee is not available');
+    });
+  });
+
+  describe('payNowForApplicationNeeded', () => {
+    it('should return payNow = true for protection appeal when paAppealTypeAipPaymentOption is payNow', () => {
+      const payNow = payNowForApplicationNeeded(req as Request);
+
+      expect(payNow).to.eql(true);
+    });
+    it('should return payNow = false for protection appeal when paAppealTypeAipPaymentOption is not payNow', () => {
+      req.session.appeal.paAppealTypeAipPaymentOption = 'payLater';
+      const payNow = payNowForApplicationNeeded(req as Request);
+
+      expect(payNow).to.eql(false);
+    });
+    it('should return payNow = true for refusalOfHumanRights or refusalOfEu or euSettlementScheme appeals', () => {
+      let payNow = true;
+      ['refusalOfHumanRights', 'refusalOfEu', 'euSettlementScheme'].forEach(appealTye => {
+        req.session.appeal.application.appealType = appealTye;
+        payNow = payNow && payNowForApplicationNeeded(req as Request);
+      });
+
+      expect(payNow).to.eql(true);
+    });
+  });
+
+  describe('payLaterForApplicationNeeded', () => {
+    it('should return payLater = true for protection appeal when paAppealTypeAipPaymentOption is payLater and appeal status is not appealStarted and payment status is not Paid', () => {
+      req.session.appeal.paAppealTypeAipPaymentOption = 'payLater';
+      const payLater = payLaterForApplicationNeeded(req as Request);
+
+      expect(payLater).to.eql(true);
+    });
+    it('should return payLater = false for protection appeal when paAppealTypeAipPaymentOption is payNow', () => {
+      const payLater = payLaterForApplicationNeeded(req as Request);
+
+      expect(payLater).to.eql(false);
+    });
+    it('should return payLater = true for refusalOfHumanRights or refusalOfEu or euSettlementScheme appeals when appeal status is paymentPending', () => {
+      req.session.appeal.appealStatus = 'pendingPayment';
+      let payLater = true;
+      ['refusalOfHumanRights', 'refusalOfEu', 'euSettlementScheme'].forEach(appealTye => {
+        req.session.appeal.application.appealType = appealTye;
+        payLater = payLater && payLaterForApplicationNeeded(req as Request);
+      });
+
+      expect(payLater).to.eql(true);
+    });
+    it('should return payLater = false for refusalOfHumanRights or refusalOfEu or euSettlementScheme appeals when appeal status is not paymentPending', () => {
+      let payLater = true;
+      ['refusalOfHumanRights', 'refusalOfEu', 'euSettlementScheme'].forEach(appealTye => {
+        req.session.appeal.application.appealType = appealTye;
+        payLater = payLater && payLaterForApplicationNeeded(req as Request);
+      });
+
+      expect(payLater).to.eql(false);
+    });
+  });
+});

--- a/views/application-overview.njk
+++ b/views/application-overview.njk
@@ -79,6 +79,12 @@
                 {% endif %}
               </p>
             {% endif %}
+            {% if applicationNextStep.cta.link %}
+              {{ govukButton({
+                text: applicationNextStep.cta.link.text,
+                  href: applicationNextStep.cta.link.url
+              }) }}
+            {% endif %}
           {% endif %}
           {% if applicationNextStep.usefulDocuments %}
             <p><b>{{ applicationNextStep.usefulDocuments.title }}</b></p>


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/RIA-6562


### Change description ###
* Show the 'pay for appeal' link on appeal overview page when appeal is in pending payment state
* Update the appeal overview page's 'Do this next' section for appeal in pending payment state as per story's specification
* Include a button that leads to the payment page in the appeal overview page's 'Do this next' section for appeal in pending payment state.
* Update existing / write new unit tests for the new updates
* Upgrade nodejs chart from 2.4.5 to 2.4.8


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
