### PR TITLE
RIA-6596 Progress bar and timeline after AIP payment

### DIFF
--- a/app/controllers/application-overview.ts
+++ b/app/controllers/application-overview.ts
@@ -136,10 +136,10 @@ function getApplicationOverview(updateAppealService: UpdateAppealService) {
       const isPartiallySaved = _.has(req.query, 'saved');
       const askForMoreTime = _.has(req.query, 'ask-for-more-time');
       const saveAndAskForMoreTime = _.has(req.query, 'save-and-ask-for-more-time');
-      const { appealReferenceNumber, appealStatus } = req.session.appeal;
+      const { appealReferenceNumber, appealStatus, paymentStatus } = req.session.appeal;
       const loggedInUserFullName: string = getAppellantName(req);
       const appealRefNumber = getAppealRefNumber(appealReferenceNumber);
-      const stagesStatus = buildProgressBarStages(appealStatus);
+      const stagesStatus = buildProgressBarStages(appealStatus, paymentStatus);
       const history = await getAppealApplicationHistory(req, updateAppealService);
       const nextSteps = await getAppealApplicationNextStep(req);
       const appealEnded = checkAppealEnded(appealStatus);

--- a/app/utils/progress-bar-utils.ts
+++ b/app/utils/progress-bar-utils.ts
@@ -1,7 +1,7 @@
 import i18n from '../../locale/en.json';
 import { States } from '../data/states';
 
-function buildProgressBarStages(state: string) {
+function buildProgressBarStages(state: string, paymentStatus?: string) {
   const stages = {
     yourAppealDetails: {
       activeStatus: [
@@ -43,15 +43,15 @@ function buildProgressBarStages(state: string) {
   const yourAppealDetailsStage = {
     title: i18n.components.progressBar.yourAppealDetails.title,
     ariaLabel: i18n.components.progressBar.yourAppealDetails.ariaLabel,
-    active: stages.yourAppealDetails.activeStatus.includes(state),
-    completed: !stages.yourAppealDetails.activeStatus.includes(state)
+    active: stages.yourAppealDetails.activeStatus.includes(state) && paymentStatus !== 'Paid',
+    completed: !stages.yourAppealDetails.activeStatus.includes(state) || paymentStatus === 'Paid'
   };
 
   const yourAppealArgumentStage = {
     title: i18n.components.progressBar.yourAppealArgument.title,
     ariaLabel: i18n.components.progressBar.yourAppealArgument.ariaLabel,
     active: stages.yourAppealArgument.activeStatus.includes(state),
-    completed: yourAppealDetailsStage.completed && !stages.yourAppealArgument.activeStatus.includes(state)
+    completed: yourAppealDetailsStage.completed && !stages.yourAppealArgument.activeStatus.includes(state) && !stages.yourAppealDetails.activeStatus.includes(state)
   };
 
   const yourHearingDetailsStage = {

--- a/app/utils/timeline-utils.ts
+++ b/app/utils/timeline-utils.ts
@@ -132,7 +132,7 @@ async function getAppealApplicationHistory(req: Request, updateAppealService: Up
 
   const { paymentStatus, paAppealTypeAipPaymentOption = null, paymentDate } = req.session.appeal;
   let paymentEvent = [];
-  if (paymentStatus === 'Paid' && paAppealTypeAipPaymentOption === 'payLater') {
+  if (paymentStatus === 'Paid') {
     paymentEvent = [{
       date: moment(paymentDate).format('DD MMMM YYYY'),
       dateObject: new Date(paymentDate),

--- a/test/unit/utils/progress-bar.test.ts
+++ b/test/unit/utils/progress-bar.test.ts
@@ -47,6 +47,22 @@ describe('progress-bar utils', () => {
       expect(expectedStages).to.deep.equal(stages);
     });
 
+    it('appealSubmitted and not Paid', () => {
+      const stages = buildProgressBarStages('appealSubmitted', 'Payment pending');
+      let expectedStages = defaultStages;
+      expectedStages[0].active = true;
+      expectedStages[0].completed = false;
+      expect(expectedStages).to.deep.equal(stages);
+    });
+
+    it('appealSubmitted and Paid', () => {
+      const stages = buildProgressBarStages('appealSubmitted', 'Paid');
+      let expectedStages = defaultStages;
+      expectedStages[0].active = false;
+      expectedStages[0].completed = true;
+      expect(expectedStages).to.deep.equal(stages);
+    });
+
     it('awaitingRespondentEvidence', () => {
       const stages = buildProgressBarStages('awaitingRespondentEvidence');
       let expectedStages = defaultStages;


### PR DESCRIPTION
### JIRA link (if applicable) ###
[RIA-6596](https://tools.hmcts.net/jira/browse/RIA-6596)


### Change description ###
- Made payment details appeal in the timeline after payment's made
- Made the first step in the progress bar be ticked when payment is made


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
