### PR TITLE
RIA-6114 link to FTPA docs overview page

### DIFF
--- a/locale/en.json
+++ b/locale/en.json
@@ -1083,14 +1083,14 @@
             "granted": [
               "A judge has <b> granted </b> your application for permission to appeal to the Upper Tribunal.",
               "The Decision and Reasons document includes the reasons the judge made this decision. You should read it carefully.",
-              "<a href={{ paths.common.decisionAndReasonsViewer }}>Read the Decision and Reasons document</a>",
+              "<a href={{ paths.common.ftpaDecisionViewer }}>Read the Decision and Reasons document</a>",
               "<b>What happens next</b>",
               "The Upper Tribunal will decide if the Tribunal's decision was wrong. The Upper Tribunal will contact you soon to tell you what will happen next."
             ],
             "partiallyGranted": [
               "A judge has <b> partially granted </b> your application for permission to appeal to the Upper Tribunal.",
               "The Decision and Reasons document includes the reasons the judge made this decision. You should read it carefully.",
-              "<a href={{ paths.common.decisionAndReasonsViewer }}>Read the Decision and Reasons document</a>",
+              "<a href={{ paths.common.ftpaDecisionViewer }}>Read the Decision and Reasons document</a>",
               "<b>What happens next</b>",
               "The Upper Tribunal will decide if the Tribunal's decision was wrong. The Upper Tribunal will contact you soon to tell you what will happen next.",
               "If you think your application should have been fully granted, you can send an application for permission to appeal directly to the Upper Tribunal.",
@@ -1100,7 +1100,7 @@
             "notAdmitted": [
               "A judge has <b> not admitted </b> your application for permission to appeal to the Upper Tribunal.",
               "The Decision and Reasons document includes the reasons the judge made this decision. You should read it carefully.",
-              "<a href={{ paths.common.decisionAndReasonsViewer }}>Read the Decision and Reasons document</a>",
+              "<a href={{ paths.common.ftpaDecisionViewer }}>Read the Decision and Reasons document</a>",
               "<b>What happens next</b>",
               "If you still think the Tribunal's decision was wrong, you can send an application for permission to appeal directly to the Upper Tribunal.",
               "<a class=\"govuk-link\" href=\"https://www.gov.uk/upper-tribunal-immigration-asylum\">Find out how to apply for permission to appeal to the Upper Tribunal</a>",
@@ -1109,7 +1109,7 @@
             "refused": [
               "A judge has <b> refused </b> your application for permission to appeal to the Upper Tribunal.<br>",
               "The Decision and Reasons document includes the reasons the judge made this decision. You should read it carefully.",
-              "<a href={{ paths.common.decisionAndReasonsViewer }}>Read the Decision and Reasons document</a>",
+              "<a href={{ paths.common.ftpaDecisionViewer }}>Read the Decision and Reasons document</a>",
               "<b>What happens next</b>",
               "If you still think the Tribunal's decision was wrong, you can send an application for permission to appeal directly to the Upper Tribunal.",
               "<a class=\"govuk-link\" href=\"https://www.gov.uk/upper-tribunal-immigration-asylum\">Find out how to apply for permission to appeal to the Upper Tribunal</a>",

--- a/test/unit/utils/application-state-utils.test.ts
+++ b/test/unit/utils/application-state-utils.test.ts
@@ -1285,7 +1285,7 @@ describe('application-state-utils', () => {
       'descriptionParagraphs': [
         'A judge has <b> granted </b> your application for permission to appeal to the Upper Tribunal.',
         'The Decision and Reasons document includes the reasons the judge made this decision. You should read it carefully.',
-        '<a href={{ paths.common.decisionAndReasonsViewer }}>Read the Decision and Reasons document</a>',
+        '<a href={{ paths.common.ftpaDecisionViewer }}>Read the Decision and Reasons document</a>',
         '<b>What happens next</b>',
         "The Upper Tribunal will decide if the Tribunal's decision was wrong. The Upper Tribunal will contact you soon to tell you what will happen next."
       ]
@@ -1310,7 +1310,7 @@ describe('application-state-utils', () => {
       'descriptionParagraphs': [
         'A judge has <b> refused </b> your application for permission to appeal to the Upper Tribunal.<br>',
         'The Decision and Reasons document includes the reasons the judge made this decision. You should read it carefully.',
-        '<a href={{ paths.common.decisionAndReasonsViewer }}>Read the Decision and Reasons document</a>',
+        '<a href={{ paths.common.ftpaDecisionViewer }}>Read the Decision and Reasons document</a>',
         '<b>What happens next</b>',
         "If you still think the Tribunal's decision was wrong, you can send an application for permission to appeal directly to the Upper Tribunal.",
         '<a class=\"govuk-link\" href=\"https://www.gov.uk/upper-tribunal-immigration-asylum\">Find out how to apply for permission to appeal to the Upper Tribunal</a>',
@@ -1337,7 +1337,7 @@ describe('application-state-utils', () => {
       'descriptionParagraphs': [
         'A judge has <b> partially granted </b> your application for permission to appeal to the Upper Tribunal.',
         'The Decision and Reasons document includes the reasons the judge made this decision. You should read it carefully.',
-        '<a href={{ paths.common.decisionAndReasonsViewer }}>Read the Decision and Reasons document</a>',
+        '<a href={{ paths.common.ftpaDecisionViewer }}>Read the Decision and Reasons document</a>',
         '<b>What happens next</b>',
         "The Upper Tribunal will decide if the Tribunal's decision was wrong. The Upper Tribunal will contact you soon to tell you what will happen next.",
         'If you think your application should have been fully granted, you can send an application for permission to appeal directly to the Upper Tribunal.',
@@ -1366,7 +1366,7 @@ describe('application-state-utils', () => {
       'descriptionParagraphs': [
         'A judge has <b> not admitted </b> your application for permission to appeal to the Upper Tribunal.',
         'The Decision and Reasons document includes the reasons the judge made this decision. You should read it carefully.',
-        '<a href={{ paths.common.decisionAndReasonsViewer }}>Read the Decision and Reasons document</a>',
+        '<a href={{ paths.common.ftpaDecisionViewer }}>Read the Decision and Reasons document</a>',
         '<b>What happens next</b>',
         "If you still think the Tribunal's decision was wrong, you can send an application for permission to appeal directly to the Upper Tribunal.",
         '<a class=\"govuk-link\" href=\"https://www.gov.uk/upper-tribunal-immigration-asylum\">Find out how to apply for permission to appeal to the Upper Tribunal</a>',
@@ -1394,7 +1394,7 @@ describe('application-state-utils', () => {
       'descriptionParagraphs': [
         'A judge has <b> not admitted </b> your application for permission to appeal to the Upper Tribunal.',
         'The Decision and Reasons document includes the reasons the judge made this decision. You should read it carefully.',
-        '<a href={{ paths.common.decisionAndReasonsViewer }}>Read the Decision and Reasons document</a>',
+        '<a href={{ paths.common.ftpaDecisionViewer }}>Read the Decision and Reasons document</a>',
         '<b>What happens next</b>',
         "If you still think the Tribunal's decision was wrong, you can send an application for permission to appeal directly to the Upper Tribunal.",
         '<a class=\"govuk-link\" href=\"https://www.gov.uk/upper-tribunal-immigration-asylum\">Find out how to apply for permission to appeal to the Upper Tribunal</a>',


### PR DESCRIPTION
### JIRA link (if applicable) ###
[https://tools.hmcts.net/jira/browse/RIA-6114](https://tools.hmcts.net/jira/browse/RIA-6114)


### Change description ###
- Change link to lead to FTPA documents instead of appeal decision documents when FTPA is decided


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
