### PR TITLE
RIA-6959 Updates to Home Office Make application event timeline and details

### DIFF
--- a/app/controllers/detail-viewers.ts
+++ b/app/controllers/detail-viewers.ts
@@ -19,7 +19,6 @@ import { addSummaryRow, Delimiter } from '../utils/summary-list';
 import {
   boolToYesNo,
   formatTextForCYA,
-  getAppellantApplications,
   getApplicant,
   getApplicationType,
   toIsoDate

--- a/app/utils/timeline-utils.ts
+++ b/app/utils/timeline-utils.ts
@@ -69,10 +69,9 @@ function getApplicationEvents(makeAnApplications: Collection<Application<Evidenc
         href: `${makeAnApplicationContent.links[0].href}/${application.id}`
       }]
     };
-    let decision;
-    if (application.value.decision !== 'Pending') {
+    if (application.value.decision !== 'Pending' && ['Appellant', 'Legal representative'].includes(application.value.applicant)) {
       const decideAnApplicationContent = i18n.pages.overviewPage.timeline.decideAnApplication[getApplicant(application.value)];
-      decision = {
+      const appellantApplicationDecision = {
         id: application.id,
         date: moment(application.value.decisionDate).format('DD MMMM YYYY'),
         dateObject: new Date(application.value.decisionDate),
@@ -82,7 +81,7 @@ function getApplicationEvents(makeAnApplications: Collection<Application<Evidenc
           href: `${decideAnApplicationContent.links[0].href}/${application.id}`
         }]
       };
-      return [decision, request];
+      return [appellantApplicationDecision, request];
     }
     return [request];
   }) : [];

