### PR TITLE
RIA-8633 FTPA decision documents refactoring with new document fields

### DIFF
--- a/app/config/idam-config.ts
+++ b/app/config/idam-config.ts
@@ -14,7 +14,7 @@ export const idamConfig = {
   idamRegistrationUrl: `${config.get('idam.webUrl')}/users/selfRegister`,
   idamSecret: config.get('idam.secret'),
   idamClientID: config.get('microservice'),
-  openId: false,
+  openId: true,
   logger: null
 };
 

--- a/app/config/idam-config.ts
+++ b/app/config/idam-config.ts
@@ -14,7 +14,7 @@ export const idamConfig = {
   idamRegistrationUrl: `${config.get('idam.webUrl')}/users/selfRegister`,
   idamSecret: config.get('idam.secret'),
   idamClientID: config.get('microservice'),
-  openId: true,
+  openId: false,
   logger: null
 };
 

--- a/app/controllers/detail-viewers.ts
+++ b/app/controllers/detail-viewers.ts
@@ -791,6 +791,7 @@ async function getFtpaRespondentDecisionDetails(req: Request, res: Response, nex
     const ftpaDecision = req.session.appeal.ftpaRespondentDecisionOutcomeType || req.session.appeal.ftpaRespondentRjDecisionOutcomeType;
     const ftpaDecisionAndReasonsDocument = req.session.appeal.ftpaRespondentDecisionDocument;
     const ftpaR35RespondentDocument = [req.session.appeal.ftpaR35RespondentDocument];
+    const ftpaApplicationRespondentDocument = [req.session.appeal.ftpaApplicationRespondentDocument];
     const ftpaDecisionDate = req.session.appeal.ftpaRespondentDecisionDate;
     const ftpaSetAsideFeatureEnabled: boolean = await LaunchDarklyService.getInstance().getVariation(req, FEATURE_FLAGS.DLRM_SETASIDE_FEATURE_FLAG, false);
 
@@ -819,7 +820,11 @@ async function getFtpaRespondentDecisionDetails(req: Request, res: Response, nex
         attachFtpaDocuments(ftpaR35RespondentDocument, data.decision, i18n.pages.detailViewers.ftpaDecision.decisionDocument);
       }
     }
-    attachFtpaDocuments(ftpaDecisionAndReasonsDocument, data.decision, i18n.pages.detailViewers.ftpaDecision.decisionDocument);
+    if (ftpaSetAsideFeatureEnabled && (ftpaApplicationRespondentDocument.length === 1 && ftpaApplicationRespondentDocument[0] !== null) && ftpaDecision !== 'reheardRule35') {
+      attachFtpaDocuments(ftpaApplicationRespondentDocument, data.decision, i18n.pages.detailViewers.ftpaDecision.decisionDocument);
+    } else {
+      attachFtpaDocuments(ftpaDecisionAndReasonsDocument, data.decision, i18n.pages.detailViewers.ftpaDecision.decisionDocument);
+    }
     if (ftpaDecisionDate) {
       data.decision.push(addSummaryRow(i18n.pages.detailViewers.ftpaDecision.date, [ formatTextForCYA(moment(ftpaDecisionDate).format(dayMonthYearFormat)) ]));
     }
@@ -845,6 +850,7 @@ async function getFtpaAppellantDecisionDetails(req: Request, res: Response, next
     const ftpaApplicationDate = req.session.appeal.ftpaAppellantApplicationDate;
     const ftpaDecision = req.session.appeal.ftpaAppellantDecisionOutcomeType || req.session.appeal.ftpaAppellantRjDecisionOutcomeType;
     const ftpaDecisionAndReasonsDocument = req.session.appeal.ftpaAppellantDecisionDocument;
+    const ftpaApplicationAppellantDocument = [req.session.appeal.ftpaApplicationAppellantDocument];
     const ftpaR35AppellantDocument = [req.session.appeal.ftpaR35AppellantDocument];
     const ftpaDecisionDate = req.session.appeal.ftpaAppellantDecisionDate;
     const ftpaSetAsideFeatureEnabled: boolean = await LaunchDarklyService.getInstance().getVariation(req, FEATURE_FLAGS.DLRM_SETASIDE_FEATURE_FLAG, false);
@@ -871,7 +877,11 @@ async function getFtpaAppellantDecisionDetails(req: Request, res: Response, next
         attachFtpaDocuments(ftpaR35AppellantDocument, data.decision, i18n.pages.detailViewers.ftpaDecision.decisionDocument);
       }
     }
-    attachFtpaDocuments(ftpaDecisionAndReasonsDocument, data.decision, i18n.pages.detailViewers.ftpaDecision.decisionDocument);
+    if (ftpaSetAsideFeatureEnabled && (ftpaApplicationAppellantDocument.length === 1 && ftpaApplicationAppellantDocument[0] !== null) && ftpaDecision !== 'reheardRule35') {
+      attachFtpaDocuments(ftpaApplicationAppellantDocument, data.decision, i18n.pages.detailViewers.ftpaDecision.decisionDocument);
+    } else {
+      attachFtpaDocuments(ftpaDecisionAndReasonsDocument, data.decision, i18n.pages.detailViewers.ftpaDecision.decisionDocument);
+    }
     if (ftpaDecisionDate) {
       data.decision.push(addSummaryRow(i18n.pages.detailViewers.ftpaDecision.date, [ formatTextForCYA(moment(ftpaDecisionDate).format(dayMonthYearFormat)) ]));
     }

