### PR TITLE
DIAC-002 adding initial renovate.json. However the github repository …

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,4 +1,31 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": ["local>hmcts/.github:renovate-config"]
+  "extends": ["local>hmcts/.github:renovate-config"],
+  "labels": ["dependencies"],
+  "packageRules": [
+    {
+      "matchPackagePatterns": [
+        "*"
+      ],
+      "matchUpdateTypes": [
+        "minor",
+        "patch"
+      ],
+      "groupName": "all non-major dependencies",
+      "groupSlug": "all-minor-patch",
+      "automerge": true
+    },
+    {
+      "matchPackageNames": ["com.github.hmcts:ccd-case-document-am-client"],
+      "enabled": false
+    },
+    {
+      "matchUpdateTypes": ["major"],
+      "enabled": false
+    }
+  ],
+  "timezone": "Europe/London",
+  "schedule": [
+    "before 3am every weekday"
+  ]
 }

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,0 +1,31 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": ["local>hmcts/.github:renovate-config"],
+  "labels": ["dependencies"],
+  "packageRules": [
+    {
+      "matchPackagePatterns": [
+        "*"
+      ],
+      "matchUpdateTypes": [
+        "minor",
+        "patch"
+      ],
+      "groupName": "all non-major dependencies",
+      "groupSlug": "all-minor-patch",
+      "automerge": true
+    },
+    {
+      "matchPackageNames": ["com.github.hmcts:ccd-case-document-am-client"],
+      "enabled": false
+    },
+    {
+      "matchUpdateTypes": ["major"],
+      "enabled": false
+    }
+  ],
+  "timezone": "Europe/London",
+  "schedule": [
+    "before 3am every weekday"
+  ]
+}

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,31 +1,4 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": ["local>hmcts/.github:renovate-config"],
-  "labels": ["dependencies"],
-  "packageRules": [
-    {
-      "matchPackagePatterns": [
-        "*"
-      ],
-      "matchUpdateTypes": [
-        "minor",
-        "patch"
-      ],
-      "groupName": "all non-major dependencies",
-      "groupSlug": "all-minor-patch",
-      "automerge": true
-    },
-    {
-      "matchPackageNames": ["com.github.hmcts:ccd-case-document-am-client"],
-      "enabled": false
-    },
-    {
-      "matchUpdateTypes": ["major"],
-      "enabled": false
-    }
-  ],
-  "timezone": "Europe/London",
-  "schedule": [
-    "before 3am every weekday"
-  ]
+  "extends": ["local>hmcts/.github:renovate-config"]
 }


### PR DESCRIPTION
…needs renovate initialised

### Jira link (if applicable)

https://tools.hmcts.net/jira/browse/DIAC-2

### Change description ###
Added renovate.json for renovate config options. Repo needs renovate intialised.

### Checklist

- [x] commit messages are meaningful and follow good commit message guidelines
- [x] README and other documentation has been updated / added (if needed)
- [x] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