--- a/locale/en.json
+++ b/locale/en.json
@@ -1618,57 +1618,57 @@
             "Withdraw": [
               "The Tribunal will decide to grant or refuse this request 14 days after the date of the request.",
               "If you are happy for the Home Office to withdraw, you do not need to do anything.",
-              "If you do not want the Home Office to withdraw, you must contact <a href=\"{{ TCO.NewportIAC@justice.gov.uk }}\">TCO.NewportIAC@justice.gov.uk</a> within 14 days of the days of the request."
+              "If you do not want the Home Office to withdraw, you must contact <a href=\"mailto:{{ hearingCentreEmail }}\">{{ hearingCentreEmail }}</a> within 14 days of the days of the request."
             ],
             "Adjourn": [
               "The Tribunal will decide to grant or refuse this request 14 days after the date of the request.",
               "If you are happy for the Home Office to change the hearing date, you do not need to do anything.",
-              "If you do not want the Home Office to change the hearing date, you must contact <a href=\"{{ TCO.NewportIAC@justice.gov.uk }}\">TCO.NewportIAC@justice.gov.uk</a> within 14 days of the days of the request."
+              "If you do not want the Home Office to change the hearing date, you must contact <a href=\"mailto:{{ hearingCentreEmail }}\">{{ hearingCentreEmail }}</a> within 14 days of the days of the request."
             ],
             "Expedite": [
               "The Tribunal will decide to grant or refuse this request 14 days after the date of the request.",
               "If you are happy for the Home Office to have the hearing sooner, you do not need to do anything.",
-              "If you do not want the Home Office to have the hearing sooner, you must contact <a href=\"{{ TCO.NewportIAC@justice.gov.uk }}\">TCO.NewportIAC@justice.gov.uk</a> within 14 days of the days of the request."
+              "If you do not want the Home Office to have the hearing sooner, you must contact <a href=\"mailto:{{ hearingCentreEmail }}\">{{ hearingCentreEmail }}</a> within 14 days of the days of the request."
             ],
             "Judge's review of application decision": [
               "The Tribunal will decide to grant or refuse this request 14 days after the date of the request.",
               "If you are happy for the Home Office to ask a judge to review a decision, you do not need to do anything.",
-              "If you do not want the Home Office to ask a judge to review a decision, you must contact <a href=\"{{ TCO.NewportIAC@justice.gov.uk }}\">TCO.NewportIAC@justice.gov.uk</a> within 14 days of the days of the request."
+              "If you do not want the Home Office to ask a judge to review a decision, you must contact <a href=\"mailto:{{ hearingCentreEmail }}\">{{ hearingCentreEmail }}</a> within 14 days of the days of the request."
             ],
             "Link/unlink appeals": [
               "The Tribunal will decide to grant or refuse this request 14 days after the date of the request.",
               "If you are happy for the Home Office to link or unlink the appeal, you do not need to do anything.",
-              "If you do not want the Home Office to link or unlink the appeal, you must contact <a href=\"{{ TCO.NewportIAC@justice.gov.uk }}\">TCO.NewportIAC@justice.gov.uk</a> within 14 days of the days of the request."
+              "If you do not want the Home Office to link or unlink the appeal, you must contact <a href=\"mailto:{{ hearingCentreEmail }}\">{{ hearingCentreEmail }}</a> within 14 days of the days of the request."
             ],
             "Reinstate": [
               "The Tribunal will decide to grant or refuse this request 14 days after the date of the request.",
               "If you are happy for the Home Office to reinstate the appeal, you do not need to do anything.",
-              "If you do not want the Home Office to reinstate the appeal, you must contact <a href=\"{{ TCO.NewportIAC@justice.gov.uk }}\">TCO.NewportIAC@justice.gov.uk</a> within 14 days of the days of the request."
+              "If you do not want the Home Office to reinstate the appeal, you must contact <a href=\"mailto:{{ hearingCentreEmail }}\">{{ hearingCentreEmail }}</a> within 14 days of the days of the request."
             ],
             "Time extension": [
               "The Tribunal will decide to grant or refuse this request 14 days after the date of the request.",
               "If you are happy for the Home Office to ask for more time, you do not need to do anything.",
-              "If you do not want the Home Office to ask for more time, you must contact <a href=\"{{ TCO.NewportIAC@justice.gov.uk }}\">TCO.NewportIAC@justice.gov.uk</a> within 14 days of the days of the request."
+              "If you do not want the Home Office to ask for more time, you must contact <a href=\"mailto:{{ hearingCentreEmail }}\">{{ hearingCentreEmail }}</a> within 14 days of the days of the request."
             ],
             "Transfer": [
               "The Tribunal will decide to grant or refuse this request 14 days after the date of the request.",
               "If you are happy for the Home Office to move the hearing to a different location, you do not need to do anything.",
-              "If you do not want the Home Office to move the hearing to a different location, you must contact <a href=\"{{ TCO.NewportIAC@justice.gov.uk }}\">TCO.NewportIAC@justice.gov.uk</a> within 14 days of the days of the request."
+              "If you do not want the Home Office to move the hearing to a different location, you must contact <a href=\"mailto:{{ hearingCentreEmail }}\">{{ hearingCentreEmail }}</a> within 14 days of the days of the request."
             ],
             "Update appeal details": [
               "The Tribunal will decide to grant or refuse this request 14 days after the date of the request.",
               "If you are happy for the Home Office to change some of the appeal details, you do not need to do anything.",
-              "If you do not want the Home Office to change some of the appeal details, you must contact <a href=\"{{ TCO.NewportIAC@justice.gov.uk }}\">TCO.NewportIAC@justice.gov.uk</a> within 14 days of the days of the request."
+              "If you do not want the Home Office to change some of the appeal details, you must contact <a href=\"mailto:{{ hearingCentreEmail }}\">{{ hearingCentreEmail }}</a> within 14 days of the days of the request."
             ],
             "Update hearing requirements": [
               "The Tribunal will decide to grant or refuse this request 14 days after the date of the request.",
               "If you are happy for the Home Office to change some of the hearing requirements, you do not need to do anything.",
-              "If you do not want the Home Office to change some of the hearing requirements, you must contact <a href=\"{{ TCO.NewportIAC@justice.gov.uk }}\">TCO.NewportIAC@justice.gov.uk</a> within 14 days of the days of the request."
+              "If you do not want the Home Office to change some of the hearing requirements, you must contact <a href=\"mailto:{{ hearingCentreEmail }}\">{{ hearingCentreEmail }}</a> within 14 days of the days of the request."
             ],
             "Other": [
               "The Tribunal will decide to grant or refuse this request 14 days after the date of the request.",
               "If you are happy for the Home Office to change something about the appeal, you do not need to do anything.",
-              "If you do not want the Home Office to change something about the appeal, you must contact <a href=\"{{ TCO.NewportIAC@justice.gov.uk }}\">TCO.NewportIAC@justice.gov.uk</a> within 14 days of the days of the request."
+              "If you do not want the Home Office to change something about the appeal, you must contact <a href=\"mailto:{{ hearingCentreEmail }}\">{{ hearingCentreEmail }}</a> within 14 days of the days of the request."
             ]
           },
           "request": {

--- a/test/unit/utils/timeline-utils.test.ts
+++ b/test/unit/utils/timeline-utils.test.ts
@@ -119,7 +119,7 @@ describe('timeline-utils', () => {
   });
 
   describe('getApplicationEvents', () => {
-    it('should get application events', () => {
+    it('should get application events and decision for appellant', () => {
       const makeAnApplications: Collection<Application<Evidence>>[] = [
         {
           id: '2',
@@ -154,6 +154,27 @@ describe('timeline-utils', () => {
       const applicationEvents = getApplicationEvents(makeAnApplications);
 
       expect(applicationEvents.length).to.be.eq(3);
+    });
+
+    it('should get application events for respondent', () => {
+      const makeAnApplications: Collection<Application<Evidence>>[] = [
+        {
+          id: '3',
+          value: {
+            applicant: 'Respondent',
+            applicantRole: 'caseworker-ia-homeofficeapc',
+            date: '2021-07-20',
+            decision: 'Granted',
+            details: 'my details',
+            state: 'awaitingReasonsForAppeal',
+            type: 'Time extension',
+            evidence: []
+          }
+        }
+      ];
+      const applicationEvents = getApplicationEvents(makeAnApplications);
+
+      expect(applicationEvents.length).to.be.eq(1);
     });
 
     it('should get application events content for Appellant application', () => {


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/RIA-6959


### Change description ###
* Remove Home Office application decision event from timeline
* Fetch the hearing centre email in the Home office application details dynamically based on the appeal's hearing centre


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
