### PR TITLE
RIA-6998 Tribunal sends Non Standard Direction to the Appellant/HO - Update to Timeline Page

### DIFF
--- a/app/utils/timeline-utils.ts
+++ b/app/utils/timeline-utils.ts
@@ -107,6 +107,28 @@ function getSubmitClarifyingQuestionsEvents(history: HistoryEvent[], directions:
   });
 }
 
+function getDirectionHistory(directions: Direction[]): any[] {
+  let directionsHistory = [];
+  if (directions) {
+    const directionsFiltered = directions.filter(direction => (
+      direction.directionType === 'sendDirection'
+      && (direction.parties === 'appellant' || direction.parties === 'respondent')));
+
+    if (directionsFiltered) {
+      directionsFiltered.map(direction => {
+        directionsHistory.push({
+          date: moment(direction.dateSent).format('DD MMMM YYYY'),
+          dateObject: new Date(direction.dateSent),
+          text: i18n.pages.overviewPage.timeline[direction.directionType][direction.parties].text || null,
+          links: i18n.pages.overviewPage.timeline[direction.directionType][direction.parties].links
+        });
+      });
+      return directionsHistory
+    }
+  }
+  return directionsHistory;
+}
+
 async function getAppealApplicationHistory(req: Request, updateAppealService: UpdateAppealService) {
   const authenticationService = updateAppealService.getAuthenticationService();
   const headers: SecurityHeaders = await authenticationService.getSecurityHeaders(req);
@@ -147,7 +169,9 @@ async function getAppealApplicationHistory(req: Request, updateAppealService: Up
     }];
   }
 
-  const argumentSection = appealArgumentSection.concat(applicationEvents, paymentEvent, submitCQHistory)
+  const directionsHistory = getDirectionHistory(req.session.appeal.directions);
+
+  const argumentSection = appealArgumentSection.concat(applicationEvents, paymentEvent, submitCQHistory, directionsHistory)
     .sort((a: any, b: any) => b.dateObject - a.dateObject);
 
   return {
@@ -244,6 +268,7 @@ export {
   getAppealApplicationHistory,
   getSubmitClarifyingQuestionsEvents,
   getApplicationEvents,
+  getDirectionHistory,
   constructSection,
   getEventsAndStates
 };

--- a/locale/en.json
+++ b/locale/en.json
@@ -1495,6 +1495,28 @@
               }
             ]
           }
+        },
+        "sendDirection": {
+          "respondent": {
+            "text": "The Tribunal asked the Home Office to do something",
+            "links": [
+              {
+                "title": "What the Tribunal sent",
+                "text": "Find out what the Home Office must do",
+                "href": "{{ paths.common.directionHistoryViewer }}"
+              }
+            ]
+          },
+          "appellant": {
+            "text": "The Tribunal asked you to do something",
+            "links": [
+              {
+                "title": "What the Tribunal sent",
+                "text": "Find out what you need to do",
+                "href": "{{ paths.common.directionHistoryViewer }}"
+              }
+            ]
+          }
         }
       }
     },

--- a/test/unit/utils/timeline-utils.test.ts
+++ b/test/unit/utils/timeline-utils.test.ts
@@ -2,7 +2,7 @@ import { Request } from 'express';
 import { Events } from '../../../app/data/events';
 import LaunchDarklyService from '../../../app/service/launchDarkly-service';
 import Logger from '../../../app/utils/logger';
-import { constructSection, getApplicationEvents, getEventsAndStates, getSubmitClarifyingQuestionsEvents } from '../../../app/utils/timeline-utils';
+import { constructSection, getApplicationEvents, getEventsAndStates, getSubmitClarifyingQuestionsEvents, getDirectionHistory } from '../../../app/utils/timeline-utils';
 import { expect, sinon } from '../../utils/testUtils';
 import { expectedEventsWithTimeExtensionsData } from '../mockData/events/expectation/expected-events-with-time-extensions';
 
@@ -305,6 +305,74 @@ describe('timeline-utils', () => {
       const events = getSubmitClarifyingQuestionsEvents([], []);
 
       expect(events.length).to.be.eql(0);
+    });
+  });
+
+  describe('getDirectionHistory', () => {
+    const directions: Direction[] = [
+      {
+        id: '1',
+        parties: 'appellant',
+        tag: '',
+        dateDue: '2023-12-11',
+        dateSent: '2023-05-11',
+        explanation: 'explanation 1',
+        uniqueId: '123456789',
+        directionType: 'sendDirection'
+      },
+      {
+        id: '2',
+        parties: 'respondent',
+        tag: '',
+        dateDue: '2023-12-11',
+        dateSent: '2023-05-11',
+        explanation: 'explanation 2',
+        uniqueId: '987654321',
+        directionType: 'sendDirection'
+      }
+    ];
+    it('should get direction history', () => {
+      const directionsHistory = getDirectionHistory(directions as Direction[]);
+
+      expect(directionsHistory.length).to.be.eql(2);
+      directionsHistory.forEach(direction => {
+        expect(direction).to.contain.keys('date', 'dateObject', 'text', 'links');
+      });
+    });
+
+    it('should filter history with non sendDirection type and appellant/respondent parties', () => {
+      directions.push(
+          {
+            id: '3',
+            parties: 'appellant',
+            tag: 'respondentEvidence',
+            dateDue: '2023-12-11',
+            dateSent: '2023-05-11',
+            explanation: 'explanation 3',
+            uniqueId: '159159159',
+            directionType: 'requestRespondentEvidence'
+          },
+          {
+            id: '4',
+            parties: 'appellant',
+            tag: '',
+            dateDue: '2023-12-11',
+            dateSent: '2023-05-11',
+            explanation: 'explanation 4',
+            uniqueId: '135135135',
+            directionType: 'sendDirection'
+          },
+        );
+      const directionsHistory = getDirectionHistory(directions as Direction[]);
+      expect(directionsHistory.length).to.be.eql(3);
+      directionsHistory.forEach(direction => {
+        expect(direction).to.contain.keys('date', 'dateObject', 'text', 'links');
+      });
+    });
+
+    it('should return empty direction history', () => {
+      const directionsHistory = getDirectionHistory([]);
+      expect(directionsHistory.length).to.be.eql(0);
     });
   });
 

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -412,6 +412,7 @@ interface Direction {
   explanation: string;
   uniqueId: string;
   clarifyingQuestions?: ClarifyingQuestion;
+  directionType?:  string;
 }
 
 interface ClarifyingQuestion<T> {


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/RIA-6998


### Change description ###
-Update the timeline page when send non standard direction to HO/appellant
-Add necessary unit test


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
