### PR TITLE
RIA-7056 Transfer to UT overview page toDoNext and timeline sections

### DIFF
--- a/app/controllers/application-overview.ts
+++ b/app/controllers/application-overview.ts
@@ -6,7 +6,7 @@ import { States } from '../data/states';
 import { paths } from '../paths';
 import LaunchDarklyService from '../service/launchDarkly-service';
 import UpdateAppealService from '../service/update-appeal-service';
-import { getAppealApplicationNextStep, isPreAddendumEvidenceUploadState } from '../utils/application-state-utils';
+import { getAppealApplicationNextStep, isPreAddendumEvidenceUploadState, transferredToUpperTribunal } from '../utils/application-state-utils';
 import { getHearingCentre } from '../utils/cma-hearing-details';
 import { formatDate, timeFormat } from '../utils/date-utils';
 import { payLaterForApplicationNeeded, payNowForApplicationNeeded } from '../utils/payments-utils';
@@ -164,6 +164,7 @@ function getApplicationOverview(updateAppealService: UpdateAppealService) {
         stages: stagesStatus,
         saved: isPartiallySaved,
         ended: appealEnded,
+        transferredToUt: transferredToUpperTribunal(req),
         askForMoreTimeInFlight: hasPendingTimeExtension(req.session.appeal),
         askForMoreTime,
         saveAndAskForMoreTime,

--- a/app/data/events.ts
+++ b/app/data/events.ts
@@ -200,5 +200,10 @@ export const Events = {
     id: 'leadershipJudgeFtpaDecision',
     summary: 'Leadership Judge FTPA decision',
     description: 'Leadership Judge FTPA decision'
+  },
+  MARK_AS_READY_FOR_UT_TRANSFER: {
+    id: 'markAsReadyForUtTransfer',
+    summary: 'Transfer appeal to Upper Tribunal',
+    description: 'Transfer appeal to Upper Tribunal'
   }
 };