--- a/app/middleware/journeyAllowed-middleware.ts
+++ b/app/middleware/journeyAllowed-middleware.ts
@@ -3,9 +3,6 @@ import { paths } from '../paths';
 import { hasPendingTimeExtension } from '../utils/utils';
 
 const isJourneyAllowedMiddleware = (req: Request, res: Response, next: NextFunction) => {
-  if (req.idam && req.idam.userDetails) {
-    req.idam.userDetails.uid = req.idam.userDetails.id;
-  }
   const currentPath: string = req.path;
   const appealStatusPathsCopy = { ...paths[req.session.appeal.appealStatus] } || {};
   const appealStatusPaths = Object.values(appealStatusPathsCopy).map((path: string) => {

--- a/app/middleware/journeyAllowed-middleware.ts
+++ b/app/middleware/journeyAllowed-middleware.ts
@@ -3,6 +3,9 @@ import { paths } from '../paths';
 import { hasPendingTimeExtension } from '../utils/utils';
 
 const isJourneyAllowedMiddleware = (req: Request, res: Response, next: NextFunction) => {
+  if (req.idam && req.idam.userDetails) {
+    req.idam.userDetails.uid = req.idam.userDetails.id;
+  }
   const currentPath: string = req.path;
   const appealStatusPathsCopy = { ...paths[req.session.appeal.appealStatus] } || {};
   const appealStatusPaths = Object.values(appealStatusPathsCopy).map((path: string) => {

--- a/app/service/authentication-service.ts
+++ b/app/service/authentication-service.ts
@@ -23,9 +23,6 @@ class AuthenticationService {
   }
 
   async getSecurityHeaders(req: Request): Promise<SecurityHeaders> {
-    if (req.idam && req.idam.userDetails) {
-      req.idam.userDetails.uid = req.idam.userDetails.id;
-    }
     const userToken = this.idamService.getUserToken(req);
     const serviceToken = await this.s2sService.getServiceToken();
     return { userToken, serviceToken };

--- a/app/service/authentication-service.ts
+++ b/app/service/authentication-service.ts
@@ -23,6 +23,9 @@ class AuthenticationService {
   }
 
   async getSecurityHeaders(req: Request): Promise<SecurityHeaders> {
+    if (req.idam && req.idam.userDetails) {
+      req.idam.userDetails.uid = req.idam.userDetails.id;
+    }
     const userToken = this.idamService.getUserToken(req);
     const serviceToken = await this.s2sService.getServiceToken();
     return { userToken, serviceToken };

--- a/app/service/update-appeal-service.ts
+++ b/app/service/update-appeal-service.ts
@@ -153,6 +153,8 @@ export default class UpdateAppealService {
     let reasonsForAppealDocumentUploads: Evidence[] = null;
     let reheardRule35AppellantDocument: Evidence = null;
     let reheardRule35RespondentDocument: Evidence = null;
+    let ftpaApplicationRespondentDocument: Evidence = null;
+    let ftpaApplicationAppellantDocument: Evidence = null;
     let requestClarifyingQuestionsDirection: Collection<CcdDirection>;
     let cmaRequirements: CmaRequirements = {};
     let hearingRequirements: HearingRequirements = {};
@@ -431,6 +433,14 @@ export default class UpdateAppealService {
       reheardRule35RespondentDocument = this.mapSupportingDocumentToEvidence(caseData.ftpaR35RespondentDocument, documentMap);
     }
 
+    if (caseData.ftpaApplicationRespondentDocument && caseData.ftpaApplicationRespondentDocument.document_filename) {
+      ftpaApplicationRespondentDocument = this.mapSupportingDocumentToEvidence(caseData.ftpaApplicationRespondentDocument, documentMap);
+    }
+
+    if (caseData.ftpaApplicationAppellantDocument && caseData.ftpaApplicationAppellantDocument.document_filename) {
+      ftpaApplicationAppellantDocument = this.mapSupportingDocumentToEvidence(caseData.ftpaApplicationAppellantDocument, documentMap);
+    }
+
     const appeal: Appeal = {
       ccdCaseId: ccdCase.id,
       appealStatus: ccdCase.state,
@@ -444,6 +454,8 @@ export default class UpdateAppealService {
       nonStandardDirectionEnabled: true,
       ftpaR35AppellantDocument: reheardRule35AppellantDocument,
       ftpaR35RespondentDocument: reheardRule35RespondentDocument,
+      ftpaApplicationRespondentDocument: ftpaApplicationRespondentDocument,
+      ftpaApplicationAppellantDocument: ftpaApplicationAppellantDocument,
       readonlyApplicationEnabled: true,
       application: {
         appellantOutOfCountryAddress: caseData.appellantOutOfCountryAddress,

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "start": "cross-env NODE_PATH=. node build/main.js",
     "build": "webpack --config webpack/webpack.prod.js",
-    "dev": "cross-env NODE_ENV=development DEFAULT_LAUNCH_DARKLY_FLAG=false nodemon app/server.ts",
+    "dev": "cross-env NODE_ENV=development DEFAULT_LAUNCH_DARKLY_FLAG=false nodemon --inspect app/server.ts",
     "dev:mock": "concurrently \"yarn mock-ccd\" \"yarn mock-idam\" \"yarn mock-postcode\" \"yarn mock-dm-store\" \"yarn mock-s2s\" \"IDAM_WEB_URL=http://localhost:20001 IDAM_API_URL=http://localhost:20001 CCD_API_URL=http://localhost:20000 ADDRESS_LOOKUP_URL=http://localhost:20002 DOC_MANAGEMENT_URL=http://localhost:20003 CASE_DOCUMENT_AM_URL=http://localhost:20003 S2S_URL=http://localhost:20004 yarn dev\"",
     "mock-ccd": "dyson test/mock/ccd/services/ 20000",
     "mock-idam": "dyson test/mock/idam/services/ 20001",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "start": "cross-env NODE_PATH=. node build/main.js",
     "build": "webpack --config webpack/webpack.prod.js",
-    "dev": "cross-env NODE_ENV=development DEFAULT_LAUNCH_DARKLY_FLAG=false nodemon --inspect app/server.ts",
+    "dev": "cross-env NODE_ENV=development DEFAULT_LAUNCH_DARKLY_FLAG=false nodemon app/server.ts",
     "dev:mock": "concurrently \"yarn mock-ccd\" \"yarn mock-idam\" \"yarn mock-postcode\" \"yarn mock-dm-store\" \"yarn mock-s2s\" \"IDAM_WEB_URL=http://localhost:20001 IDAM_API_URL=http://localhost:20001 CCD_API_URL=http://localhost:20000 ADDRESS_LOOKUP_URL=http://localhost:20002 DOC_MANAGEMENT_URL=http://localhost:20003 CASE_DOCUMENT_AM_URL=http://localhost:20003 S2S_URL=http://localhost:20004 yarn dev\"",
     "mock-ccd": "dyson test/mock/ccd/services/ 20000",
     "mock-idam": "dyson test/mock/idam/services/ 20001",

--- a/test/unit/controllers/detail-viewers.test.ts
+++ b/test/unit/controllers/detail-viewers.test.ts
@@ -2967,6 +2967,470 @@ describe('Detail viewer Controller', () => {
       });
     });
 
+    it('should render ftpa-application/ftpa-decision-details-viewer.nj for FTPA Application by: Appellant for Decide FTPA Application event with decision: granted', async () => {
+      req.session.appeal = {
+        ...req.session.appeal,
+        ftpaApplicantType: 'appellant',
+        ftpaAppellantGrounds: 'ftpaAppellantGrounds',
+        ftpaAppellantApplicationDate: '2023-03-20',
+        ftpaAppellantEvidenceDocuments: [ ...documents ],
+        ftpaAppellantOutOfTimeExplanation: 'ftpaAppellantOutOfTimeExplanation',
+        ftpaAppellantOutOfTimeDocuments: [ ...documents ],
+        ftpaAppellantDecisionDate: '2023-03-20',
+        ftpaAppellantDecisionDocument: [],
+        ftpaApplicationAppellantDocument: document,
+        ftpaAppellantRjDecisionOutcomeType: 'granted'
+      };
+
+      documents[0].name = 'FTPA_Appellant_Doc.PDF';
+      document.name = 'FTPA_Granted_Doc.PDF';
+
+      const expectedSummaryRows = {
+        application: [
+          {
+            key: { text: i18n.pages.detailViewers.ftpaApplication.grounds },
+            value: { html: 'ftpaAppellantGrounds' }
+          },
+          {
+            key: { text: i18n.pages.detailViewers.ftpaApplication.evidence },
+            value: { html: `<a class='govuk-link' target='_blank' rel='noopener noreferrer' href='/view/document/976fa409-4aab-40a4-a3f9-0c918f7293c8'>FTPA_Appellant_Doc.PDF</a>` }
+          },
+          {
+            key: { text: i18n.pages.detailViewers.ftpaApplication.date },
+            value: { html: '20&nbsp;March&nbsp;2023' }
+          },
+          {
+            key: { text: i18n.pages.detailViewers.ftpaApplication.outOfTimeReason },
+            value: { html: 'ftpaAppellantOutOfTimeExplanation' }
+          },
+          {
+            key: { text: i18n.pages.detailViewers.ftpaApplication.outOfTimeEvidence },
+            value: { html: `<a class='govuk-link' target='_blank' rel='noopener noreferrer' href='/view/document/976fa409-4aab-40a4-a3f9-0c918f7293c8'>FTPA_Appellant_Doc.PDF</a>` }
+          }
+        ],
+        decision: [
+          {
+            key: { text: i18n.pages.detailViewers.ftpaDecision.decision },
+            value: { html: 'Granted' }
+          },
+          {
+            key: { text: i18n.pages.detailViewers.ftpaDecision.decisionDocument },
+            value: { html: `<a class='govuk-link' target='_blank' rel='noopener noreferrer' href='/view/document/976fa409-4aab-40a4-a3f9-0c918f7293c8'>FTPA_Granted_Doc.PDF</a>` }
+          },
+          {
+            key: { text: i18n.pages.detailViewers.ftpaDecision.date },
+            value: { html: '20&nbsp;March&nbsp;2023' }
+          }
+        ]
+      };
+
+      sandbox.stub(LaunchDarklyService.prototype, 'getVariation').withArgs(req as Request, FEATURE_FLAGS.DLRM_SETASIDE_FEATURE_FLAG, false).resolves(true);
+      await getFtpaDecisionDetails(req as Request, res as Response, next);
+
+      expect(res.render).to.have.been.calledWith('ftpa-application/ftpa-decision-details-viewer.njk', {
+        title: i18n.pages.detailViewers.ftpaApplication.title.appellant,
+        subTitle: i18n.pages.detailViewers.ftpaDecision.title,
+        data: expectedSummaryRows,
+        previousPage: paths.common.overview
+      });
+    });
+
+    it('should render ftpa-application/ftpa-decision-details-viewer.nj for FTPA Application by: Appellant for Decide FTPA Application event with decision: partially granted', async () => {
+      req.session.appeal = {
+        ...req.session.appeal,
+        ftpaApplicantType: 'appellant',
+        ftpaAppellantGrounds: 'ftpaAppellantGrounds',
+        ftpaAppellantApplicationDate: '2023-03-20',
+        ftpaAppellantEvidenceDocuments: [ ...documents ],
+        ftpaAppellantOutOfTimeExplanation: 'ftpaAppellantOutOfTimeExplanation',
+        ftpaAppellantOutOfTimeDocuments: [ ...documents ],
+        ftpaAppellantDecisionDate: '2023-03-20',
+        ftpaAppellantDecisionDocument: [],
+        ftpaApplicationAppellantDocument: document,
+        ftpaAppellantRjDecisionOutcomeType: 'granted'
+      };
+
+      documents[0].name = 'FTPA_Appellant_Doc.PDF';
+      document.name = 'FTPA_Granted_Doc.PDF';
+
+      const expectedSummaryRows = {
+        application: [
+          {
+            key: { text: i18n.pages.detailViewers.ftpaApplication.grounds },
+            value: { html: 'ftpaAppellantGrounds' }
+          },
+          {
+            key: { text: i18n.pages.detailViewers.ftpaApplication.evidence },
+            value: { html: `<a class='govuk-link' target='_blank' rel='noopener noreferrer' href='/view/document/976fa409-4aab-40a4-a3f9-0c918f7293c8'>FTPA_Appellant_Doc.PDF</a>` }
+          },
+          {
+            key: { text: i18n.pages.detailViewers.ftpaApplication.date },
+            value: { html: '20&nbsp;March&nbsp;2023' }
+          },
+          {
+            key: { text: i18n.pages.detailViewers.ftpaApplication.outOfTimeReason },
+            value: { html: 'ftpaAppellantOutOfTimeExplanation' }
+          },
+          {
+            key: { text: i18n.pages.detailViewers.ftpaApplication.outOfTimeEvidence },
+            value: { html: `<a class='govuk-link' target='_blank' rel='noopener noreferrer' href='/view/document/976fa409-4aab-40a4-a3f9-0c918f7293c8'>FTPA_Appellant_Doc.PDF</a>` }
+          }
+        ],
+        decision: [
+          {
+            key: { text: i18n.pages.detailViewers.ftpaDecision.decision },
+            value: { html: 'Granted' }
+          },
+          {
+            key: { text: i18n.pages.detailViewers.ftpaDecision.decisionDocument },
+            value: { html: `<a class='govuk-link' target='_blank' rel='noopener noreferrer' href='/view/document/976fa409-4aab-40a4-a3f9-0c918f7293c8'>FTPA_Granted_Doc.PDF</a>` }
+          },
+          {
+            key: { text: i18n.pages.detailViewers.ftpaDecision.date },
+            value: { html: '20&nbsp;March&nbsp;2023' }
+          }
+        ]
+      };
+
+      sandbox.stub(LaunchDarklyService.prototype, 'getVariation').withArgs(req as Request, FEATURE_FLAGS.DLRM_SETASIDE_FEATURE_FLAG, false).resolves(true);
+      await getFtpaDecisionDetails(req as Request, res as Response, next);
+
+      expect(res.render).to.have.been.calledWith('ftpa-application/ftpa-decision-details-viewer.njk', {
+        title: i18n.pages.detailViewers.ftpaApplication.title.appellant,
+        subTitle: i18n.pages.detailViewers.ftpaDecision.title,
+        data: expectedSummaryRows,
+        previousPage: paths.common.overview
+      });
+    });
+
+    it('should render ftpa-application/ftpa-decision-details-viewer.nj for FTPA Application by: Appellant for Decide FTPA Application event with decision: refused', async () => {
+      req.session.appeal = {
+        ...req.session.appeal,
+        ftpaApplicantType: 'appellant',
+        ftpaAppellantApplicationDate: '2023-03-20',
+        ftpaAppellantDecisionDate: '2023-03-20',
+        ftpaAppellantDecisionDocument: [],
+        ftpaApplicationAppellantDocument: document,
+        ftpaAppellantRjDecisionOutcomeType: 'refused'
+      };
+
+      documents[0].name = 'FTPA_Appellant_Doc.PDF';
+      document.name = 'FTPA_Refused_Doc.PDF';
+
+      const expectedSummaryRows = {
+        application: [
+          {
+            key: { text: i18n.pages.detailViewers.ftpaApplication.date },
+            value: { html: '20&nbsp;March&nbsp;2023' }
+          }
+        ],
+        decision: [
+          {
+            key: { text: i18n.pages.detailViewers.ftpaDecision.decision },
+            value: { html: 'Refused' }
+          },
+          {
+            key: { text: i18n.pages.detailViewers.ftpaDecision.decisionDocument },
+            value: { html: `<a class='govuk-link' target='_blank' rel='noopener noreferrer' href='/view/document/976fa409-4aab-40a4-a3f9-0c918f7293c8'>FTPA_Refused_Doc.PDF</a>` }
+          },
+          {
+            key: { text: i18n.pages.detailViewers.ftpaDecision.date },
+            value: { html: '20&nbsp;March&nbsp;2023' }
+          }
+        ]
+      };
+
+      sandbox.stub(LaunchDarklyService.prototype, 'getVariation').withArgs(req as Request, FEATURE_FLAGS.DLRM_SETASIDE_FEATURE_FLAG, false).resolves(true);
+      await getFtpaDecisionDetails(req as Request, res as Response, next);
+
+      expect(res.render).to.have.been.calledWith('ftpa-application/ftpa-decision-details-viewer.njk', {
+        title: i18n.pages.detailViewers.ftpaApplication.title.appellant,
+        subTitle: i18n.pages.detailViewers.ftpaDecision.title,
+        data: expectedSummaryRows,
+        previousPage: paths.common.overview
+      });
+    });
+
+    it('should render ftpa-application/ftpa-decision-details-viewer.nj for FTPA Application by: Appellant for Decide FTPA Application event with decision: not admitted', async () => {
+      req.session.appeal = {
+        ...req.session.appeal,
+        ftpaApplicantType: 'appellant',
+        ftpaAppellantApplicationDate: '2023-03-20',
+        ftpaAppellantDecisionDate: '2023-03-20',
+        ftpaAppellantDecisionDocument: [],
+        ftpaApplicationAppellantDocument: document,
+        ftpaAppellantRjDecisionOutcomeType: 'notAdmitted'
+      };
+
+      documents[0].name = 'FTPA_Appellant_Doc.PDF';
+      document.name = 'FTPA_Not_Admitted_Doc.PDF';
+
+      const expectedSummaryRows = {
+        application: [
+          {
+            key: { text: i18n.pages.detailViewers.ftpaApplication.date },
+            value: { html: '20&nbsp;March&nbsp;2023' }
+          }
+        ],
+        decision: [
+          {
+            key: { text: i18n.pages.detailViewers.ftpaDecision.decision },
+            value: { html: 'Not&nbsp;admitted' }
+          },
+          {
+            key: { text: i18n.pages.detailViewers.ftpaDecision.decisionDocument },
+            value: { html: `<a class='govuk-link' target='_blank' rel='noopener noreferrer' href='/view/document/976fa409-4aab-40a4-a3f9-0c918f7293c8'>FTPA_Not_Admitted_Doc.PDF</a>` }
+          },
+          {
+            key: { text: i18n.pages.detailViewers.ftpaDecision.date },
+            value: { html: '20&nbsp;March&nbsp;2023' }
+          }
+        ]
+      };
+
+      sandbox.stub(LaunchDarklyService.prototype, 'getVariation').withArgs(req as Request, FEATURE_FLAGS.DLRM_SETASIDE_FEATURE_FLAG, false).resolves(true);
+      await getFtpaDecisionDetails(req as Request, res as Response, next);
+
+      expect(res.render).to.have.been.calledWith('ftpa-application/ftpa-decision-details-viewer.njk', {
+        title: i18n.pages.detailViewers.ftpaApplication.title.appellant,
+        subTitle: i18n.pages.detailViewers.ftpaDecision.title,
+        data: expectedSummaryRows,
+        previousPage: paths.common.overview
+      });
+    });
+
+    it('should render ftpa-application/ftpa-decision-details-viewer.nj for FTPA Application by: Respondent for Decide FTPA Application event with decision: granted', async () => {
+      req.session.appeal = {
+        ...req.session.appeal,
+        ftpaApplicantType: 'respondent',
+        ftpaRespondentGroundsDocuments: [ ...documents ],
+        ftpaRespondentApplicationDate: '2023-03-20',
+        ftpaRespondentEvidenceDocuments: [ ...documents ],
+        ftpaRespondentOutOfTimeExplanation: 'ftpaRespondentOutOfTimeExplanation',
+        ftpaRespondentOutOfTimeDocuments: [ ...documents ],
+        ftpaRespondentDecisionDate: '2023-03-20',
+        ftpaRespondentDecisionDocument: [],
+        ftpaApplicationRespondentDocument: document,
+        ftpaRespondentRjDecisionOutcomeType: 'granted'
+      };
+
+      documents[0].name = 'FTPA_Respondent_Doc.PDF';
+      document.name = 'FTPA_Granted_Doc.PDF';
+
+      const expectedSummaryRows = {
+        application: [
+          {
+            key: { text: i18n.pages.detailViewers.ftpaApplication.groundsDocument },
+            value: { html: `<a class='govuk-link' target='_blank' rel='noopener noreferrer' href='/view/document/976fa409-4aab-40a4-a3f9-0c918f7293c8'>FTPA_Respondent_Doc.PDF</a>` }
+          },
+          {
+            key: { text: i18n.pages.detailViewers.ftpaApplication.evidence },
+            value: { html: `<a class='govuk-link' target='_blank' rel='noopener noreferrer' href='/view/document/976fa409-4aab-40a4-a3f9-0c918f7293c8'>FTPA_Respondent_Doc.PDF</a>` }
+          },
+          {
+            key: { text: i18n.pages.detailViewers.ftpaApplication.date },
+            value: { html: '20&nbsp;March&nbsp;2023' }
+          },
+          {
+            key: { text: i18n.pages.detailViewers.ftpaApplication.outOfTimeReason },
+            value: { html: 'ftpaRespondentOutOfTimeExplanation' }
+          },
+          {
+            key: { text: i18n.pages.detailViewers.ftpaApplication.outOfTimeEvidence },
+            value: { html: `<a class='govuk-link' target='_blank' rel='noopener noreferrer' href='/view/document/976fa409-4aab-40a4-a3f9-0c918f7293c8'>FTPA_Respondent_Doc.PDF</a>` }
+          }
+        ],
+        decision: [
+          {
+            key: { text: i18n.pages.detailViewers.ftpaDecision.decision },
+            value: { html: 'Granted' }
+          },
+          {
+            key: { text: i18n.pages.detailViewers.ftpaDecision.decisionDocument },
+            value: { html: `<a class='govuk-link' target='_blank' rel='noopener noreferrer' href='/view/document/976fa409-4aab-40a4-a3f9-0c918f7293c8'>FTPA_Granted_Doc.PDF</a>` }
+          },
+          {
+            key: { text: i18n.pages.detailViewers.ftpaDecision.date },
+            value: { html: '20&nbsp;March&nbsp;2023' }
+          }
+        ]
+      };
+
+      sandbox.stub(LaunchDarklyService.prototype, 'getVariation').withArgs(req as Request, FEATURE_FLAGS.DLRM_SETASIDE_FEATURE_FLAG, false).resolves(true);
+      await getFtpaDecisionDetails(req as Request, res as Response, next);
+
+      expect(res.render).to.have.been.calledWith('ftpa-application/ftpa-decision-details-viewer.njk', {
+        title: i18n.pages.detailViewers.ftpaApplication.title.respondent,
+        subTitle: i18n.pages.detailViewers.ftpaDecision.title,
+        data: expectedSummaryRows,
+        previousPage: paths.common.overview
+      });
+    });
+
+    it('should render ftpa-application/ftpa-decision-details-viewer.nj for FTPA Application by: Respondent for Decide FTPA Application event with decision: partially granted', async () => {
+      req.session.appeal = {
+        ...req.session.appeal,
+        ftpaApplicantType: 'respondent',
+        ftpaRespondentGroundsDocuments: [ ...documents ],
+        ftpaRespondentApplicationDate: '2023-03-20',
+        ftpaRespondentEvidenceDocuments: [ ...documents ],
+        ftpaRespondentOutOfTimeExplanation: 'ftpaRespondentOutOfTimeExplanation',
+        ftpaRespondentOutOfTimeDocuments: [ ...documents ],
+        ftpaRespondentDecisionDate: '2023-03-20',
+        ftpaRespondentDecisionDocument: [],
+        ftpaApplicationRespondentDocument: document,
+        ftpaRespondentRjDecisionOutcomeType: 'partiallyGranted'
+      };
+
+      documents[0].name = 'FTPA_Respondent_Doc.PDF';
+      document.name = 'FTPA_Partially_Granted_Doc.PDF';
+
+      const expectedSummaryRows = {
+        application: [
+          {
+            key: { text: i18n.pages.detailViewers.ftpaApplication.groundsDocument },
+            value: { html: `<a class='govuk-link' target='_blank' rel='noopener noreferrer' href='/view/document/976fa409-4aab-40a4-a3f9-0c918f7293c8'>FTPA_Respondent_Doc.PDF</a>` }
+          },
+          {
+            key: { text: i18n.pages.detailViewers.ftpaApplication.evidence },
+            value: { html: `<a class='govuk-link' target='_blank' rel='noopener noreferrer' href='/view/document/976fa409-4aab-40a4-a3f9-0c918f7293c8'>FTPA_Respondent_Doc.PDF</a>` }
+          },
+          {
+            key: { text: i18n.pages.detailViewers.ftpaApplication.date },
+            value: { html: '20&nbsp;March&nbsp;2023' }
+          },
+          {
+            key: { text: i18n.pages.detailViewers.ftpaApplication.outOfTimeReason },
+            value: { html: 'ftpaRespondentOutOfTimeExplanation' }
+          },
+          {
+            key: { text: i18n.pages.detailViewers.ftpaApplication.outOfTimeEvidence },
+            value: { html: `<a class='govuk-link' target='_blank' rel='noopener noreferrer' href='/view/document/976fa409-4aab-40a4-a3f9-0c918f7293c8'>FTPA_Respondent_Doc.PDF</a>` }
+          }
+        ],
+        decision: [
+          {
+            key: { text: i18n.pages.detailViewers.ftpaDecision.decision },
+            value: { html: 'Partially&nbsp;granted' }
+          },
+          {
+            key: { text: i18n.pages.detailViewers.ftpaDecision.decisionDocument },
+            value: { html: `<a class='govuk-link' target='_blank' rel='noopener noreferrer' href='/view/document/976fa409-4aab-40a4-a3f9-0c918f7293c8'>FTPA_Partially_Granted_Doc.PDF</a>` }
+          },
+          {
+            key: { text: i18n.pages.detailViewers.ftpaDecision.date },
+            value: { html: '20&nbsp;March&nbsp;2023' }
+          }
+        ]
+      };
+
+      sandbox.stub(LaunchDarklyService.prototype, 'getVariation').withArgs(req as Request, FEATURE_FLAGS.DLRM_SETASIDE_FEATURE_FLAG, false).resolves(true);
+      await getFtpaDecisionDetails(req as Request, res as Response, next);
+
+      expect(res.render).to.have.been.calledWith('ftpa-application/ftpa-decision-details-viewer.njk', {
+        title: i18n.pages.detailViewers.ftpaApplication.title.respondent,
+        subTitle: i18n.pages.detailViewers.ftpaDecision.title,
+        data: expectedSummaryRows,
+        previousPage: paths.common.overview
+      });
+    });
+
+    it('should render ftpa-application/ftpa-decision-details-viewer.nj for FTPA Application by: Respondent for Decide FTPA Application event with decision: refused', async () => {
+      req.session.appeal = {
+        ...req.session.appeal,
+        ftpaApplicantType: 'respondent',
+        ftpaRespondentApplicationDate: '2023-03-20',
+        ftpaRespondentDecisionDate: '2023-03-20',
+        ftpaRespondentDecisionDocument: [],
+        ftpaApplicationRespondentDocument: document,
+        ftpaRespondentRjDecisionOutcomeType: 'refused'
+      };
+
+      documents[0].name = 'FTPA_Respondent_Doc.PDF';
+      document.name = 'FTPA_Refused_Doc.PDF';
+
+      const expectedSummaryRows = {
+        application: [
+          {
+            key: { text: i18n.pages.detailViewers.ftpaApplication.date },
+            value: { html: '20&nbsp;March&nbsp;2023' }
+          }
+        ],
+        decision: [
+          {
+            key: { text: i18n.pages.detailViewers.ftpaDecision.decision },
+            value: { html: 'Refused' }
+          },
+          {
+            key: { text: i18n.pages.detailViewers.ftpaDecision.decisionDocument },
+            value: { html: `<a class='govuk-link' target='_blank' rel='noopener noreferrer' href='/view/document/976fa409-4aab-40a4-a3f9-0c918f7293c8'>FTPA_Refused_Doc.PDF</a>` }
+          },
+          {
+            key: { text: i18n.pages.detailViewers.ftpaDecision.date },
+            value: { html: '20&nbsp;March&nbsp;2023' }
+          }
+        ]
+      };
+
+      sandbox.stub(LaunchDarklyService.prototype, 'getVariation').withArgs(req as Request, FEATURE_FLAGS.DLRM_SETASIDE_FEATURE_FLAG, false).resolves(true);
+      await getFtpaDecisionDetails(req as Request, res as Response, next);
+
+      expect(res.render).to.have.been.calledWith('ftpa-application/ftpa-decision-details-viewer.njk', {
+        title: i18n.pages.detailViewers.ftpaApplication.title.respondent,
+        subTitle: i18n.pages.detailViewers.ftpaDecision.title,
+        data: expectedSummaryRows,
+        previousPage: paths.common.overview
+      });
+    });
+
+    it('should render ftpa-application/ftpa-decision-details-viewer.nj for FTPA Application by: Respondent for Decide FTPA Application event with decision: not admitted', async () => {
+      req.session.appeal = {
+        ...req.session.appeal,
+        ftpaApplicantType: 'respondent',
+        ftpaRespondentApplicationDate: '2023-03-20',
+        ftpaRespondentDecisionDate: '2023-03-20',
+        ftpaRespondentDecisionDocument: [],
+        ftpaApplicationRespondentDocument: document,
+        ftpaRespondentRjDecisionOutcomeType: 'notAdmitted'
+      };
+
+      documents[0].name = 'FTPA_Respondent_Doc.PDF';
+      document.name = 'FTPA_Not_Admitted_Doc.PDF';
+
+      const expectedSummaryRows = {
+        application: [
+          {
+            key: { text: i18n.pages.detailViewers.ftpaApplication.date },
+            value: { html: '20&nbsp;March&nbsp;2023' }
+          }
+        ],
+        decision: [
+          {
+            key: { text: i18n.pages.detailViewers.ftpaDecision.decision },
+            value: { html: 'Not&nbsp;admitted' }
+          },
+          {
+            key: { text: i18n.pages.detailViewers.ftpaDecision.decisionDocument },
+            value: { html: `<a class='govuk-link' target='_blank' rel='noopener noreferrer' href='/view/document/976fa409-4aab-40a4-a3f9-0c918f7293c8'>FTPA_Not_Admitted_Doc.PDF</a>` }
+          },
+          {
+            key: { text: i18n.pages.detailViewers.ftpaDecision.date },
+            value: { html: '20&nbsp;March&nbsp;2023' }
+          }
+        ]
+      };
+
+      sandbox.stub(LaunchDarklyService.prototype, 'getVariation').withArgs(req as Request, FEATURE_FLAGS.DLRM_SETASIDE_FEATURE_FLAG, false).resolves(true);
+      await getFtpaDecisionDetails(req as Request, res as Response, next);
+
+      expect(res.render).to.have.been.calledWith('ftpa-application/ftpa-decision-details-viewer.njk', {
+        title: i18n.pages.detailViewers.ftpaApplication.title.respondent,
+        subTitle: i18n.pages.detailViewers.ftpaDecision.title,
+        data: expectedSummaryRows,
+        previousPage: paths.common.overview
+      });
+    });
+
     it('should catch error and call next with it', async () => {
       const error = new Error('an error');
       req.session.appeal = {

--- a/test/unit/service/update-appeal-service.test.ts
+++ b/test/unit/service/update-appeal-service.test.ts
@@ -1118,6 +1118,46 @@ describe('update-appeal-service', () => {
         expect(mappedAppeal.ftpaR35RespondentDocument.name).eq('FTPA_R35_DOCUMENT.PDF');
       });
     });
+
+    describe('ftpaApplicationAppellantDocument', () => {
+      const caseData: Partial<CaseData> = {
+        'ftpaApplicationAppellantDocument':
+        {
+          'document_url': 'http://dm-store:8080/documents/d8b3ef28-f67f-4859-86e2-1d34dde208bb',
+          'document_filename': 'FTPA_APPELLANT_DECISION_DOCUMENT.PDF',
+          'document_binary_url': 'http://dm-store:8080/documents/d8b3ef28-f67f-4859-86e2-1d34dde208bb/binary'
+        }
+      };
+
+      const appeal: Partial<CcdCaseDetails> = {
+        case_data: caseData as CaseData
+      };
+      it('should map Decide FTPA decision document (appellant)', () => {
+        const mappedAppeal = updateAppealService.mapCcdCaseToAppeal(appeal as CcdCaseDetails);
+
+        expect(mappedAppeal.ftpaApplicationAppellantDocument.name).eq('FTPA_APPELLANT_DECISION_DOCUMENT.PDF');
+      });
+    });
+
+    describe('ftpaApplicationRespondentDocument', () => {
+      const caseData: Partial<CaseData> = {
+        'ftpaApplicationRespondentDocument':
+        {
+          'document_url': 'http://dm-store:8080/documents/d8b3ef28-f67f-4859-86e2-1d34dde208bb',
+          'document_filename': 'FTPA_RESPONDENT_DECISION_DOCUMENT.PDF',
+          'document_binary_url': 'http://dm-store:8080/documents/d8b3ef28-f67f-4859-86e2-1d34dde208bb/binary'
+        }
+      };
+
+      const appeal: Partial<CcdCaseDetails> = {
+        case_data: caseData as CaseData
+      };
+      it('should map Decide FTPA decision document (respondent)', () => {
+        const mappedAppeal = updateAppealService.mapCcdCaseToAppeal(appeal as CcdCaseDetails);
+
+        expect(mappedAppeal.ftpaApplicationRespondentDocument.name).eq('FTPA_RESPONDENT_DECISION_DOCUMENT.PDF');
+      });
+    });
   });
 
   describe('submitEvent', () => {

--- a/types/caseData.d.ts
+++ b/types/caseData.d.ts
@@ -171,7 +171,9 @@ interface CaseData {
   ftpaAppellantDecisionDocument?: Collection<DocumentWithDescription | DocumentWithMetaData>[];
   ftpaAppellantDecisionDate?: string;
   ftpaR35AppellantDocument: SupportingDocument;
+  ftpaApplicationAppellantDocument: SupportingDocument;
   ftpaR35RespondentDocument: SupportingDocument;
+  ftpaApplicationRespondentDocument: SupportingDocument;
 }
 
 interface Application<T> {

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -188,6 +188,8 @@ interface Appeal {
   readonlyApplicationEnabled?: boolean;
   ftpaR35AppellantDocument?: Evidence;
   ftpaR35RespondentDocument?: Evidence;
+  ftpaApplicationRespondentDocument?: Evidence;
+  ftpaApplicationAppellantDocument?: Evidence;
 }
 
 interface Hearing {


### PR DESCRIPTION
### Jira link (if applicable)

https://tools.hmcts.net/jira/browse/RIA-8633

### Change description ###

- Refactoring to allow new appellant and respondent decision documents to be added and displayed for FTPA decisions: granted, partially granted, refused and not admitted.

- Conditions allow in-flight cases to still read from old document collection, and new cases or in-flight cases decided after release to read from new document fields.

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [X] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [X] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
