### PR TITLE
RIA-6572 endAppealAutomatically document tag

### DIFF
--- a/app/controllers/detail-viewers.ts
+++ b/app/controllers/detail-viewers.ts
@@ -507,7 +507,7 @@ function getCmaRequirementsViewer(req: Request, res: Response, next: NextFunctio
 function getNoticeEndedAppeal(req: Request, res: Response, next: NextFunction) {
   try {
     let previousPage: string = paths.common.overview;
-    const endedAppealDoc = req.session.appeal.tribunalDocuments.find(doc => doc.tag === 'endAppeal');
+    const endedAppealDoc = req.session.appeal.tribunalDocuments.find(doc => ['endAppeal', 'endAppealAutomatically'].includes(doc.tag));
     const fileNameFormatted = fileNameFormatter(endedAppealDoc.name);
     const data = [
       addSummaryRow(i18n.pages.detailViewers.common.dateUploaded, [moment(endedAppealDoc.dateUploaded).format(dayMonthYearFormat)]),


### PR DESCRIPTION
### JIRA link (if applicable) ###
[RIA-6572](https://tools.hmcts.net/jira/browse/RIA-6572)


### Change description ###
- Made the frontend look for `endAppealAutomatically` tag as well as `endAppeal` when looking for documents generated for the end of the appeal (when clicking on _Notice of Ended Appeal_)


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