--- a/app/service/update-appeal-service.ts
+++ b/app/service/update-appeal-service.ts
@@ -428,6 +428,7 @@ export default class UpdateAppealService {
       removeAppealFromOnlineDate: formatDate(caseData.removeAppealFromOnlineDate),
       isDecisionAllowed: caseData.isDecisionAllowed,
       appealOutOfCountry: caseData.appealOutOfCountry,
+      utAppealReferenceNumber: caseData.utAppealReferenceNumber,
       nonStandardDirectionEnabled: false,
       readonlyApplicationEnabled: false,
       application: {

--- a/app/utils/application-state-utils.ts
+++ b/app/utils/application-state-utils.ts
@@ -49,6 +49,7 @@ interface DoThisNextSection {
   decision?: string;
   feedbackTitle?: string;
   feedbackDescription?: string;
+  utAppealReferenceNumber?: string;
 }
 
 /**
@@ -483,20 +484,40 @@ async function getAppealApplicationNextStep(req: Request) {
       };
       break;
     case 'ended':
-      doThisNextSection = {
-        descriptionParagraphs: [
-          i18n.pages.overviewPage.doThisNext.ended.ctaInstruction,
-          i18n.pages.overviewPage.doThisNext.ended.ctaReview,
-          i18n.pages.overviewPage.doThisNext.ended.ctaFeedbackTitle,
-          i18n.pages.overviewPage.doThisNext.ended.ctaFeedbackDescription
-        ],
-        cta: {
-          url: null,
-          ctaTitle: i18n.pages.overviewPage.doThisNext.ended.ctaTitle
-        },
-        allowedAskForMoreTime: false,
-        hearingCentreEmail: getHearingCentreEmail(req)
-      };
+      if (transferredToUpperTribunal(req)) {
+        doThisNextSection = {
+          descriptionParagraphs: [
+            i18n.pages.overviewPage.doThisNext.transferredToUt.description,
+            i18n.pages.overviewPage.doThisNext.transferredToUt.explanation,
+            i18n.pages.overviewPage.doThisNext.transferredToUt.utAppealReferenceNumber,
+            i18n.pages.overviewPage.doThisNext.transferredToUt.utAction
+          ],
+          info: {
+            title: i18n.pages.overviewPage.doThisNext.transferredToUt.usefulDocuments.title,
+            url: i18n.pages.overviewPage.doThisNext.transferredToUt.usefulDocuments.url
+          },
+          usefulDocuments: {
+            title: i18n.pages.overviewPage.doThisNext.transferredToUt.info.title,
+            url: i18n.pages.overviewPage.doThisNext.transferredToUt.info.description
+          },
+          utAppealReferenceNumber: req.session.appeal.utAppealReferenceNumber
+        };
+      } else {
+        doThisNextSection = {
+          descriptionParagraphs: [
+            i18n.pages.overviewPage.doThisNext.ended.ctaInstruction,
+            i18n.pages.overviewPage.doThisNext.ended.ctaReview,
+            i18n.pages.overviewPage.doThisNext.ended.ctaFeedbackTitle,
+            i18n.pages.overviewPage.doThisNext.ended.ctaFeedbackDescription
+          ],
+          cta: {
+            url: null,
+            ctaTitle: i18n.pages.overviewPage.doThisNext.ended.ctaTitle
+          },
+          allowedAskForMoreTime: false,
+          hearingCentreEmail: getHearingCentreEmail(req)
+        };
+      }
       break;
     case 'appealTakenOffline':
       doThisNextSection = {
@@ -637,11 +658,16 @@ function eventByLegalRep(req: Request, eventId: string, state: string): boolean 
     && event.user.id !== req.idam.userDetails.uid).length > 0;
 }
 
+function transferredToUpperTribunal(req: Request): boolean {
+  return req.session.appeal.utAppealReferenceNumber == null ? false : true;
+}
+
 export {
   getAppealApplicationNextStep,
   getAppealStatus,
   getMoveAppealOfflineReason,
   getMoveAppealOfflineDate,
   isPreAddendumEvidenceUploadState,
-  eventByLegalRep
+  eventByLegalRep,
+  transferredToUpperTribunal
 };

--- a/app/utils/timeline-utils.ts
+++ b/app/utils/timeline-utils.ts
@@ -8,6 +8,7 @@ import { paths } from '../paths';
 import { SecurityHeaders } from '../service/authentication-service';
 import LaunchDarklyService from '../service/launchDarkly-service';
 import UpdateAppealService from '../service/update-appeal-service';
+import { transferredToUpperTribunal } from './application-state-utils';
 import {
   getAppellantApplications,
   getApplicant,
@@ -217,7 +218,8 @@ function getEventsAndStates(uploadAddendumEvidenceFeatureEnabled: boolean,
     Events.REQUEST_HEARING_REQUIREMENTS_FEATURE.id,
     Events.END_APPEAL.id,
     Events.END_APPEAL_AUTOMATICALLY.id,
-    Events.RECORD_OUT_OF_TIME_DECISION.id
+    Events.RECORD_OUT_OF_TIME_DECISION.id,
+    Events.MARK_AS_READY_FOR_UT_TRANSFER.id
   ];
   const appealDecisionSectionEvents = [Events.SEND_DECISION_AND_REASONS.id];
 

--- a/locale/en.json
+++ b/locale/en.json
@@ -800,6 +800,7 @@
       "email": "Email:",
       "emailLink": "contactia@justice.gov.uk",
       "endedInsert": "This appeal has ended",
+      "transferredToUt": "Appeal moved to the Upper Tribunal",
       "time": "Monday to Friday, 8:30am to 5pm",
       "charges": "Find out about call charges",
       "newWindow": "(opens in a new window)",
@@ -1054,7 +1055,7 @@
           "feedbackTitle": "<h3 class=\"govuk-heading-s govuk-!-margin-bottom-0\">Tell us what you think</h3>",
           "feedbackDescription": "<a class=\"govuk-link\" href=\"https://www.smartsurvey.co.uk/s/AiPImmigrationAsylum_Exit/\" target=\"_blank\">Take a short survey about this service (opens in a new window)</a>."
         },
-        "ftpaSubmitted":{
+        "ftpaSubmitted": {
           "description": {
             "appellant": [
               "A judge will decide your application for permission to appeal to the Upper Tribunal.",
@@ -1120,6 +1121,20 @@
               "<a class=\"govuk-link\" href=\"https://www.gov.uk/upper-tribunal-immigration-asylum\">Find out how to apply for permission to appeal to the Upper Tribunal</a>",
               "You must send your application by {{ applicationNextStep.ftpaDeadline }}"
             ]
+          }
+        },
+        "transferredToUt": {
+          "description": "Your appeal has been moved to the Upper Tribunal, which is a higher tribunal than the First-tier tribunal.",
+          "explanation": "This is because you also have an expedited section 82A appeal in the Upper Tribunal, with the following appeal reference:",
+          "utAppealReferenceNumber": "{{ applicationNextStep.utAppealReferenceNumber }}",
+          "utAction": "An Upper Tribunal judge will decide both appeals at the same time.",
+          "info": {
+            "title": "What happens next",
+            "description": "The upper tribunal may contact you about this appeal.<br/>If you still have to respond to a question about your appeal from the First-tier Tribunal, you should tell the Upper Tribunal. The Upper Tribunal will decide what will happen next."
+          },
+          "usefulDocuments": {
+            "title": "Helpful Information",
+            "url": "<a class=\"govuk-link\" href=\"https://www.gov.uk/courts-tribunals/upper-tribunal-administrative-appeals-chamber\">Find out more about the Upper Tribunal, including contact details (Opens in a new window)</a>"
           }
         }
       },
@@ -1526,6 +1541,9 @@
               }
             ]
           }
+        },
+        "markAsReadyForUtTransfer": {
+          "text": "Your appeal moved to the Upper Tribunal"
         }
       }
     },

--- a/test/unit/controllers/application-overview.test.ts
+++ b/test/unit/controllers/application-overview.test.ts
@@ -179,6 +179,7 @@ describe('Confirmation Page Controller', () => {
       stages: expectedStages,
       saved: false,
       ended: false,
+      transferredToUt: false,
       askForMoreTimeInFlight: false,
       askForMoreTime: false,
       saveAndAskForMoreTime: false,
@@ -238,6 +239,7 @@ describe('Confirmation Page Controller', () => {
       stages: expectedStages,
       saved: false,
       ended: false,
+      transferredToUt: false,
       askForMoreTimeInFlight: false,
       askForMoreTime: false,
       saveAndAskForMoreTime: false,
@@ -298,6 +300,7 @@ describe('Confirmation Page Controller', () => {
       stages: expectedStages,
       saved: false,
       ended: false,
+      transferredToUt: false,
       askForMoreTimeInFlight: false,
       askForMoreTime: false,
       saveAndAskForMoreTime: false,
@@ -326,6 +329,7 @@ describe('Confirmation Page Controller', () => {
     req.session.appeal.appealStatus = 'appealStarted';
     req.session.appeal.application.homeOfficeRefNumber = 'A1234567';
     req.session.appeal.appealReferenceNumber = 'RP/50004/2020';
+    req.session.appeal.utAppealReferenceNumber = null;
 
     await getApplicationOverview(updateAppealService as UpdateAppealService)(req as Request, res as Response, next);
 
@@ -370,6 +374,7 @@ describe('Confirmation Page Controller', () => {
       stages: expectedStages,
       saved: false,
       ended: false,
+      transferredToUt: false,
       askForMoreTimeInFlight: false,
       askForMoreTime: false,
       saveAndAskForMoreTime: false,
@@ -444,6 +449,7 @@ describe('Confirmation Page Controller', () => {
       stages: expectedStages,
       saved: false,
       ended: false,
+      transferredToUt: false,
       askForMoreTimeInFlight: false,
       askForMoreTime: false,
       saveAndAskForMoreTime: false,

--- a/test/unit/utils/timeline-utils.test.ts
+++ b/test/unit/utils/timeline-utils.test.ts
@@ -489,13 +489,13 @@ describe('timeline-utils', () => {
   describe('getEventsAndStates', () => {
     it('should return relevant events and states when uploadAddendumEvidence feature enabled', () => {
       const eventsAndStates = getEventsAndStates(true, true, false);
-      expect(eventsAndStates.appealArgumentSectionEvents.length).to.be.eqls(16);
+      expect(eventsAndStates.appealArgumentSectionEvents.length).to.be.eqls(17);
       expect(eventsAndStates.appealArgumentSectionStates.length).to.be.eqls(14);
     });
 
     it('should return relevant events and states when uploadAddendumEvidence feature disabled', () => {
       const eventsAndStates = getEventsAndStates(false, true, false);
-      expect(eventsAndStates.appealArgumentSectionEvents.length).to.be.eqls(12);
+      expect(eventsAndStates.appealArgumentSectionEvents.length).to.be.eqls(13);
       expect(eventsAndStates.appealArgumentSectionStates.length).to.be.eqls(11);
     });
 

--- a/types/caseData.d.ts
+++ b/types/caseData.d.ts
@@ -170,6 +170,7 @@ interface CaseData {
   ftpaAppellantDecisionOutcomeType?: string;
   ftpaAppellantDecisionDocument?: Collection<DocumentWithDescription | DocumentWithMetaData>[];
   ftpaAppellantDecisionDate?: string;
+  utAppealReferenceNumber?: string;
 }
 
 interface Application<T> {

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -186,6 +186,7 @@ interface Appeal {
   ftpaAppellantDecisionDate?: string;
   nonStandardDirectionEnabled?: boolean;
   readonlyApplicationEnabled?: boolean;
+  utAppealReferenceNumber?: string;
 }
 
 interface Hearing {

--- a/views/application-overview.njk
+++ b/views/application-overview.njk
@@ -17,10 +17,14 @@
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-two-thirds">
         <div class="banner-line"></div>
-        {% if ended %}
-        <div class="govuk-inset-text inset-bold">
-          {{ i18n.pages.overviewPage.endedInsert }}
-        </div>      
+        {% if ended and transferredToUt %}
+            <div class="govuk-inset-text inset-bold">
+              {{ i18n.pages.overviewPage.transferredToUt }}
+            </div>
+        {% elif ended %}
+            <div class="govuk-inset-text inset-bold">
+              {{ i18n.pages.overviewPage.endedInsert }}
+            </div>
         {% else %}
           {{ progressBar(stages) }}
         {% endif %}


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/RIA-7056


### Change description ###
* Added transferToUt content for toDoNext section of overview page
* Dynamically returned correct dict for doThisNext for ended state depending on if utAppealReferenceNumber is present
* Added utility to check if appeal ended state reached via transferToUT event
* Added transferToUT event for timeline
* Added markAsReadyForUtTransfer event
* Added markAsReadyForUtTransfer event to appealArgument section
* Added utAppealReferenceNumber to appeal interface
* Added utAppealReferenceNumber to service class so that it can be read from case data
* Updates tests

### Testing ###
AiP overview page and timeline when appeal is in ended state after being transferred to UT
![image](https://github.com/hmcts/ia-aip-frontend/assets/118450580/8aa74bb7-779b-402d-80d0-3165ec901235)

AiP overview page (doThisNext) section updates only when there is a change in case state. Unlike the timeline section, triggering events cannot update the UI, only when the case state changes. So, ended state content is shared by the normal flow to end appeal, as well as transfer to UT. The code returns a dictionary for ended state, but the dict returned is dynamic based on if UtAppealReferenceNumber exists or not (if it exists, it means case was transferred to UT so the content for ended state should be the transferredToUt content, and when it utAppealReferenceNumber does not exist, the dict returned for ended state contains the standard 'case ended' content.
For the reasons above, I have tested AiP overview/timeline when case is ended normally to ensure my changes have not broken the existing functionality/content, which I can confirm it hasn't. Screenshot for AiP content on ended state.

![image](https://github.com/hmcts/ia-aip-frontend/assets/118450580/324c07c3-01b9-41bb-b805-ba6210168cb4)



**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
