### PR TITLE
DO NOT MERGE!!! TEST ONLY

### DIFF
--- a/Jenkinsfile_CNP
+++ b/Jenkinsfile_CNP
@@ -49,7 +49,30 @@ def yarnBuilder = new uk.gov.hmcts.contino.YarnBuilder(this)
 withPipeline("nodejs", product, component) {
 
   afterAlways('checkout') { sh 'yarn cache clean' }
-  afterAlways('build') { sh 'yarn build' }
+  afterAlways('build') {
+    sh 'yarn build'
+
+    stage('Unit Tests') {
+      yarnBuilder.yarn('test:unit')
+      publishHTML target: [
+              allowMissing         : true,
+              alwaysLinkToLastBuild: true,
+              keepAll              : true,
+              reportDir            : "mochawesome-report",
+              reportFiles          : "mochawesome.html",
+              reportName           : "Unit & Smoke Test Report"
+      ]
+      publishHTML target: [
+              allowMissing         : true,
+              alwaysLinkToLastBuild: true,
+              keepAll              : true,
+              reportDir            : "test/coverage/html",
+              reportFiles          : "index.html",
+              reportName           : "Code Coverage Report"
+      ]
+      steps.archiveArtifacts allowEmptyArchive: true, artifacts: '**/test/coverage/*'
+    }
+  }
 
   loadVaultSecrets(secrets)
 

--- a/app/assets/scss/_remission-summary.scss
+++ b/app/assets/scss/_remission-summary.scss
@@ -1,0 +1,16 @@
+.govuk-summary-history {
+  border: 1px solid #bfc1c3;
+  margin-bottom: 35px;
+}
+.govuk-summary-history-header {
+  background-color: #f3f2f1;
+  > div {
+    padding: 12px 20px;
+  }
+}
+.govuk-summary-history-body {
+  padding: 0px 20px;
+  .govuk-summary-list__row:last-child {
+    border-bottom: none;
+  }
+}

--- a/app/assets/scss/application.scss
+++ b/app/assets/scss/application.scss
@@ -9,6 +9,7 @@
 @import "_header";
 @import "_timeout-modal";
 @import "save-buttons-component";
+@import "_remission-summary";
 
 body {
   @extend .govuk-body;

--- a/app/controllers/appeal-application/asylum-support.ts
+++ b/app/controllers/appeal-application/asylum-support.ts
@@ -33,8 +33,8 @@ function postAsylumSupport(updateAppealService: UpdateAppealService) {
   return async (req: Request, res: Response, next: NextFunction) => {
     const dlrmFeeRemissionFlag = await LaunchDarklyService.getInstance().getVariation(req, FEATURE_FLAGS.DLRM_FEE_REMISSION_FEATURE_FLAG, false);
     if (!dlrmFeeRemissionFlag) return res.redirect(paths.common.overview);
-    async function persistAppeal(appeal: Appeal) {
-      const appealUpdated: Appeal = await updateAppealService.submitEventRefactored(Events.EDIT_APPEAL, appeal, req.idam.userDetails.uid, req.cookies['__auth-token']);
+    async function persistAppeal(appeal: Appeal, drlmSetAsideFlag) {
+      const appealUpdated: Appeal = await updateAppealService.submitEventRefactored(Events.EDIT_APPEAL, appeal, req.idam.userDetails.uid, req.cookies['__auth-token'], drlmSetAsideFlag);
       req.session.appeal = {
         ...req.session.appeal,
         ...appealUpdated
@@ -67,7 +67,7 @@ function postAsylumSupport(updateAppealService: UpdateAppealService) {
       };
       const isEdit: boolean = req.session.appeal.application.isEdit || false;
       resetJourneyValues(appeal.application);
-      await persistAppeal(appeal);
+      await persistAppeal(appeal, dlrmFeeRemissionFlag);
       const defaultRedirect = paths.appealStarted.taskList;
       let redirectPage = getRedirectPage(isEdit, paths.appealStarted.checkAndSend, req.body.saveForLater, defaultRedirect);
       return res.redirect(redirectPage);

--- a/app/controllers/appeal-application/confirmation-page.ts
+++ b/app/controllers/appeal-application/confirmation-page.ts
@@ -1,7 +1,11 @@
 import config from 'config';
 import { NextFunction, Request, Response, Router } from 'express';
 import i18n from '../../../locale/en.json';
+import { FEATURE_FLAGS } from '../../data/constants';
+import { Events } from '../../data/events';
 import { paths } from '../../paths';
+import LaunchDarklyService from '../../service/launchDarkly-service';
+import UpdateAppealService from '../../service/update-appeal-service';
 import { addDaysToDate } from '../../utils/date-utils';
 import { payLaterForApplicationNeeded, payNowForApplicationNeeded } from '../../utils/payments-utils';
 import { appealHasRemissionOption } from '../../utils/remission-utils';
@@ -32,56 +36,66 @@ function getConfirmationPage(req: Request, res: Response, next: NextFunction) {
   }
 }
 
-function getConfirmationPaidPage(req: Request, res: Response, next: NextFunction) {
-  req.app.locals.logger.trace(`Successful AIP paid after submission for ccd id ${JSON.stringify(req.session.appeal.ccdCaseId)}`, 'Confirmation appeal submission');
+function getConfirmationPaidPage(updateAppealService: UpdateAppealService) {
+  return async (req: Request, res: Response, next: NextFunction) => {
+    req.app.locals.logger.trace(`Successful AIP paid after submission for ccd id ${JSON.stringify(req.session.appeal.ccdCaseId)}`, 'Confirmation appeal submission');
 
-  try {
-    const { application, paAppealTypeAipPaymentOption = null } = req.session.appeal;
-    const { payingImmediately = false } = req.session;
-    const isLate = application.isAppealLate;
-    const isPaPayNow = application.appealType === 'protection' && paAppealTypeAipPaymentOption === 'payNow';
-    const isPaPayLater = application.appealType === 'protection' && paAppealTypeAipPaymentOption === 'payLater';
-    const daysToWait: number = config.get('daysToWait.afterSubmission');
-    const appealWithRemissionOption = appealHasRemissionOption(application);
+    try {
+      const { application, paAppealTypeAipPaymentOption = null } = req.session.appeal;
+      const { payingImmediately = false } = req.session;
+      const isLate = application.isAppealLate;
+      const isPaPayNow = application.appealType === 'protection' && paAppealTypeAipPaymentOption === 'payNow';
+      const isPaPayLater = application.appealType === 'protection' && paAppealTypeAipPaymentOption === 'payLater';
+      const daysToWait: number = config.get('daysToWait.afterSubmission');
+      const appealWithRemissionOption = appealHasRemissionOption(application);
 
-    if (isPaPayLater) {
-      res.render('templates/confirmation-page.njk', {
-        date: addDaysToDate(daysToWait),
-        title: i18n.pages.confirmationPaid.title,
-        whatNextContent: i18n.pages.confirmationPaidLater.content,
-        appealWithRemissionOption
-      });
-    } else if (isPaPayNow) {
-      res.render('templates/confirmation-page.njk', {
-        date: addDaysToDate(daysToWait),
-        title: (payingImmediately && !isLate) ? i18n.pages.successPage.inTime.panel
-          : (payingImmediately && isLate) ? i18n.pages.successPage.outOfTime.panel
-            : i18n.pages.confirmationPaidLater.title,
-        whatNextListItems: (payingImmediately && isLate) ? i18n.pages.confirmationPaid.contentLate
-          : (payingImmediately && !isLate) ? i18n.pages.confirmationPaid.content
-            : i18n.pages.confirmationPaidLater.content,
-        thingsYouCanDoAfterPaying: i18n.pages.confirmationPaid.thingsYouCanDoAfterPaying,
-        appealWithRemissionOption
-      });
-    } else {
-      res.render('templates/confirmation-page.njk', {
-        date: addDaysToDate(daysToWait),
-        title: isLate ? i18n.pages.successPage.outOfTime.panel : i18n.pages.successPage.inTime.panel,
-        whatNextListItems: isLate ? i18n.pages.confirmationPaid.contentLate : i18n.pages.confirmationPaid.content,
-        thingsYouCanDoAfterPaying: i18n.pages.confirmationPaid.thingsYouCanDoAfterPaying,
-        appealWithRemissionOption
-      });
+      if (isPaPayLater) {
+        res.render('templates/confirmation-page.njk', {
+          date: addDaysToDate(daysToWait),
+          title: i18n.pages.confirmationPaid.title,
+          whatNextContent: i18n.pages.confirmationPaidLater.content,
+          appealWithRemissionOption
+        });
+      } else if (isPaPayNow) {
+        res.render('templates/confirmation-page.njk', {
+          date: addDaysToDate(daysToWait),
+          title: getPaPayNowTitle(payingImmediately, isLate),
+          whatNextListItems: getPaPayNowWhatNextItems(payingImmediately, isLate),
+          thingsYouCanDoAfterPaying: i18n.pages.confirmationPaid.thingsYouCanDoAfterPaying,
+          appealWithRemissionOption
+        });
+      } else {
+        res.render('templates/confirmation-page.njk', {
+          date: addDaysToDate(daysToWait),
+          title: isLate ? i18n.pages.successPage.outOfTime.panel : i18n.pages.successPage.inTime.panel,
+          whatNextListItems: isLate ? i18n.pages.confirmationPaid.contentLate : i18n.pages.confirmationPaid.content,
+          thingsYouCanDoAfterPaying: i18n.pages.confirmationPaid.thingsYouCanDoAfterPaying,
+          appealWithRemissionOption
+        });
+      }
+    } catch (e) {
+      next(e);
     }
-  } catch (e) {
-    next(e);
-  }
+  };
 }
 
-function setConfirmationController(middleware: Middleware[]): Router {
+function setConfirmationController(middleware: Middleware[], updateAppealService: UpdateAppealService): Router {
   const router = Router();
   router.get(paths.appealSubmitted.confirmation, middleware, getConfirmationPage);
-  router.get(paths.common.confirmationPayment, middleware, getConfirmationPaidPage);
+  router.get(paths.common.confirmationPayment, middleware, getConfirmationPaidPage(updateAppealService));
   return router;
+}
+
+function getPaPayNowTitle(payingImmediately: boolean, isLate: boolean) {
+  return payingImmediately
+      ? (isLate ? i18n.pages.successPage.outOfTime.panel : i18n.pages.successPage.inTime.panel)
+      : i18n.pages.confirmationPaidLater.title;
+}
+
+function getPaPayNowWhatNextItems(payingImmediately: boolean, isLate: boolean) {
+  return payingImmediately
+      ? (isLate ? i18n.pages.confirmationPaid.contentLate : i18n.pages.confirmationPaid.content)
+      : i18n.pages.confirmationPaidLater.content;
 }
 
 export {

--- a/app/controllers/appeal-application/fee-waiver.ts
+++ b/app/controllers/appeal-application/fee-waiver.ts
@@ -26,8 +26,8 @@ function postFeeWaiver(updateAppealService: UpdateAppealService) {
   return async (req: Request, res: Response, next: NextFunction) => {
     const dlrmFeeRemissionFlag = await LaunchDarklyService.getInstance().getVariation(req, FEATURE_FLAGS.DLRM_FEE_REMISSION_FEATURE_FLAG, false);
     if (!dlrmFeeRemissionFlag) return res.redirect(paths.common.overview);
-    async function persistAppeal(appeal: Appeal) {
-      const appealUpdated: Appeal = await updateAppealService.submitEventRefactored(Events.EDIT_APPEAL, appeal, req.idam.userDetails.uid, req.cookies['__auth-token']);
+    async function persistAppeal(appeal: Appeal, drlmSetAsideFlag) {
+      const appealUpdated: Appeal = await updateAppealService.submitEventRefactored(Events.EDIT_APPEAL, appeal, req.idam.userDetails.uid, req.cookies['__auth-token'], drlmSetAsideFlag);
       req.session.appeal = {
         ...req.session.appeal,
         ...appealUpdated
@@ -38,7 +38,7 @@ function postFeeWaiver(updateAppealService: UpdateAppealService) {
       resetJourneyValues(req.session.appeal.application);
       const isEdit: boolean = req.session.appeal.application.isEdit || false;
       req.session.appeal.application.feeSupportPersisted = true;
-      await persistAppeal(req.session.appeal);
+      await persistAppeal(req.session.appeal, dlrmFeeRemissionFlag);
       const defaultRedirect = paths.appealStarted.taskList;
       let redirectPage = getRedirectPage(isEdit, paths.appealStarted.checkAndSend, req.body.saveForLater, defaultRedirect);
       return res.redirect(redirectPage);

--- a/app/controllers/appeal-application/help-with-fees-reference-number.ts
+++ b/app/controllers/appeal-application/help-with-fees-reference-number.ts
@@ -34,8 +34,8 @@ function postHelpWithFeesRefNumber(updateAppealService: UpdateAppealService) {
   return async (req: Request, res: Response, next: NextFunction) => {
     const dlrmFeeRemissionFlag = await LaunchDarklyService.getInstance().getVariation(req, FEATURE_FLAGS.DLRM_FEE_REMISSION_FEATURE_FLAG, false);
     if (!dlrmFeeRemissionFlag) return res.redirect(paths.common.overview);
-    async function persistAppeal(appeal: Appeal) {
-      const appealUpdated: Appeal = await updateAppealService.submitEventRefactored(Events.EDIT_APPEAL, appeal, req.idam.userDetails.uid, req.cookies['__auth-token']);
+    async function persistAppeal(appeal: Appeal, drlmSetAsideFlag) {
+      const appealUpdated: Appeal = await updateAppealService.submitEventRefactored(Events.EDIT_APPEAL, appeal, req.idam.userDetails.uid, req.cookies['__auth-token'], drlmSetAsideFlag);
       req.session.appeal = {
         ...req.session.appeal,
         ...appealUpdated
@@ -68,7 +68,7 @@ function postHelpWithFeesRefNumber(updateAppealService: UpdateAppealService) {
       const isEdit: boolean = req.session.appeal.application.isEdit || false;
       appeal.application.feeSupportPersisted = true;
       resetJourneyValues(appeal.application);
-      await persistAppeal(appeal);
+      await persistAppeal(appeal, dlrmFeeRemissionFlag);
       const defaultRedirect = paths.appealStarted.taskList;
       let redirectPage = getRedirectPage(isEdit, paths.appealStarted.checkAndSend, req.body.saveForLater, defaultRedirect);
       return res.redirect(redirectPage);

--- a/app/controllers/appeal-application/help-with-fees.ts
+++ b/app/controllers/appeal-application/help-with-fees.ts
@@ -59,8 +59,8 @@ function postHelpWithFees(updateAppealService: UpdateAppealService) {
   return async (req: Request, res: Response, next: NextFunction) => {
     const dlrmFeeRemissionFlag = await LaunchDarklyService.getInstance().getVariation(req, FEATURE_FLAGS.DLRM_FEE_REMISSION_FEATURE_FLAG, false);
     if (!dlrmFeeRemissionFlag) return res.redirect(paths.common.overview);
-    async function persistAppeal(appeal: Appeal) {
-      const appealUpdated: Appeal = await updateAppealService.submitEventRefactored(Events.EDIT_APPEAL, appeal, req.idam.userDetails.uid, req.cookies['__auth-token']);
+    async function persistAppeal(appeal: Appeal, drlmSetAsideFlag) {
+      const appealUpdated: Appeal = await updateAppealService.submitEventRefactored(Events.EDIT_APPEAL, appeal, req.idam.userDetails.uid, req.cookies['__auth-token'], drlmSetAsideFlag);
       req.session.appeal = {
         ...req.session.appeal,
         ...appealUpdated
@@ -97,7 +97,7 @@ function postHelpWithFees(updateAppealService: UpdateAppealService) {
       if (defaultRedirect === paths.appealStarted.taskList) {
         appeal.application.feeSupportPersisted = true;
       }
-      await persistAppeal(appeal);
+      await persistAppeal(appeal, dlrmFeeRemissionFlag);
       let redirectPage = getRedirectPage(isEdit, defaultRedirect, req.body.saveForLater, defaultRedirect);
       return res.redirect(redirectPage);
     } catch (error) {

--- a/app/controllers/appeal-application/steps-to-help-with-fees.ts
+++ b/app/controllers/appeal-application/steps-to-help-with-fees.ts
@@ -26,8 +26,8 @@ function postStepsToHelpWithFees(updateAppealService: UpdateAppealService) {
   return async (req: Request, res: Response, next: NextFunction) => {
     const dlrmFeeRemissionFlag = await LaunchDarklyService.getInstance().getVariation(req, FEATURE_FLAGS.DLRM_FEE_REMISSION_FEATURE_FLAG, false);
     if (!dlrmFeeRemissionFlag) return res.redirect(paths.common.overview);
-    async function persistAppeal(appeal: Appeal) {
-      const appealUpdated: Appeal = await updateAppealService.submitEventRefactored(Events.EDIT_APPEAL, appeal, req.idam.userDetails.uid, req.cookies['__auth-token']);
+    async function persistAppeal(appeal: Appeal, drlmSetAsideFlag) {
+      const appealUpdated: Appeal = await updateAppealService.submitEventRefactored(Events.EDIT_APPEAL, appeal, req.idam.userDetails.uid, req.cookies['__auth-token'], drlmSetAsideFlag);
       req.session.appeal = {
         ...req.session.appeal,
         ...appealUpdated
@@ -36,7 +36,7 @@ function postStepsToHelpWithFees(updateAppealService: UpdateAppealService) {
 
     try {
       const isEdit: boolean = req.session.appeal.application.isEdit || false;
-      await persistAppeal(req.session.appeal);
+      await persistAppeal(req.session.appeal, dlrmFeeRemissionFlag);
       const defaultRedirect = paths.appealStarted.helpWithFeesReferenceNumber;
       let redirectPage = getRedirectPage(isEdit, paths.appealStarted.checkAndSend, req.body.saveForLater, defaultRedirect);
       return res.redirect(redirectPage);

--- a/app/controllers/appeal-application/type-of-appeal.ts
+++ b/app/controllers/appeal-application/type-of-appeal.ts
@@ -64,7 +64,9 @@ function postTypeOfAppeal(updateAppealService: UpdateAppealService) {
         }
       };
 
-      const appealUpdated: Appeal = await updateAppealService.submitEventRefactored(Events.EDIT_APPEAL, appeal, req.idam.userDetails.uid, req.cookies['__auth-token'], true);
+      const dlrmRefundFlag = await LaunchDarklyService.getInstance().getVariation(req, FEATURE_FLAGS.DLRM_REFUND_FEATURE_FLAG, false);
+
+      const appealUpdated: Appeal = await updateAppealService.submitEventRefactored(Events.EDIT_APPEAL, appeal, req.idam.userDetails.uid, req.cookies['__auth-token'], true, dlrmRefundFlag);
       req.session.appeal = {
         ...req.session.appeal,
         ...req.body['appealType'] !== 'protection' && { paAppealTypeAipPaymentOption: '' },

--- a/app/controllers/appeal-application/upload-local-authority-letter.ts
+++ b/app/controllers/appeal-application/upload-local-authority-letter.ts
@@ -46,8 +46,8 @@ function postLocalAuthorityLetter(updateAppealService: UpdateAppealService) {
   return async (req: Request, res: Response, next: NextFunction) => {
     const dlrmFeeRemissionFlag = await LaunchDarklyService.getInstance().getVariation(req, FEATURE_FLAGS.DLRM_FEE_REMISSION_FEATURE_FLAG, false);
     if (!dlrmFeeRemissionFlag) return res.redirect(paths.common.overview);
-    async function persistAppeal(appeal: Appeal) {
-      const appealUpdated: Appeal = await updateAppealService.submitEventRefactored(Events.EDIT_APPEAL, appeal, req.idam.userDetails.uid, req.cookies['__auth-token']);
+    async function persistAppeal(appeal: Appeal, drlmSetAsideFlag) {
+      const appealUpdated: Appeal = await updateAppealService.submitEventRefactored(Events.EDIT_APPEAL, appeal, req.idam.userDetails.uid, req.cookies['__auth-token'], drlmSetAsideFlag);
       req.session.appeal = {
         ...req.session.appeal,
         ...appealUpdated
@@ -59,7 +59,7 @@ function postLocalAuthorityLetter(updateAppealService: UpdateAppealService) {
       if (authLetterUploads.length > 0) {
         req.session.appeal.application.feeSupportPersisted = true;
         resetJourneyValues(req.session.appeal.application);
-        await persistAppeal(req.session.appeal);
+        await persistAppeal(req.session.appeal, dlrmFeeRemissionFlag);
         const redirectTo = req.session.appeal.application.isEdit ? paths.appealStarted.checkAndSend : paths.appealStarted.taskList;
         return res.redirect(redirectTo);
       } else {

--- a/app/controllers/ask-for-fee-remission/asylum-support-refund.ts
+++ b/app/controllers/ask-for-fee-remission/asylum-support-refund.ts
@@ -1,0 +1,74 @@
+import { NextFunction, Request, Response, Router } from 'express';
+import _ from 'lodash';
+import i18n from '../../../locale/en.json';
+import { FEATURE_FLAGS } from '../../data/constants';
+import { paths } from '../../paths';
+import LaunchDarklyService from '../../service/launchDarkly-service';
+import { asylumSupportValidation } from '../../utils/validations/fields-validations';
+
+async function getAsylumSupport(req: Request, res: Response, next: NextFunction) {
+  try {
+    const refundFeatureEnabled = await LaunchDarklyService.getInstance().getVariation(req, FEATURE_FLAGS.DLRM_REFUND_FEATURE_FLAG, false);
+    if (!refundFeatureEnabled) return res.redirect(paths.common.overview);
+    req.session.appeal.application.isEdit = _.has(req.query, 'edit');
+
+    const asylumSupportRefNumber = req.session.appeal.application.lateAsylumSupportRefNumber || null;
+    return res.render('appeal-application/fee-support/asylum-support.njk', {
+      previousPage: paths.appealSubmitted.feeSupportRefund,
+      formAction: paths.appealSubmitted.asylumSupportRefund,
+      asylumSupportRefNumber,
+      refundJourney: true
+    });
+  } catch (error) {
+    next(error);
+  }
+}
+
+function postAsylumSupport() {
+  return async (req: Request, res: Response, next: NextFunction) => {
+    const refundFeatureEnabled = await LaunchDarklyService.getInstance().getVariation(req, FEATURE_FLAGS.DLRM_REFUND_FEATURE_FLAG, false);
+    if (!refundFeatureEnabled) return res.redirect(paths.common.overview);
+
+    try {
+      const validation = asylumSupportValidation(req.body);
+      if (validation) {
+        return res.render('appeal-application/fee-support/asylum-support.njk', {
+          errors: validation,
+          errorList: Object.values(validation),
+          previousPage: paths.appealSubmitted.asylumSupportRefund,
+          pageTitle: i18n.pages.asylumSupportPage.title,
+          formAction: paths.appealSubmitted.asylumSupportRefund,
+          refundJourney: true
+        });
+      }
+      const selectedValue = req.body['asylumSupportRefNumber'];
+      const application = req.session.appeal.application;
+      application.lateAsylumSupportRefNumber = selectedValue;
+      resetJourneyValues(application);
+      return res.redirect(paths.appealSubmitted.checkYourAnswersRefund);
+    } catch (error) {
+      next(error);
+    }
+  };
+}
+
+function setupAsylumSupportRefundController(middleware: Middleware[]): Router {
+  const router = Router();
+  router.get(paths.appealSubmitted.asylumSupportRefund, middleware, getAsylumSupport);
+  router.post(paths.appealSubmitted.asylumSupportRefund, middleware, postAsylumSupport());
+  return router;
+}
+
+// Function used in CYA page edit mode, when the start page option is changed other values should be reset and the journey should start from the new selected option
+function resetJourneyValues(application: AppealApplication) {
+  application.lateHelpWithFeesOption = null;
+  application.lateHelpWithFeesRefNumber = null;
+  application.lateLocalAuthorityLetters = null;
+}
+
+export {
+  getAsylumSupport,
+  postAsylumSupport,
+  setupAsylumSupportRefundController,
+  resetJourneyValues
+};

--- a/app/controllers/ask-for-fee-remission/check-your-answers-refund.ts
+++ b/app/controllers/ask-for-fee-remission/check-your-answers-refund.ts
@@ -1,0 +1,130 @@
+import { NextFunction, Request, Response, Router } from 'express';
+import i18n from '../../../locale/en.json';
+import { FEATURE_FLAGS } from '../../data/constants';
+import { Events } from '../../data/events';
+import { paths } from '../../paths';
+import LaunchDarklyService from '../../service/launchDarkly-service';
+import UpdateAppealService from '../../service/update-appeal-service';
+import { addSummaryRow, Delimiter } from '../../utils/summary-list';
+
+async function getCheckYourAnswersRefund(req: Request, res: Response, next: NextFunction) {
+  try {
+    const refundFeatureEnabled = await LaunchDarklyService.getInstance().getVariation(req, FEATURE_FLAGS.DLRM_REFUND_FEATURE_FLAG, false);
+    if (!refundFeatureEnabled) return res.redirect(paths.common.overview);
+    const summaryRows = await createSummaryRowsFrom(req);
+    return res.render('ask-for-fee-remission/check-and-send.njk', {
+      previousPage: { attributes: { onclick: 'history.go(-1); return false;' } },
+      summaryRows
+    });
+  } catch (error) {
+    next(error);
+  }
+}
+
+function postCheckYourAnswersRefund(updateAppealService: UpdateAppealService) {
+  return async (req: Request, res: Response, next: NextFunction) => {
+    const refundFeatureEnabled = await LaunchDarklyService.getInstance().getVariation(req, FEATURE_FLAGS.DLRM_REFUND_FEATURE_FLAG, false);
+    if (!refundFeatureEnabled) return res.redirect(paths.common.overview);
+    try {
+      const appeal: Appeal = {
+        ...req.session.appeal,
+        application: {
+          ...req.session.appeal.application,
+          refundRequested: true
+        }
+      };
+
+      const appealUpdated: Appeal = await updateAppealService.submitEventRefactored(Events.REQUEST_FEE_REMISSION, appeal, req.idam.userDetails.uid, req.cookies['__auth-token'], true, refundFeatureEnabled);
+
+      req.session.appeal = {
+        ...req.session.appeal,
+        ...appealUpdated
+      };
+      return res.redirect(paths.appealSubmitted.confirmationRefund);
+    } catch (error) {
+      next(error);
+    }
+  };
+}
+
+async function createSummaryRowsFrom(req: Request) {
+  const application = req.session.appeal.application;
+  const editParameter = '?edit';
+  const lateRemissionOption = application.lateRemissionOption;
+  const lateAsylumSupportRefNumber = application.lateAsylumSupportRefNumber;
+  const lateHelpWithFeesOption = application.lateHelpWithFeesOption;
+  const lateHelpWithFeesRefNumber = application.lateHelpWithFeesRefNumber;
+  const lateLocalAuthorityLetters = application.lateLocalAuthorityLetters;
+  const rows = [];
+
+  if (lateRemissionOption) {
+    let rowValue = [i18n.pages.remissionOptionPage.options[lateRemissionOption].text];
+    if (lateRemissionOption === 'iWantToGetHelpWithFees') {
+      rowValue = [i18n.pages.remissionOptionPage.noneOfTheseStatements];
+    }
+    const feeStatementRow = addSummaryRow(
+      i18n.pages.checkYourAnswers.rowTitles.feeStatement,
+      rowValue,
+      paths.appealSubmitted.feeSupportRefund + editParameter
+    );
+    rows.push(feeStatementRow);
+  }
+
+  if (lateAsylumSupportRefNumber) {
+    const asylumSupportRefNumberRow = addSummaryRow(
+      i18n.pages.checkYourAnswers.rowTitles.asylumSupportRefNumber,
+      [lateAsylumSupportRefNumber],
+      paths.appealSubmitted.asylumSupportRefund + editParameter
+    );
+    rows.push(asylumSupportRefNumberRow);
+  }
+
+  if (lateHelpWithFeesOption && lateHelpWithFeesOption !== 'willPayForAppeal') {
+    let helpWithFeeValue = '';
+    if (lateHelpWithFeesOption === 'wantToApply') {
+      helpWithFeeValue = i18n.pages.helpWithFees.checkAndSendWantToApply;
+    } else {
+      helpWithFeeValue = i18n.pages.helpWithFees.options[lateHelpWithFeesOption].text;
+    }
+    const helpWithFeesRow = addSummaryRow(
+      i18n.pages.checkYourAnswers.rowTitles.helpWithFees,
+      [helpWithFeeValue],
+      paths.appealSubmitted.helpWithFeesRefund + editParameter
+    );
+    rows.push(helpWithFeesRow);
+  }
+
+  if (lateHelpWithFeesRefNumber) {
+    const helpWithFeeRefNumberRow = addSummaryRow(
+      i18n.pages.checkYourAnswers.rowTitles.helpWithFeesRefNumber,
+      [lateHelpWithFeesRefNumber],
+      paths.appealSubmitted.helpWithFeesReferenceNumberRefund + editParameter
+    );
+    rows.push(helpWithFeeRefNumberRow);
+  }
+
+  if (lateLocalAuthorityLetters && lateLocalAuthorityLetters.length > 0) {
+    const localAuthorityLetterRow = addSummaryRow(
+      i18n.pages.checkYourAnswers.rowTitles.localAuthorityLetter,
+      application.lateLocalAuthorityLetters.map(evidence => `<a class='govuk-link' target='_blank' rel='noopener noreferrer' href='${paths.common.documentViewer}/${evidence.fileId}'>${evidence.name}</a>`),
+      paths.appealSubmitted.localAuthorityLetterRefund + editParameter,
+      Delimiter.BREAK_LINE
+    );
+    rows.push(localAuthorityLetterRow);
+  }
+  return rows;
+}
+
+function setupCheckYourAnswersRefundController(middleware: Middleware[], updateAppealService: UpdateAppealService): Router {
+  const router = Router();
+  router.get(paths.appealSubmitted.checkYourAnswersRefund, middleware, getCheckYourAnswersRefund);
+  router.post(paths.appealSubmitted.checkYourAnswersRefund, middleware, postCheckYourAnswersRefund(updateAppealService));
+  return router;
+}
+
+export {
+  getCheckYourAnswersRefund,
+  postCheckYourAnswersRefund,
+  setupCheckYourAnswersRefundController,
+  createSummaryRowsFrom
+};

--- a/app/controllers/ask-for-fee-remission/confirmation-page.ts
+++ b/app/controllers/ask-for-fee-remission/confirmation-page.ts
@@ -1,0 +1,28 @@
+import config from 'config';
+import { NextFunction, Request, Response, Router } from 'express';
+import { paths } from '../../paths';
+import { addDaysToDate } from '../../utils/date-utils';
+
+function getConfirmationPage(req: Request, res: Response, next: NextFunction) {
+  req.app.locals.logger.trace(`Successful AIP appeal submission for ccd id ${JSON.stringify(req.session.appeal.ccdCaseId)}`, 'Confirmation appeal submission');
+
+  try {
+    const daysToWait: number = config.get('daysToWait.fromRemissionAppliedDate');
+    res.render('ask-for-fee-remission/confirmation-page.njk', {
+      date: addDaysToDate(daysToWait)
+    });
+  } catch (e) {
+    next(e);
+  }
+}
+
+function setConfirmationRefundController(middleware: Middleware[]): Router {
+  const router = Router();
+  router.get(paths.appealSubmitted.confirmationRefund, middleware, getConfirmationPage);
+  return router;
+}
+
+export {
+  setConfirmationRefundController,
+  getConfirmationPage
+};

--- a/app/controllers/ask-for-fee-remission/fee-support-refund.ts
+++ b/app/controllers/ask-for-fee-remission/fee-support-refund.ts
@@ -1,0 +1,121 @@
+import { NextFunction, Request, Response, Router } from 'express';
+import _ from 'lodash';
+import i18n from '../../../locale/en.json';
+import { FEATURE_FLAGS } from '../../data/constants';
+import { paths } from '../../paths';
+import LaunchDarklyService from '../../service/launchDarkly-service';
+import { remissionOptionsValidation } from '../../utils/validations/fields-validations';
+
+function getOptionsQuestion(appeal: Appeal) {
+  let remissionOption = appeal.application.lateRemissionOption || null;
+
+  return {
+    title: i18n.pages.remissionOptionPage.refundTitle,
+    hint: i18n.pages.remissionOptionPage.selectOne,
+    options: [
+      {
+        value: i18n.pages.remissionOptionPage.options.asylumSupportFromHo.value,
+        text: i18n.pages.remissionOptionPage.options.asylumSupportFromHo.text,
+        checked: remissionOption === i18n.pages.remissionOptionPage.options.asylumSupportFromHo.value
+      },
+      {
+        value: i18n.pages.remissionOptionPage.options.feeWaiverFromHo.value,
+        text: i18n.pages.remissionOptionPage.options.feeWaiverFromHo.text,
+        checked: remissionOption === i18n.pages.remissionOptionPage.options.feeWaiverFromHo.value
+      },
+      {
+        value: i18n.pages.remissionOptionPage.options.under18GetSupportFromLocalAuthority.value,
+        text: i18n.pages.remissionOptionPage.options.under18GetSupportFromLocalAuthority.text,
+        checked: remissionOption === i18n.pages.remissionOptionPage.options.under18GetSupportFromLocalAuthority.value
+      },
+      {
+        value: i18n.pages.remissionOptionPage.options.parentGetSupportFromLocalAuthority.value,
+        text: i18n.pages.remissionOptionPage.options.parentGetSupportFromLocalAuthority.text,
+        checked: remissionOption === i18n.pages.remissionOptionPage.options.parentGetSupportFromLocalAuthority.value
+      },
+      {
+        value: i18n.pages.remissionOptionPage.options.iWantToGetHelpWithFees.value,
+        text: i18n.pages.remissionOptionPage.options.iWantToGetHelpWithFees.text,
+        checked: remissionOption === i18n.pages.remissionOptionPage.options.iWantToGetHelpWithFees.value
+      }
+    ],
+    inline: false
+  };
+}
+
+async function getFeeSupport(req: Request, res: Response, next: NextFunction) {
+  try {
+    const refundFeatureEnabled = await LaunchDarklyService.getInstance().getVariation(req, FEATURE_FLAGS.DLRM_REFUND_FEATURE_FLAG, false);
+    if (!refundFeatureEnabled) return res.redirect(paths.common.overview);
+    const appeal = req.session.appeal;
+    appeal.application.isEdit = _.has(req.query, 'edit');
+
+    return res.render('ask-for-fee-remission/fee-support-refund.njk', {
+      previousPage: paths.common.overview,
+      pageTitle: i18n.pages.remissionOptionPage.refundTitle,
+      formAction: paths.appealSubmitted.feeSupportRefund,
+      question: getOptionsQuestion(req.session.appeal)
+    });
+  } catch (error) {
+    next(error);
+  }
+}
+
+function postFeeSupport() {
+  return async (req: Request, res: Response, next: NextFunction) => {
+    const refundFeatureEnabled = await LaunchDarklyService.getInstance().getVariation(req, FEATURE_FLAGS.DLRM_REFUND_FEATURE_FLAG, false);
+    if (!refundFeatureEnabled) return res.redirect(paths.common.overview);
+
+    try {
+      const validation = remissionOptionsValidation(req.body);
+      if (validation) {
+        return res.render('ask-for-fee-remission/fee-support-refund.njk', {
+          errors: validation,
+          errorList: Object.values(validation),
+          previousPage: paths.common.overview,
+          pageTitle: i18n.pages.remissionOptionPage.refundTitle,
+          formAction: paths.appealSubmitted.feeSupportRefund,
+          question: getOptionsQuestion(req.session.appeal)
+        });
+      }
+
+      const selectedValue = req.body['answer'];
+      const application = req.session.appeal.application;
+      application.lateRemissionOption = selectedValue;
+      return res.redirect(getFeeSupportRedirectPage(selectedValue));
+    } catch (error) {
+      next(error);
+    }
+  };
+}
+
+function setupFeeSupportRefundController(middleware: Middleware[]): Router {
+  const router = Router();
+  router.get(paths.appealSubmitted.feeSupportRefund, middleware, getFeeSupport);
+  router.post(paths.appealSubmitted.feeSupportRefund, middleware, postFeeSupport());
+  return router;
+}
+
+function getFeeSupportRedirectPage(remissionOption: string): string {
+  switch (remissionOption) {
+    case i18n.pages.remissionOptionPage.options.asylumSupportFromHo.value:
+      return paths.appealSubmitted.asylumSupportRefund;
+    case i18n.pages.remissionOptionPage.options.feeWaiverFromHo.value:
+      return paths.appealSubmitted.feeWaiverRefund;
+    case i18n.pages.remissionOptionPage.options.under18GetSupportFromLocalAuthority.value:
+    case i18n.pages.remissionOptionPage.options.parentGetSupportFromLocalAuthority.value:
+      return paths.appealSubmitted.localAuthorityLetterRefund;
+    case i18n.pages.remissionOptionPage.options.iWantToGetHelpWithFees.value:
+      return paths.appealSubmitted.helpWithFeesRefund;
+    default:
+      throw new Error('The selected remission option is not valid. Please check the value.');
+  }
+}
+
+export {
+  setupFeeSupportRefundController,
+  getFeeSupportRedirectPage,
+  getFeeSupport,
+  postFeeSupport,
+  getOptionsQuestion
+};

--- a/app/controllers/ask-for-fee-remission/fee-waiver-refund.ts
+++ b/app/controllers/ask-for-fee-remission/fee-waiver-refund.ts
@@ -1,0 +1,57 @@
+import { NextFunction, Request, Response, Router } from 'express';
+import _ from 'lodash';
+import { FEATURE_FLAGS } from '../../data/constants';
+import { paths } from '../../paths';
+import LaunchDarklyService from '../../service/launchDarkly-service';
+
+async function getFeeWaiver(req: Request, res: Response, next: NextFunction) {
+  try {
+    const refundFeatureEnabled = await LaunchDarklyService.getInstance().getVariation(req, FEATURE_FLAGS.DLRM_REFUND_FEATURE_FLAG, false);
+    if (!refundFeatureEnabled) return res.redirect(paths.common.overview);
+    req.session.appeal.application.isEdit = _.has(req.query, 'edit');
+
+    return res.render('appeal-application/fee-support/fee-waiver.njk', {
+      previousPage: paths.appealSubmitted.feeSupportRefund,
+      refundJourney: true
+    });
+  } catch (error) {
+    next(error);
+  }
+}
+
+function postFeeWaiver() {
+  return async (req: Request, res: Response, next: NextFunction) => {
+    const refundFeatureEnabled = await LaunchDarklyService.getInstance().getVariation(req, FEATURE_FLAGS.DLRM_REFUND_FEATURE_FLAG, false);
+    if (!refundFeatureEnabled) return res.redirect(paths.common.overview);
+
+    try {
+      resetJourneyValues(req.session.appeal.application);
+      req.session.appeal.application.feeSupportPersisted = true;
+      return res.redirect(paths.appealSubmitted.checkYourAnswersRefund);
+    } catch (error) {
+      next(error);
+    }
+  };
+}
+
+function setupFeeWaiverRefundController(middleware: Middleware[]): Router {
+  const router = Router();
+  router.get(paths.appealSubmitted.feeWaiverRefund, middleware, getFeeWaiver);
+  router.post(paths.appealSubmitted.feeWaiverRefund, middleware, postFeeWaiver());
+  return router;
+}
+
+// Function used in CYA page edit mode, when the start page option is changed other values should be reset and the journey should start from the new selected option
+function resetJourneyValues(application: AppealApplication) {
+  application.lateAsylumSupportRefNumber = null;
+  application.lateHelpWithFeesOption = null;
+  application.lateHelpWithFeesRefNumber = null;
+  application.lateLocalAuthorityLetters = null;
+}
+
+export {
+  getFeeWaiver,
+  postFeeWaiver,
+  setupFeeWaiverRefundController,
+  resetJourneyValues
+};

--- a/app/controllers/ask-for-fee-remission/help-with-fees-reference-number-refund.ts
+++ b/app/controllers/ask-for-fee-remission/help-with-fees-reference-number-refund.ts
@@ -1,0 +1,75 @@
+import { NextFunction, Request, Response, Router } from 'express';
+import _ from 'lodash';
+import i18n from '../../../locale/en.json';
+import { FEATURE_FLAGS } from '../../data/constants';
+import { paths } from '../../paths';
+import LaunchDarklyService from '../../service/launchDarkly-service';
+import { helpWithFeesRefNumberValidation } from '../../utils/validations/fields-validations';
+
+async function getHelpWithFeesRefNumber(req: Request, res: Response, next: NextFunction) {
+  try {
+    const refundFeatureEnabled = await LaunchDarklyService.getInstance().getVariation(req, FEATURE_FLAGS.DLRM_REFUND_FEATURE_FLAG, false);
+    if (!refundFeatureEnabled) return res.redirect(paths.common.overview);
+    req.session.appeal.application.isEdit = _.has(req.query, 'edit');
+    const previousPage = { attributes: { onclick: 'history.go(-1); return false;' } };
+    const helpWithFeesReferenceNumber = req.session.appeal.application.lateHelpWithFeesRefNumber || null;
+
+    return res.render('appeal-application/fee-support/help-with-fees-reference-number.njk', {
+      previousPage: previousPage,
+      formAction: paths.appealSubmitted.helpWithFeesReferenceNumberRefund,
+      helpWithFeesReferenceNumber,
+      refundJourney: true,
+      errors: req.session.validationErrors || null
+    });
+  } catch (error) {
+    next(error);
+  }
+}
+
+function postHelpWithFeesRefNumber() {
+  return async (req: Request, res: Response, next: NextFunction) => {
+    const refundFeatureEnabled = await LaunchDarklyService.getInstance().getVariation(req, FEATURE_FLAGS.DLRM_REFUND_FEATURE_FLAG, false);
+    if (!refundFeatureEnabled) return res.redirect(paths.common.overview);
+
+    try {
+      const validation = helpWithFeesRefNumberValidation(req.body);
+      if (validation) {
+        return res.render('appeal-application/fee-support/help-with-fees-reference-number.njk', {
+          errors: validation,
+          errorList: Object.values(validation),
+          previousPage: paths.appealSubmitted.helpWithFeesReferenceNumberRefund,
+          pageTitle: i18n.pages.helpWithFeesReference.title,
+          formAction: paths.appealSubmitted.helpWithFeesReferenceNumberRefund,
+          refundJourney: true
+        });
+      }
+      const selectedValue = req.body['helpWithFeesRefNumber'];
+      const application = req.session.appeal.application;
+      application.lateHelpWithFeesRefNumber = selectedValue;
+      resetJourneyValues(application);
+      return res.redirect(paths.appealSubmitted.checkYourAnswersRefund);
+    } catch (error) {
+      next(error);
+    }
+  };
+}
+
+// Function used in CYA page edit mode, when the start page option is changed other values should be reset and the journey should start from the new selected option
+function resetJourneyValues(application: AppealApplication) {
+  application.lateAsylumSupportRefNumber = null;
+  application.lateLocalAuthorityLetters = null;
+}
+
+function setupHelpWithFeesReferenceNumberRefundController(middleware: Middleware[]): Router {
+  const router = Router();
+  router.get(paths.appealSubmitted.helpWithFeesReferenceNumberRefund, middleware, getHelpWithFeesRefNumber);
+  router.post(paths.appealSubmitted.helpWithFeesReferenceNumberRefund, middleware, postHelpWithFeesRefNumber());
+  return router;
+}
+
+export {
+  getHelpWithFeesRefNumber,
+  postHelpWithFeesRefNumber,
+  setupHelpWithFeesReferenceNumberRefundController,
+  resetJourneyValues
+};

--- a/app/controllers/ask-for-fee-remission/help-with-fees-refund.ts
+++ b/app/controllers/ask-for-fee-remission/help-with-fees-refund.ts
@@ -1,0 +1,104 @@
+import { NextFunction, Request, Response, Router } from 'express';
+import _ from 'lodash';
+import i18n from '../../../locale/en.json';
+import { FEATURE_FLAGS } from '../../data/constants';
+import { paths } from '../../paths';
+import LaunchDarklyService from '../../service/launchDarkly-service';
+import { getFee } from '../../utils/payments-utils';
+import { helpWithFeesValidation } from '../../utils/validations/fields-validations';
+
+function getApplyOption(appeal: Appeal) {
+  let selectedOption = appeal.application.lateHelpWithFeesOption || null;
+  const fee = getFee(appeal).calculated_amount;
+  return {
+    title: i18n.pages.helpWithFees.radioButtonsTitle,
+    helpWithFeesHint: i18n.pages.helpWithFees.refundsNote.replace('{{ fee }}', fee),
+    options: [
+      {
+        value: i18n.pages.helpWithFees.options.wantToApply.value,
+        text: i18n.pages.helpWithFees.options.wantToApply.text,
+        checked: selectedOption === i18n.pages.helpWithFees.options.wantToApply.value
+      },
+      {
+        value: i18n.pages.helpWithFees.options.alreadyApplied.value,
+        text: i18n.pages.helpWithFees.options.alreadyApplied.text,
+        checked: selectedOption === i18n.pages.helpWithFees.options.alreadyApplied.value
+      }
+    ],
+    inline: false
+  };
+}
+
+async function getHelpWithFees(req: Request, res: Response, next: NextFunction) {
+  try {
+    const refundFeatureEnabled = await LaunchDarklyService.getInstance().getVariation(req, FEATURE_FLAGS.DLRM_REFUND_FEATURE_FLAG, false);
+    if (!refundFeatureEnabled) return res.redirect(paths.common.overview);
+    const appeal = req.session.appeal;
+    appeal.application.isEdit = _.has(req.query, 'edit');
+
+    return res.render('appeal-application/fee-support/help-with-fees.njk', {
+      previousPage: paths.appealSubmitted.feeSupportRefund,
+      formAction: paths.appealSubmitted.helpWithFeesRefund,
+      question: getApplyOption(req.session.appeal),
+      continueCancelButtons: true,
+      refundJourney: true
+    });
+  } catch (error) {
+    next(error);
+  }
+}
+
+function postHelpWithFees() {
+  return async (req: Request, res: Response, next: NextFunction) => {
+    const refundFeatureEnabled = await LaunchDarklyService.getInstance().getVariation(req, FEATURE_FLAGS.DLRM_REFUND_FEATURE_FLAG, false);
+    if (!refundFeatureEnabled) return res.redirect(paths.common.overview);
+
+    try {
+      const validation = helpWithFeesValidation(req.body);
+      if (validation) {
+        return res.render('appeal-application/fee-support/help-with-fees.njk', {
+          errors: validation,
+          errorList: Object.values(validation),
+          previousPage: paths.appealSubmitted.feeSupportRefund,
+          pageTitle: i18n.pages.helpWithFees.title,
+          question: getApplyOption(req.session.appeal),
+          formAction: paths.appealSubmitted.helpWithFeesRefund,
+          continueCancelButtons: true,
+          refundJourney: true
+        });
+      }
+      const selectedValue = req.body['answer'];
+      const application = req.session.appeal.application;
+      application.lateHelpWithFeesOption = selectedValue;
+      return res.redirect(getHelpWithFeesRedirectPage(selectedValue));
+    } catch (error) {
+      next(error);
+    }
+  };
+}
+
+function getHelpWithFeesRedirectPage(selectedOption: string): string {
+  switch (selectedOption) {
+    case i18n.pages.helpWithFees.options.wantToApply.value:
+      return paths.appealSubmitted.stepsToApplyForHelpWithFeesRefund;
+    case i18n.pages.helpWithFees.options.alreadyApplied.value:
+      return paths.appealSubmitted.helpWithFeesReferenceNumberRefund;
+    default:
+      throw new Error('The selected help with fees page option is not valid. Please check the value.');
+  }
+}
+
+function setupHelpWithFeesRefundController(middleware: Middleware[]): Router {
+  const router = Router();
+  router.get(paths.appealSubmitted.helpWithFeesRefund, middleware, getHelpWithFees);
+  router.post(paths.appealSubmitted.helpWithFeesRefund, middleware, postHelpWithFees());
+  return router;
+}
+
+export {
+  getHelpWithFees,
+  postHelpWithFees,
+  setupHelpWithFeesRefundController,
+  getHelpWithFeesRedirectPage,
+  getApplyOption
+};

--- a/app/controllers/ask-for-fee-remission/steps-to-help-with-fees-refund.ts
+++ b/app/controllers/ask-for-fee-remission/steps-to-help-with-fees-refund.ts
@@ -1,0 +1,45 @@
+import { NextFunction, Request, Response, Router } from 'express';
+import _ from 'lodash';
+import { FEATURE_FLAGS } from '../../data/constants';
+import { paths } from '../../paths';
+import LaunchDarklyService from '../../service/launchDarkly-service';
+
+async function getStepsToHelpWithFees(req: Request, res: Response, next: NextFunction) {
+  try {
+    const refundFeatureEnabled = await LaunchDarklyService.getInstance().getVariation(req, FEATURE_FLAGS.DLRM_REFUND_FEATURE_FLAG, false);
+    if (!refundFeatureEnabled) return res.redirect(paths.common.overview);
+    req.session.appeal.application.isEdit = _.has(req.query, 'edit');
+
+    return res.render('appeal-application/fee-support/steps-to-help-with-fees.njk', {
+      previousPage: paths.appealSubmitted.helpWithFeesRefund,
+      refundJourney: true
+    });
+  } catch (error) {
+    next(error);
+  }
+}
+
+function postStepsToHelpWithFees() {
+  return async (req: Request, res: Response, next: NextFunction) => {
+    const refundFeatureEnabled = await LaunchDarklyService.getInstance().getVariation(req, FEATURE_FLAGS.DLRM_REFUND_FEATURE_FLAG, false);
+    if (!refundFeatureEnabled) return res.redirect(paths.common.overview);
+    try {
+      return res.redirect(paths.appealSubmitted.helpWithFeesReferenceNumberRefund);
+    } catch (error) {
+      next(error);
+    }
+  };
+}
+
+function setupStepToHelpWithFeesRefundController(middleware: Middleware[]): Router {
+  const router = Router();
+  router.get(paths.appealSubmitted.stepsToApplyForHelpWithFeesRefund, middleware, getStepsToHelpWithFees);
+  router.post(paths.appealSubmitted.stepsToApplyForHelpWithFeesRefund, middleware, postStepsToHelpWithFees());
+  return router;
+}
+
+export {
+  getStepsToHelpWithFees,
+  postStepsToHelpWithFees,
+  setupStepToHelpWithFeesRefundController
+};

--- a/app/controllers/ask-for-fee-remission/upload-local-authority-letter-refund.ts
+++ b/app/controllers/ask-for-fee-remission/upload-local-authority-letter-refund.ts
@@ -1,0 +1,138 @@
+import { NextFunction, Request, Response, Router } from 'express';
+import _ from 'lodash';
+import i18n from '../../../locale/en.json';
+import { FEATURE_FLAGS } from '../../data/constants';
+import { PageSetup } from '../../interfaces/PageSetup';
+import { paths } from '../../paths';
+import { DocumentManagementService } from '../../service/document-management-service';
+import LaunchDarklyService from '../../service/launchDarkly-service';
+import { createStructuredError } from '../../utils/validations/fields-validations';
+
+async function getLocalAuthorityLetterRefund(req: Request, res: Response, next: NextFunction) {
+  try {
+    const refundFeatureEnabled = await LaunchDarklyService.getInstance().getVariation(req, FEATURE_FLAGS.DLRM_REFUND_FEATURE_FLAG, false);
+    if (!refundFeatureEnabled) return res.redirect(paths.common.overview);
+    req.session.appeal.application.isEdit = _.has(req.query, 'edit');
+    const evidenceListTitle = i18n.pages.uploadLocalAuthorityLetter.uploadedFileTitle;
+    let validationErrors: ValidationErrors;
+    if (req.query.error) {
+      validationErrors = {
+        uploadFile: createStructuredError('uploadFile', i18n.validationErrors.fileUpload[`${req.query.error}`])
+      };
+    }
+    const localAuthorityLetterEvidences = req.session.appeal.application.lateLocalAuthorityLetters || [];
+    let previousPage = paths.appealSubmitted.feeSupportRefund;
+
+    res.render('appeal-application/fee-support/upload-local-authority-letter.njk', {
+      title: i18n.pages.uploadLocalAuthorityLetter.title,
+      evidenceListTitle,
+      formSubmitAction: paths.appealSubmitted.localAuthorityLetterRefund,
+      evidenceUploadAction: paths.appealSubmitted.localAuthorityLetterUploadRefund,
+      evidences: localAuthorityLetterEvidences,
+      evidenceCTA: paths.appealSubmitted.localAuthorityLetterDeleteRefund,
+      previousPage: previousPage,
+      saveForLaterCTA: paths.common.overview,
+      ...validationErrors && { error: validationErrors },
+      ...validationErrors && { errorList: Object.values(validationErrors) },
+      continueCancelButtons: true
+    });
+  } catch (e) {
+    next(e);
+  }
+}
+
+function postLocalAuthorityLetterRefund() {
+  return async (req: Request, res: Response, next: NextFunction) => {
+    const refundFeatureEnabled = await LaunchDarklyService.getInstance().getVariation(req, FEATURE_FLAGS.DLRM_REFUND_FEATURE_FLAG, false);
+    if (!refundFeatureEnabled) return res.redirect(paths.common.overview);
+
+    try {
+      const authLetterUploads = req.session.appeal.application.lateLocalAuthorityLetters || [];
+      if (authLetterUploads.length > 0) {
+        resetJourneyValues(req.session.appeal.application);
+        return res.redirect(paths.appealSubmitted.checkYourAnswersRefund);
+      } else {
+        return res.redirect(`${paths.appealSubmitted.localAuthorityLetterRefund}?error=noFileSelected`);
+      }
+    } catch (error) {
+      next(error);
+    }
+  };
+}
+
+function validate(req: Request, res: Response, next: NextFunction) {
+  try {
+    let errorCode: string;
+    if (res.locals.errorCode) {
+      errorCode = res.locals.errorCode;
+    }
+    if (errorCode) {
+      return res.redirect(`${paths.appealSubmitted.localAuthorityLetterRefund}?error=${errorCode}`);
+    }
+    next();
+  } catch (e) {
+    next(e);
+  }
+}
+
+function uploadLocalAuthorityLetterRefund(documentManagementService: DocumentManagementService) {
+  return async (req: Request, res: Response, next: NextFunction) => {
+    try {
+      if (req.file) {
+        let localAuthorityLetterEvidences: Evidence[] = req.session.appeal.application.lateLocalAuthorityLetters || [];
+        const localAuthorityLetter: Evidence = await documentManagementService.uploadFile(req);
+        localAuthorityLetterEvidences.push(localAuthorityLetter);
+        const application = req.session.appeal.application;
+        application.lateLocalAuthorityLetters = localAuthorityLetterEvidences;
+        return res.redirect(paths.appealSubmitted.localAuthorityLetterRefund);
+      }
+      return res.redirect(`${paths.appealSubmitted.localAuthorityLetterRefund}?error=noFileSelected`);
+    } catch (e) {
+      next(e);
+    }
+  };
+}
+
+function deleteLocalAuthorityLetterRefund(documentManagementService: DocumentManagementService) {
+  return async (req: Request, res: Response, next: NextFunction) => {
+    try {
+      if (req.query.id) {
+        await documentManagementService.deleteFile(req, req.query.id as string);
+        const application = req.session.appeal.application;
+        application.lateLocalAuthorityLetters = req.session.appeal.application.lateLocalAuthorityLetters.filter(document => document.fileId !== req.query.id);
+        return res.redirect(paths.appealSubmitted.localAuthorityLetterRefund);
+      }
+    } catch (e) {
+      next(e);
+    }
+  };
+}
+
+// Function used in CYA page edit mode, when the start page option is changed other values should be reset and the journey should start from the new selected option
+function resetJourneyValues(application: AppealApplication) {
+  application.lateAsylumSupportRefNumber = null;
+  application.lateHelpWithFeesOption = null;
+  application.lateHelpWithFeesRefNumber = null;
+}
+
+@PageSetup.register
+class SetupLocalAuthorityLetterRefundController {
+  initialise(middleware: any[], updateAppealService, documentManagementService: DocumentManagementService): any {
+    const router = Router();
+    router.get(paths.appealSubmitted.localAuthorityLetterRefund, middleware, getLocalAuthorityLetterRefund);
+    router.post(paths.appealSubmitted.localAuthorityLetterRefund, middleware, postLocalAuthorityLetterRefund());
+    router.post(paths.appealSubmitted.localAuthorityLetterUploadRefund, middleware, validate, uploadLocalAuthorityLetterRefund(documentManagementService));
+    router.get(paths.appealSubmitted.localAuthorityLetterDeleteRefund, middleware, deleteLocalAuthorityLetterRefund(documentManagementService));
+    return router;
+  }
+}
+
+export {
+  getLocalAuthorityLetterRefund,
+  postLocalAuthorityLetterRefund,
+  uploadLocalAuthorityLetterRefund,
+  deleteLocalAuthorityLetterRefund,
+  SetupLocalAuthorityLetterRefundController,
+  validate,
+  resetJourneyValues
+};

--- a/app/data/constants.ts
+++ b/app/data/constants.ts
@@ -11,7 +11,8 @@ export const FEATURE_FLAGS = {
   FTPA: 'aip-ftpa-feature',
   USE_CCD_DOCUMENT_AM: 'use-ccd-document-am',
   DLRM_FEE_REMISSION_FEATURE_FLAG: 'dlrm-fee-remission-feature-flag',
-  DLRM_SETASIDE_FEATURE_FLAG: 'dlrm-setaside-feature-flag'
+  DLRM_SETASIDE_FEATURE_FLAG: 'dlrm-setaside-feature-flag',
+  DLRM_REFUND_FEATURE_FLAG: 'dlrm-refund-feature-flag'
 };
 
 export const APPLICANT_TYPE = {

--- a/app/data/events.ts
+++ b/app/data/events.ts
@@ -226,9 +226,27 @@ export const Events = {
     summary: 'Decide FTPA application',
     description: 'Decide FTPA application'
   },
+  REQUEST_FEE_REMISSION: {
+    id: 'requestFeeRemission',
+    description: 'Request fee remission'
+  },
+  RECORD_REMISSION_DECISION: {
+    id: 'recordRemissionDecision',
+    description: 'Record remission decision'
+  },
+  MANAGE_A_FEE_UPDATE: {
+    id: 'manageFeeUpdate',
+    summary: 'Manage a fee update',
+    description: 'Manage a fee update'
+  },
   MARK_APPEAL_AS_REMITTED: {
     id: 'markAppealAsRemitted',
     summary: 'Mark appeal as remitted',
     description: 'Mark appeal as remitted'
+  },
+  MARK_APPEAL_PAID: {
+    id: 'markAppealPaid',
+    summary: 'Mark appeal as paid',
+    description: 'Make a paid'
   }
 };

--- a/app/paths.ts
+++ b/app/paths.ts
@@ -43,7 +43,18 @@ const paths = {
     oocProtectionDepartureDate: '/ooc-protection-departure-date'
   },
   appealSubmitted: {
-    confirmation: '/appeals-details-sent'
+    confirmation: '/appeals-details-sent',
+    feeSupportRefund: '/fee-support-refund',
+    asylumSupportRefund: '/asylum-support-refund',
+    feeWaiverRefund: '/fee-waiver-refund',
+    localAuthorityLetterRefund: '/local-authority-letter-refund',
+    localAuthorityLetterUploadRefund: '/local-authority-letter-refund/upload',
+    localAuthorityLetterDeleteRefund: '/local-authority-letter-refund/delete',
+    helpWithFeesRefund: '/help-with-fees-refund',
+    stepsToApplyForHelpWithFeesRefund: '/steps-to-help-with-fees-refund',
+    helpWithFeesReferenceNumberRefund: '/help-with-fees-ref-number-refund',
+    checkYourAnswersRefund: '/check-your-answers-refund',
+    confirmationRefund: '/asked-for-remission'
   },
   pendingPayment: {
     confirmation: '/appeals-details-sent'

--- a/app/routes.ts
+++ b/app/routes.ts
@@ -21,6 +21,18 @@ import { setupStepToHelpWithFeesController } from './controllers/appeal-applicat
 import { setupTaskListController } from './controllers/appeal-application/task-list';
 import { setupTypeOfAppealController } from './controllers/appeal-application/type-of-appeal';
 import { setupApplicationOverviewController } from './controllers/application-overview';
+import { setupAsylumSupportRefundController } from './controllers/ask-for-fee-remission/asylum-support-refund';
+import { setupCheckYourAnswersRefundController } from './controllers/ask-for-fee-remission/check-your-answers-refund';
+import { setConfirmationRefundController } from './controllers/ask-for-fee-remission/confirmation-page';
+import { setupFeeSupportRefundController } from './controllers/ask-for-fee-remission/fee-support-refund';
+import { setupFeeWaiverRefundController } from './controllers/ask-for-fee-remission/fee-waiver-refund';
+import {
+  setupHelpWithFeesReferenceNumberRefundController
+} from './controllers/ask-for-fee-remission/help-with-fees-reference-number-refund';
+import { setupHelpWithFeesRefundController } from './controllers/ask-for-fee-remission/help-with-fees-refund';
+import {
+  setupStepToHelpWithFeesRefundController
+} from './controllers/ask-for-fee-remission/steps-to-help-with-fees-refund';
 import { setupAskForMoreTimeController } from './controllers/ask-for-more-time/ask-for-more-time';
 import { setupChangeRepresentationControllers } from './controllers/changing-representation';
 import { setupCQAnythingElseAnswerController } from './controllers/clarifying-questions/anything-else-answer';
@@ -199,6 +211,7 @@ import { setupSecrets } from './setupSecrets';
 import './controllers/appeal-application/home-office-details-upload-decision-letter';
 import './controllers/appeal-application/pay-now';
 import './controllers/appeal-application/upload-local-authority-letter';
+import './controllers/ask-for-fee-remission/upload-local-authority-letter-refund';
 
 const config = setupSecrets();
 const sessionLoggerEnabled: boolean = config.get('session.useLogger');
@@ -230,15 +243,23 @@ const homeOfficeDetailsController = setupHomeOfficeDetailsController(middleware,
 const typeOfAppealController = setupTypeOfAppealController(middleware, updateAppealService);
 const decisionTypeController = setupDecisionTypeController(middleware, updateAppealService);
 const feeSupportController = setupFeeSupportController(middleware, updateAppealService);
+const feeSupportRefundController = setupFeeSupportRefundController(middleware);
 const asylumSupportController = setupAsylumSupportController(middleware, updateAppealService);
+const asylumSupportRefundController = setupAsylumSupportRefundController(middleware);
 const feeWaiverController = setupFeeWaiverController(middleware, updateAppealService);
+const feeWaiverRefundController = setupFeeWaiverRefundController(middleware);
 const helpWithFeesController = setupHelpWithFeesController(middleware, updateAppealService);
+const helpWithFeesRefundController = setupHelpWithFeesRefundController(middleware);
 const helpWithFeesReferenceNumberController = setupHelpWithFeesReferenceNumberController(middleware, updateAppealService);
+const helpWithFeesReferenceNumberRefundController = setupHelpWithFeesReferenceNumberRefundController(middleware);
 const stepsToHelpWithFeesController = setupStepToHelpWithFeesController(middleware, updateAppealService);
+const stepsToHelpWithFeesRefundController = setupStepToHelpWithFeesRefundController(middleware);
+const checkYourAnswersRefundController = setupCheckYourAnswersRefundController(middleware, updateAppealService);
+const confirmationRefundController = setConfirmationRefundController(middleware);
 const personalDetailsController = setupPersonalDetailsController(middleware, { updateAppealService, osPlacesClient });
 const contactDetailsController = setupContactDetailsController(middleware, updateAppealService);
 const checkAndSendController = setupCheckAndSendController(middleware, updateAppealService, paymentService);
-const confirmationController = setConfirmationController(middleware);
+const confirmationController = setConfirmationController(middleware, updateAppealService);
 const outOfTimeController = setupOutOfTimeController(middleware, { updateAppealService, documentManagementService });
 const reasonsForAppealController = setupReasonsForAppealController(middleware, {
   updateAppealService,
@@ -366,11 +387,19 @@ router.use(personalDetailsController);
 router.use(typeOfAppealController);
 router.use(decisionTypeController);
 router.use(feeSupportController);
+router.use(feeSupportRefundController);
 router.use(asylumSupportController);
+router.use(asylumSupportRefundController);
 router.use(feeWaiverController);
+router.use(feeWaiverRefundController);
 router.use(helpWithFeesController);
+router.use(helpWithFeesRefundController);
 router.use(helpWithFeesReferenceNumberController);
+router.use(helpWithFeesReferenceNumberRefundController);
 router.use(stepsToHelpWithFeesController);
+router.use(stepsToHelpWithFeesRefundController);
+router.use(checkYourAnswersRefundController);
+router.use(confirmationRefundController);
 router.use(contactDetailsController);
 router.use(confirmationController);
 router.use(checkAndSendController);

--- a/app/service/payments-service.ts
+++ b/app/service/payments-service.ts
@@ -56,7 +56,7 @@ export default class PaymentService {
       const paymentDetails = JSON.parse(await this.getPaymentDetails(req, req.session.appeal.paymentReference));
       if (paymentDetails.status === 'Initiated') {
         req.app.locals.logger.trace(`Payment already initiated, cancel payment should go here`, 'Payments Service');
-      } else if (paymentDetails.status === 'Success') {
+      } else if (!req.session.appeal.application.refundConfirmationApplied && paymentDetails.status === 'Success') {
         return res.redirect(paths.common.finishPayment);
       }
     }

--- a/app/utils/application-state-utils.ts
+++ b/app/utils/application-state-utils.ts
@@ -16,7 +16,8 @@ import {
 } from '../utils/utils';
 import { getHearingCentre, getHearingCentreEmail, getHearingDate, getHearingTime } from './cma-hearing-details';
 import { getDeadline, getDueDateForAppellantToRespondToFtpaDecision } from './event-deadline-date-finder';
-import { appealHasNoRemissionOption, appealHasRemissionOption } from './remission-utils';
+import { convertToAmountOfMoneyDividedBy100, getFee } from './payments-utils';
+import { appealHasRemissionOption, hasFeeRemissionDecision } from './remission-utils';
 
 interface DoThisNextSection {
   descriptionParagraphs: string[];
@@ -50,8 +51,12 @@ interface DoThisNextSection {
   removeAppealFromOnlineReason?: string;
   removeAppealFromOnlineDate?: string;
   decision?: string;
+  feeForAppeal?: string;
+  feeLeftToPay?: string;
+  remissionRejectedDatePlus14days?: string;
   utAppealReferenceNumber?: string;
   sourceOfRemittal?: string;
+  ccdReferenceNumber?: string;
 }
 
 /**
@@ -118,6 +123,8 @@ async function getAppealApplicationNextStep(req: Request) {
   const ftpaApplicantType = getFtpaApplicantType(req.session.appeal);
   const ftpaSetAsideFeatureEnabled: boolean = await LaunchDarklyService.getInstance().getVariation(req, FEATURE_FLAGS.DLRM_SETASIDE_FEATURE_FLAG, false);
   const dlrmFeeRemissionFlag: boolean = await LaunchDarklyService.getInstance().getVariation(req, FEATURE_FLAGS.DLRM_FEE_REMISSION_FEATURE_FLAG, false);
+  const deadLineDate = getDeadline(currentAppealStatus, req, dlrmFeeRemissionFlag, ftpaSetAsideFeatureEnabled);
+  const isLateRemissionRequest = req.session.appeal.application.isLateRemissionRequest;
 
   let descriptionParagraphs;
   let respondBy;
@@ -149,18 +156,10 @@ async function getAppealApplicationNextStep(req: Request) {
       };
       break;
     case 'appealSubmitted':
-      if (dlrmFeeRemissionFlag &&
-        !appealHasNoRemissionOption(req.session.appeal.application)) {
-        doThisNextSection = {
-          descriptionParagraphs: [
-            i18n.pages.overviewPage.doThisNext.appealSubmittedDlrmFeeRemission.detailsSent,
-            i18n.pages.overviewPage.doThisNext.appealSubmittedDlrmFeeRemission.feeDetails,
-            i18n.pages.overviewPage.doThisNext.appealSubmittedDlrmFeeRemission.tribunalCheck,
-            i18n.pages.overviewPage.doThisNext.appealSubmittedDlrmFeeRemission.dueDate
-          ],
-          cta: null,
-          allowedAskForMoreTime: false
-        };
+      if (dlrmFeeRemissionFlag && remissionDecisionEventIsTheLatest(req) && !isLateRemissionRequest) {
+        doThisNextSection = getRemissionDecisionParagraphs(req);
+      } else if (dlrmFeeRemissionFlag && requestFeeRemissionEventIsTheLatest(req)) {
+        doThisNextSection = getFeeRemissionParagraph(deadLineDate);
       } else {
         doThisNextSection = {
           descriptionParagraphs: [
@@ -198,8 +197,10 @@ async function getAppealApplicationNextStep(req: Request) {
       };
       break;
     case 'lateAppealSubmitted':
-      if (dlrmFeeRemissionFlag &&
-        !appealHasNoRemissionOption(req.session.appeal.application)) {
+      if (dlrmFeeRemissionFlag && remissionDecisionEventIsTheLatest(req) && !isLateRemissionRequest) {
+        doThisNextSection = getRemissionDecisionParagraphs(req);
+      } else if (dlrmFeeRemissionFlag &&
+        requestFeeRemissionEventIsTheLatest(req)) {
         doThisNextSection = {
           descriptionParagraphs: [
             i18n.pages.overviewPage.doThisNext.lateAppealSubmittedDlrmFeeRemission.detailsSent,
@@ -559,8 +560,7 @@ async function getAppealApplicationNextStep(req: Request) {
       break;
     case 'appealTakenOffline':
       doThisNextSection = {
-        descriptionParagraphs: [
-        ],
+        descriptionParagraphs: [],
         info: {
           title: i18n.pages.overviewPage.doThisNext.appealTakenOffline.info.title,
           url: i18n.pages.overviewPage.doThisNext.appealTakenOffline.info.description
@@ -584,7 +584,6 @@ async function getAppealApplicationNextStep(req: Request) {
       };
       break;
     case 'decided':
-
       let decidedDescriptionParagraphs;
       let decidedInfo;
       let decision;
@@ -641,7 +640,9 @@ async function getAppealApplicationNextStep(req: Request) {
       };
       break;
     case 'pendingPayment':
-      if (dlrmFeeRemissionFlag && appealHasRemissionOption(req.session.appeal.application)) {
+      if (dlrmFeeRemissionFlag && remissionDecisionEventIsTheLatest(req)) {
+        doThisNextSection = getRemissionDecisionParagraphs(req);
+      } else if (dlrmFeeRemissionFlag && appealHasRemissionOption(req.session.appeal.application)) {
         doThisNextSection = {
           descriptionParagraphs: [
             i18n.pages.overviewPage.doThisNext.appealSubmittedDlrmFeeRemission.detailsSent,
@@ -672,8 +673,8 @@ async function getAppealApplicationNextStep(req: Request) {
     case 'ftpaSubmitted':
       doThisNextSection = {
         descriptionParagraphs: (ftpaEnabled)
-            ? i18n.pages.overviewPage.doThisNext.ftpaSubmitted.description[ftpaApplicantType]
-            : [ `Nothing to do next` ]
+          ? i18n.pages.overviewPage.doThisNext.ftpaSubmitted.description[ftpaApplicantType]
+          : [`Nothing to do next`]
       };
       break;
     case 'ftpaDecided':
@@ -698,7 +699,7 @@ async function getAppealApplicationNextStep(req: Request) {
         }
       } else {
         doThisNextSection = {
-          descriptionParagraphs: [ `Nothing to do next` ]
+          descriptionParagraphs: [`Nothing to do next`]
         };
       }
       break;
@@ -718,7 +719,7 @@ async function getAppealApplicationNextStep(req: Request) {
       };
       break;
   }
-  doThisNextSection.deadline = getDeadline(currentAppealStatus, req, dlrmFeeRemissionFlag, ftpaSetAsideFeatureEnabled);
+  doThisNextSection.deadline = deadLineDate;
   return doThisNextSection;
 }
 
@@ -740,6 +741,84 @@ function eventByLegalRep(req: Request, eventId: string, state: string): boolean 
     && event.user.id !== req.idam.userDetails.uid).length > 0;
 }
 
+function getRemissionDecisionParagraphs(req: Request) {
+  let doThisNextSection: DoThisNextSection;
+  const remissionDecision = req.session.appeal.application.remissionDecision;
+  switch (remissionDecision) {
+    case 'approved':
+      doThisNextSection = {
+        descriptionParagraphs: [
+          i18n.pages.overviewPage.doThisNext.remissionDecided.approved.detailsSent,
+          i18n.pages.overviewPage.doThisNext.remissionDecided.approved.legalOfficerCheck,
+          i18n.pages.overviewPage.doThisNext.remissionDecided.approved.helpFulInfo,
+          i18n.pages.overviewPage.doThisNext.remissionDecided.approved.href
+        ],
+        cta: null,
+        allowedAskForMoreTime: false
+      };
+      break;
+    case 'partiallyApproved':
+      doThisNextSection = {
+        descriptionParagraphs: [
+          i18n.pages.overviewPage.doThisNext.remissionDecided.partiallyApproved.feeForAppeal,
+          i18n.pages.overviewPage.doThisNext.remissionDecided.partiallyApproved.dueDate,
+          i18n.pages.overviewPage.doThisNext.remissionDecided.partiallyApproved.howToPay,
+          i18n.pages.overviewPage.doThisNext.remissionDecided.partiallyApproved.bulletText
+        ],
+        cta: {},
+        allowedAskForMoreTime: false
+      };
+      doThisNextSection.feeLeftToPay = convertToAmountOfMoneyDividedBy100(req.session.appeal.application.amountLeftToPay);
+      doThisNextSection.remissionRejectedDatePlus14days = req.session.appeal.application.remissionRejectedDatePlus14days;
+      doThisNextSection.ccdReferenceNumber = req.session.appeal.ccdReferenceNumber.split(' ').join('-');
+      break;
+    case 'rejected':
+      doThisNextSection = {
+        descriptionParagraphs: [
+          i18n.pages.overviewPage.doThisNext.remissionDecided.rejected.feeForAppeal,
+          i18n.pages.overviewPage.doThisNext.remissionDecided.rejected.dueDate,
+          i18n.pages.overviewPage.doThisNext.remissionDecided.rejected.payForAppeal
+        ],
+        cta: {},
+        allowedAskForMoreTime: false
+      };
+      doThisNextSection.feeForAppeal = getFee(req.session.appeal).calculated_amount;
+      doThisNextSection.remissionRejectedDatePlus14days = req.session.appeal.application.remissionRejectedDatePlus14days;
+      break;
+    default:
+      throw new Error(`Remission decision type ${remissionDecision} is not presented`);
+  }
+  return doThisNextSection;
+}
+
+function getFeeRemissionParagraph(deadLineDate: string) {
+  let doThisNextSection: DoThisNextSection;
+  doThisNextSection = {
+    descriptionParagraphs: [
+      i18n.pages.overviewPage.doThisNext.appealSubmittedDlrmFeeRemission.detailsSent,
+      i18n.pages.overviewPage.doThisNext.appealSubmittedDlrmFeeRemission.feeDetails,
+      i18n.pages.overviewPage.doThisNext.appealSubmittedDlrmFeeRemission.tribunalCheck,
+      i18n.pages.overviewPage.doThisNext.appealSubmittedDlrmFeeRemission.dueDate
+    ],
+    cta: null,
+    allowedAskForMoreTime: false
+  };
+  doThisNextSection.deadline = deadLineDate;
+  return doThisNextSection;
+}
+
+function remissionDecisionEventIsTheLatest(req: Request) {
+  return hasFeeRemissionDecision(req) && isEventLatestInHistoryList(req, Events.RECORD_REMISSION_DECISION.id);
+}
+
+function requestFeeRemissionEventIsTheLatest(req: Request) {
+  return appealHasRemissionOption(req.session.appeal.application) && isEventLatestInHistoryList(req, Events.REQUEST_FEE_REMISSION.id);
+}
+
+function isEventLatestInHistoryList(req: Request, eventId: string) {
+  return req.session.appeal.history && req.session.appeal.history.length > 0 ? req.session.appeal.history[0].id === eventId : false;
+}
+
 function transferredToUpperTribunal(req: Request): boolean {
   return req.session.appeal.utAppealReferenceNumber == null ? false : true;
 }
@@ -751,5 +830,11 @@ export {
   getMoveAppealOfflineDate,
   isAddendumEvidenceUploadState,
   eventByLegalRep,
-  transferredToUpperTribunal
+  transferredToUpperTribunal,
+  isEventLatestInHistoryList,
+  requestFeeRemissionEventIsTheLatest,
+  remissionDecisionEventIsTheLatest,
+  getFeeRemissionParagraph,
+  getRemissionDecisionParagraphs
+
 };

--- a/app/utils/payments-utils.ts
+++ b/app/utils/payments-utils.ts
@@ -31,3 +31,11 @@ export function payLaterForApplicationNeeded(req: Request): boolean {
   const payLaterProtection = appealStatus !== States.APPEAL_STARTED.id && appealType === 'protection' && paAppealTypeAipPaymentOption === 'payLater' && paymentStatus !== 'Paid';
   return payLaterProtection;
 }
+
+export function convertToAmountOfMoneyDividedBy100(amount: string): string {
+  const parsedAmountValue = parseFloat(amount);
+  if (isNaN(parsedAmountValue)) {
+    throw new Error('Amount value is not available');
+  }
+  return (parsedAmountValue / 100).toString();
+}

--- a/app/utils/remission-utils.ts
+++ b/app/utils/remission-utils.ts
@@ -1,12 +1,14 @@
+import { Request } from 'express';
+import i18n from '../../locale/en.json';
+import { Events } from '../data/events';
+import { convertToAmountOfMoneyDividedBy100 } from './payments-utils';
+import { addSummaryRow } from './summary-list';
+
 function appealHasRemissionOption(application: AppealApplication) {
-  return [
-    'asylumSupportFromHo',
-    'feeWaiverFromHo',
-    'under18GetSupportFromLocalAuthority',
-    'parentGetSupportFromLocalAuthority'
-  ].includes(application.remissionOption) ||
-    'noneOfTheseStatements' === application.remissionOption &&
-    ('wantToApply' === application.helpWithFeesOption || 'alreadyApplied' === application.helpWithFeesOption)
+  return ['asylumSupportFromHo', 'feeWaiverFromHo', 'under18GetSupportFromLocalAuthority', 'parentGetSupportFromLocalAuthority']
+      .includes(application.remissionOption)
+    || ['noneOfTheseStatements', 'iWantToGetHelpWithFees'].includes(application.remissionOption)
+    && ['wantToApply', 'alreadyApplied'].includes(application.helpWithFeesOption)
     && application.helpWithFeesRefNumber;
 }
 
@@ -14,7 +16,91 @@ function appealHasNoRemissionOption(application: AppealApplication) {
   return 'noneOfTheseStatements' === application.remissionOption && 'willPayForAppeal' === application.helpWithFeesOption;
 }
 
+function hasFeeRemissionDecision(req: Request) {
+  return !!req.session.appeal.application.remissionDecision;
+}
+
+function getFeeSupportStatusForAppealDetails(req: Request) {
+  if (hasFeeRemissionDecision(req)) {
+    const remissionDecision = req.session.appeal.application.remissionDecision;
+    switch (remissionDecision) {
+      case 'approved':
+        return i18n.pages.overviewPage.doThisNext.remissionDecided.feeSupportStatusApproved;
+      case 'partiallyApproved':
+        return i18n.pages.overviewPage.doThisNext.remissionDecided.feeSupportStatusPartiallyApproved;
+      case 'rejected':
+        return i18n.pages.overviewPage.doThisNext.remissionDecided.feeSupportStatusRefused;
+    }
+  } else {
+    return i18n.pages.overviewPage.doThisNext.remissionDecided.feeSupportRequested;
+  }
+}
+
+function getDecisionReasonRowForAppealDetails(req: Request) {
+  const remissionDecision = req.session.appeal.application.remissionDecision;
+  const remissionDecisionReason = req.session.appeal.application.remissionDecisionReason;
+  switch (remissionDecision) {
+    case 'approved':
+      return [];
+    case 'partiallyApproved':
+      const amountLeftToPay = convertToAmountOfMoneyDividedBy100(req.session.appeal.application.amountLeftToPay);
+      return [
+        addSummaryRow(i18n.pages.checkYourAnswers.rowTitles.reasonForDecision,
+          [remissionDecisionReason], null),
+        addSummaryRow(i18n.pages.checkYourAnswers.rowTitles.feeToPay, ['£' + amountLeftToPay], null)
+      ];
+    case 'rejected':
+      return [
+        addSummaryRow(i18n.pages.checkYourAnswers.rowTitles.reasonForDecision,
+          [remissionDecisionReason], null)
+      ];
+    default:
+      return [];
+  }
+}
+
+function getPaymentStatusRow(req: Request) {
+  const { paymentStatus = null } = req.session.appeal;
+  const { application } = req.session.appeal;
+  const { remissionDecision, isLateRemissionRequest } = application;
+
+  if (!hasFeeRemissionDecision(req)) {
+    return paymentStatus;
+  }
+
+  if (isLateRemissionRequest) {
+    return ['approved', 'partiallyApproved'].includes(remissionDecision) ? 'To be refunded' : paymentStatus;
+  } else {
+    if (paymentForAppealHasBeenMade(req) && paymentStatus === 'Paid') {
+      return paymentStatus;
+    } else {
+      switch (remissionDecision) {
+        case 'approved':
+          return i18n.pages.overviewPage.doThisNext.remissionDecided.paymentPending.decisionApprovedPaymentStatus;
+        case 'partiallyApproved':
+          return i18n.pages.overviewPage.doThisNext.remissionDecided.paymentPending.decisionPartiallyApprovedPaymentStatus;
+        case 'rejected':
+          return i18n.pages.overviewPage.doThisNext.remissionDecided.paymentPending.decisionRejectedPaymentStatus;
+      }
+    }
+  }
+}
+
+/* An appeal can be created with options such as 'Fee Remission' and 'Pay Later'.
+Following submission, remission can be decided.
+In such cases, the payment status changed to 'PAID' automatically without the occurrence of a payment event.
+This function verifies whether a payment event has been triggered or not. */
+function paymentForAppealHasBeenMade(req: Request) {
+  return req.session.appeal.history
+    && req.session.appeal.history.some(history => [Events.PAYMENT_APPEAL.id, Events.MARK_APPEAL_PAID.id].includes(history.id));
+}
+
 export {
   appealHasRemissionOption,
-  appealHasNoRemissionOption
+  appealHasNoRemissionOption,
+  hasFeeRemissionDecision,
+  getFeeSupportStatusForAppealDetails,
+  getDecisionReasonRowForAppealDetails,
+  getPaymentStatusRow,
+  paymentForAppealHasBeenMade
 };

--- a/app/utils/timeline-utils.ts
+++ b/app/utils/timeline-utils.ts
@@ -9,17 +9,18 @@ import { paths } from '../paths';
 import { SecurityHeaders } from '../service/authentication-service';
 import LaunchDarklyService from '../service/launchDarkly-service';
 import UpdateAppealService from '../service/update-appeal-service';
-import { transferredToUpperTribunal } from './application-state-utils';
+import { appealHasRemissionOption, paymentForAppealHasBeenMade } from './remission-utils';
 import {
-    getAppellantApplications,
-    getApplicant,
-    getFtpaApplicantType,
-    getLatestUpdateTribunalDecisionHistory,
-    isFtpaFeatureEnabled,
-    isNonStandardDirectionEnabled,
-    isReadonlyApplicationEnabled,
-    isUpdateTribunalDecideWithRule31,
-    isUpdateTribunalDecideWithRule32
+  getAppellantApplications,
+  getApplicant,
+  getFtpaApplicantType,
+  getLatestUpdateRemissionDecionsEventHistory,
+  getLatestUpdateTribunalDecisionHistory,
+  isFtpaFeatureEnabled,
+  isNonStandardDirectionEnabled,
+  isReadonlyApplicationEnabled,
+  isUpdateTribunalDecideWithRule31,
+  isUpdateTribunalDecideWithRule32
 } from './utils';
 
 /**
@@ -265,6 +266,7 @@ function getUpdateTribunalDecisionDocumentHistory(req: Request, ftpaSetAsideFeat
 async function getAppealApplicationHistory(req: Request, updateAppealService: UpdateAppealService) {
   const authenticationService = updateAppealService.getAuthenticationService();
   const headers: SecurityHeaders = await authenticationService.getSecurityHeaders(req);
+  const { application } = req.session.appeal;
   const ccdService = updateAppealService.getCcdService();
   req.session.appeal.history = await ccdService.getCaseHistory(req.idam.userDetails.uid, req.session.appeal.ccdCaseId, headers);
 
@@ -272,7 +274,8 @@ async function getAppealApplicationHistory(req: Request, updateAppealService: Up
   const hearingBundleFeatureEnabled: boolean = await LaunchDarklyService.getInstance().getVariation(req, FEATURE_FLAGS.HEARING_BUNDLE, false);
   const ftpaFeatureEnabled: boolean = await isFtpaFeatureEnabled(req);
   const ftpaSetAsideFeatureEnabled: boolean = await LaunchDarklyService.getInstance().getVariation(req, FEATURE_FLAGS.DLRM_SETASIDE_FEATURE_FLAG, false);
-  const eventsAndStates = getEventsAndStates(uploadAddendumEvidenceFeatureEnabled, hearingBundleFeatureEnabled, ftpaFeatureEnabled, ftpaSetAsideFeatureEnabled);
+  const refundFeatureEnabled = await LaunchDarklyService.getInstance().getVariation(req, FEATURE_FLAGS.DLRM_REFUND_FEATURE_FLAG, false);
+  const eventsAndStates = getEventsAndStates(uploadAddendumEvidenceFeatureEnabled, hearingBundleFeatureEnabled, ftpaFeatureEnabled, ftpaSetAsideFeatureEnabled, refundFeatureEnabled);
 
   const appealDecisionSection = constructSection(eventsAndStates.appealDecisionSectionEvents, req.session.appeal.history, null, req);
   let appealHearingRequirementsSection = constructSection(
@@ -293,20 +296,28 @@ async function getAppealApplicationHistory(req: Request, updateAppealService: Up
   const applicationEvents = getApplicationEvents(req);
   const submitCQHistory = getSubmitClarifyingQuestionsEvents(req.session.appeal.history, req.session.appeal.directions || []);
   const { paymentStatus, paAppealTypeAipPaymentOption = null, paymentDate } = req.session.appeal;
+  const directionsHistory = getDirectionHistory(req);
   let paymentEvent = [];
-  if (paymentStatus === 'Paid') {
-    paymentEvent = [{
-      date: moment(paymentDate).format('DD MMMM YYYY'),
-      dateObject: new Date(paymentDate),
-      text: i18n.pages.overviewPage.timeline.paymentAppeal.text || null,
-      links: i18n.pages.overviewPage.timeline.paymentAppeal.links
-    }];
+  let appealRemissionSection: any[];
+  let appealRemissionDecisionSection: any[];
+  let manageAFeeUpdate: any[];
+  let argumentSection: any[];
+  const manageAFeeUpdateEvents = req.session.appeal.history.filter(event => Events.MANAGE_A_FEE_UPDATE.id.includes(event.id));
+
+  if (paymentStatus === 'Paid' && refundFeatureEnabled && appealHasRemissionOption(application) && application.isLateRemissionRequest) {
+    const remissionEvent = getApplicationHistoryRemissionEvent(paymentDate);
+    appealRemissionSection = appealArgumentSection.concat(applicationEvents, remissionEvent, submitCQHistory, directionsHistory)
+      .sort((a: any, b: any) => b.dateObject - a.dateObject);
+  } else if (paymentStatus === 'Paid' && refundFeatureEnabled && !application.isLateRemissionRequest && manageAFeeUpdateEvents.length > 0) {
+    manageAFeeUpdate = getApplicationHistoryManageAFeeUpdate(manageAFeeUpdateEvents);
+  } else if (paymentStatus === 'Paid' && paymentForAppealHasBeenMade(req)) {
+    paymentEvent = getApplicationHistoryPaymentEvent(paymentDate);
   }
 
-  const directionsHistory = getDirectionHistory(req);
+  argumentSection = appealArgumentSection.concat(applicationEvents, paymentEvent, submitCQHistory, directionsHistory)
+    .sort((a: any, b: any) => b.dateObject - a.dateObject);
 
-  const argumentSection = appealArgumentSection.concat(applicationEvents, paymentEvent, submitCQHistory, directionsHistory)
-        .sort((a: any, b: any) => b.dateObject - a.dateObject);
+  appealRemissionDecisionSection = getApplicationHistoryAppealRemissionSection(req, manageAFeeUpdate, refundFeatureEnabled, appealRemissionSection, application, applicationEvents, submitCQHistory, directionsHistory);
 
   const updatedTribunalDecisionHistory = getUpdateTribunalDecisionHistory(req, ftpaSetAsideFeatureEnabled);
   const updatedTribunalDecisionDocumentHistory = getUpdateTribunalDecisionDocumentHistory(req, ftpaSetAsideFeatureEnabled);
@@ -319,14 +330,65 @@ async function getAppealApplicationHistory(req: Request, updateAppealService: Up
     ...(appealHearingRequirementsSection && appealHearingRequirementsSection.length > 0) &&
         { appealHearingRequirementsSection: appealHearingRequirementsSection },
     appealArgumentSection: argumentSection,
-    appealDetailsSection: appealDetailsSection
+    appealDetailsSection: appealDetailsSection,
+    ...(appealRemissionSection && appealRemissionSection.length > 0) &&
+    { appealRemissionSection: appealRemissionSection },
+    ...(appealRemissionDecisionSection && appealRemissionDecisionSection.length > 0) &&
+    { appealRemissionDecisionSection: appealRemissionDecisionSection }
   };
+}
+
+function getApplicationHistoryRemissionEvent(paymentDate: string) {
+  return [{
+    date: moment(paymentDate).format('DD MMMM YYYY'),
+    dateObject: new Date(paymentDate),
+    text: i18n.pages.overviewPage.timeline.refundAppeal.text || null,
+    links: i18n.pages.overviewPage.timeline.refundAppeal.links
+  }];
+}
+
+function getApplicationHistoryManageAFeeUpdate(manageAFeeUpdateEvents) {
+  return [{
+    date: moment(manageAFeeUpdateEvents[0].createdDate).format('DD MMMM YYYY'),
+    dateObject: new Date(manageAFeeUpdateEvents[0].createdDate),
+    text: i18n.pages.overviewPage.timeline.manageFeeUpdate.text || null,
+    links: i18n.pages.overviewPage.timeline.manageFeeUpdate.links
+  }];
+}
+
+function getApplicationHistoryPaymentEvent(paymentDate) {
+  return [{
+    date: moment(paymentDate).format('DD MMMM YYYY'),
+    dateObject: new Date(paymentDate),
+    text: i18n.pages.overviewPage.timeline.paymentAppeal.text || null,
+    links: i18n.pages.overviewPage.timeline.paymentAppeal.links
+  }];
+}
+
+function getApplicationHistoryAppealRemissionSection(req, manageAFeeUpdate, refundFeatureEnabled, appealRemissionSection, application, applicationEvents, submitCQHistory, directionsHistory) {
+  if (manageAFeeUpdate) {
+    return manageAFeeUpdate;
+  } else if (refundFeatureEnabled && application.remissionDecision) {
+    const latestUpdateRemissionDecisionHistory = getLatestUpdateRemissionDecionsEventHistory(req, refundFeatureEnabled);
+    const decisionRemissionEvent = [{
+      date: moment(latestUpdateRemissionDecisionHistory.createdDate).format('DD MMMM YYYY'),
+      dateObject: new Date(latestUpdateRemissionDecisionHistory.createdDate),
+      text: i18n.pages.overviewPage.timeline.feeRemissionDecision.text || null,
+      links: i18n.pages.overviewPage.timeline.feeRemissionDecision.links
+    }];
+    if (appealRemissionSection) {
+      return decisionRemissionEvent.concat(appealRemissionSection);
+    } else {
+      return decisionRemissionEvent.concat(applicationEvents, submitCQHistory, directionsHistory);
+    }
+  }
 }
 
 function getEventsAndStates(uploadAddendumEvidenceFeatureEnabled: boolean,
                             hearingBundleFeatureEnabled: boolean,
                             ftpaFeatureEnabled: boolean,
-                            ftpaSetAsideFeatureEnabled: boolean) {
+                            ftpaSetAsideFeatureEnabled: boolean,
+                            refundFeatureEnabled: boolean = false) {
   const appealHearingRequirementsSectionEvents = [
     Events.SUBMIT_AIP_HEARING_REQUIREMENTS.id,
     Events.STITCHING_BUNDLE_COMPLETE.id,

--- a/app/utils/utils.ts
+++ b/app/utils/utils.ts
@@ -156,6 +156,19 @@ export function getLatestUpdateTribunalDecisionHistory(req: Request, ftpaSetAsid
     .sort((a: any, b: any) => new Date(b.createdDate).getTime() - new Date(a.createdDate).getTime())[0] : null;
 }
 
+export function isRemissionDecisionDecided(req: Request, refundFeatureEnabled: boolean = false): boolean {
+  return (refundFeatureEnabled &&
+    req.session.appeal.history &&
+    req.session.appeal.history.find(event => event.id === Events.RECORD_REMISSION_DECISION.id) !== undefined &&
+    !!req.session.appeal.application.remissionDecision);
+}
+
+export function getLatestUpdateRemissionDecionsEventHistory(req: Request, refundFeatureEnabled: boolean = false): HistoryEvent {
+  return isRemissionDecisionDecided(req, refundFeatureEnabled) ? req.session.appeal.history
+    .filter(history => history.id === Events.RECORD_REMISSION_DECISION.id)
+    .sort((a: any, b: any) => new Date(b.createdDate).getTime() - new Date(a.createdDate).getTime())[0] : null;
+}
+
 export function formatWitnessName(witnessName: WitnessName) {
   const givenNames = witnessName.witnessGivenNames;
   const familyName = witnessName.witnessFamilyName;

--- a/config/default.json
+++ b/config/default.json
@@ -88,7 +88,8 @@
     "pendingPayment": 14,
     "afterReasonsForAppeal": 14,
     "afterCQSubmission": 7,
-    "outOfCountry": 28
+    "outOfCountry": 28,
+    "fromRemissionAppliedDate": 14
   },
   "features": {
     "askForMoreTime": false,

--- a/locale/en.json
+++ b/locale/en.json
@@ -308,7 +308,21 @@
         "feeSupportType": "Fee support type",
         "localAuthorityLetter": "Local Authority letter",
         "helpWithFeesReferenceNumber": "Help with fees reference number",
-        "paymentStatus": "Payment status"
+        "amountToRefund": "Amount to refund",
+        "feeToRefund": "Fee to refund",
+        "paymentStatus": "Payment status",
+        "reasonForDecision": "Reason for decision",
+        "feeToPay": "Fee to pay",
+        "dateOfApplication": "Date of application",
+        "feeAmountPaid": "Fee amount paid",
+        "reasonForFeeChange": "Reason for fee change",
+        "decisionTypeChanged": "Decision type changed",
+        "feeRemissionChanged": "Fee remission changed",
+        "appealNotValid": "Appeal not valid",
+        "appealWithdrawn": "Appeal withdrawn",
+        "amountToBeRefund": "Amount to be refunded",
+        "additionalPaymentRequested": "Additional payment requested",
+        "toBeRefunded": "To be refunded"
       },
       "supportingEvidence": "<a href='{{ evidenceUrl }}' class='govuk-link'>{{ evidence }}</a>",
       "decisionType": "Decision Type",
@@ -874,6 +888,7 @@
       "noLongerRepresentingMyself": "I am no longer representing myself",
       "iWantTo": "I want to...",
       "withdrawAppeal": "Withdraw my appeal",
+      "askForFeeRemission": "Ask for a fee remission",
       "appealRequests": {
         "sectionHeading": "Appeal requests",
         "askToChangeDetails": "Ask to change some of your details",
@@ -1260,6 +1275,34 @@
         },
         "remitted": {
           "decision": "The {{ applicationNextStep.sourceOfRemittal }} has decided that this appeal will be heard again by the First-tier Tribunal. <br><br> <a href={{ paths.common.remittalDocumentsViewer }}>See the {{ applicationNextStep.sourceOfRemittal }} documents</a> <br><br> <b>What happens next</b> <br><br> There will be a new hearing for this appeal. The Tribunal will contact you to let you know what to do next. <br><br> You can <a href={{ paths.common.provideMoreEvidenceForm }}>provide more evidence for this appeal</a> to the Tribunal, if you have it."
+        },
+        "remissionDecided": {
+          "approved": {
+            "detailsSent": "Your appeal details have been sent to the Tribunal.",
+            "legalOfficerCheck": "A Legal Officer will contact you to tell you what happens next. This should be by <span class='govuk-body govuk-!-font-weight-bold'>{{ applicationNextStep.deadline }}</span> but it might take longer than that.",
+            "helpFulInfo": "<b>Helpful information</b>",
+            "href": "<a href={{ paths.common.tribunalCaseworker }}>What is a Tribunal Caseworker?</a>"
+          },
+          "rejected": {
+            "feeForAppeal": "The fee for this appeal is £{{ applicationNextStep.feeForAppeal }}.",
+            "dueDate": "If you do not pay the fee by <span class='govuk-body govuk-!-font-weight-bold'>{{ applicationNextStep.remissionRejectedDatePlus14days }}</span> the Tribunal will end the appeal.",
+            "payForAppeal": "<a href={{ paths.common.payLater }}>Pay for the appeal</a>"
+          },
+          "partiallyApproved": {
+            "feeForAppeal": "The fee for this appeal is £{{ applicationNextStep.feeLeftToPay }}.",
+            "dueDate": "If you do not pay the fee by <span class='govuk-body govuk-!-font-weight-bold'>{{ applicationNextStep.remissionRejectedDatePlus14days }}</span> the Tribunal will end the appeal.",
+            "howToPay": "<b>How to pay the fee</b>",
+            "bulletText": "1. Call the Tribunal on 0300 123 1711, then select option 4<br />2. Provide your 16-digit online case reference number: {{ applicationNextStep.ccdReferenceNumber }}<br />3. Make the payment with a debit or credit card"
+          },
+          "feeSupportRequested": "Fee support requested",
+          "feeSupportStatusApproved": "Fee support request approved",
+          "feeSupportStatusRefused": "Fee support request refused",
+          "feeSupportStatusPartiallyApproved": "Fee support partially approved",
+          "paymentPending": {
+            "decisionApprovedPaymentStatus": "No payment needed",
+            "decisionPartiallyApprovedPaymentStatus": "Not paid",
+            "decisionRejectedPaymentStatus": "Not paid"
+          }
         }
       },
       "timeline": {
@@ -1268,7 +1311,8 @@
           "appealDecisionSection": "Your appeal decision",
           "appealHearingRequirementsSection": "Your hearing details",
           "appealArgumentSection": "Your appeal argument",
-          "appealDetailsSection": "Your appeal details"
+          "appealDetailsSection": "Your appeal details",
+          "appealRemissionSection": "Your appeal details"
         },
         "asyncStitchingComplete": {
           "text": "The hearing bundle is ready to view.",
@@ -1387,6 +1431,16 @@
               "title": "Helpful information",
               "text": "What is a Tribunal Caseworker?",
               "href": "{{ paths.common.tribunalCaseworker }}"
+            }
+          ]
+        },
+        "manageFeeUpdate": {
+          "text": "The fee for this appeal has changed.",
+          "links": [
+            {
+              "title": "What's changed",
+              "text": "Your appeal details",
+              "href": "{{ paths.common.appealDetailsViewer }}"
             }
           ]
         },
@@ -1586,6 +1640,16 @@
             }
           ]
         },
+        "refundAppeal": {
+          "text": "You asked the Tribunal for a fee remission.",
+          "links": [
+            {
+              "title": "What you sent",
+              "text": "Your appeal details",
+              "href": "{{ paths.common.appealDetailsViewer }}"
+            }
+          ]
+        },
         "listCase": {
           "text": "Your hearing was listed.",
           "textForEditListCase": "Your hearing details were updated.",
@@ -1708,6 +1772,16 @@
               ]
             }
           }
+        },
+        "feeRemissionDecision": {
+          "text": "Your request for fee support was decided.",
+          "links": [
+            {
+              "title": "What the Tribunal said",
+              "text": "Your appeal details",
+              "href": "{{ paths.common.appealDetailsViewer }}"
+            }
+          ]
         },
         "markAppealAsRemitted": {
           "Upper Tribunal": {
@@ -2912,7 +2986,6 @@
           "content": [
             "We’re always looking to improve the accessibility of this website. If you find any problems not listed on this page, or think we’re not meeting accessibility requirements, contact:",
             "<ul><li>email <a class=\"govuk-link\" href=\"mailto:contactia@justice.gov.uk\">contactia@justice.gov.uk</a></li><li>call +44 (0) 300 123 1711</li><li>Opening Hours - Monday to Friday, 8:30am to 5pm</li></ul>"
-
           ]
         },
         {
@@ -2942,7 +3015,6 @@
             "This website is partially compliant with the <a class='govuk-link' target='_blank' rel='noopener noreferrer' href='https://www.w3.org/TR/WCAG21/'>Web Content Accessibility Guidelines version 2.1</a> AA standard, due to the non-compliances, listed below."
           ]
         },
-
         {
           "title": "Non-accessible content",
           "content": [
@@ -3763,7 +3835,7 @@
     },
     "remissionOptionPage": {
       "title": "Do you have to pay the fee?",
-      "hint" : "<p>The fee for this appeal is £{{ fee }}. You do not have to pay the fee if one of the following statements applies to you.</p><p>Select one</p>",
+      "hint": "<p>The fee for this appeal is £{{ fee }}. You do not have to pay the fee if one of the following statements applies to you.</p><p>Select one</p>",
       "options": {
         "asylumSupportFromHo": {
           "value": "asylumSupportFromHo",
@@ -3784,13 +3856,23 @@
         "noneOfTheseStatements": {
           "value": "noneOfTheseStatements",
           "text": "None of these statements apply to me",
-          "hint":  "You may still be able to get help to pay the fee"
+          "hint": "You may still be able to get help to pay the fee"
+        },
+        "iWantToGetHelpWithFees": {
+          "value": "iWantToGetHelpWithFees",
+          "text": "I want to get help with fees"
         }
-      }
+      },
+      "refundTitle": "Why are you asking for a fee remission?",
+      "refundParagraph1": "You do not have to pay a fee in certain circumstances. For example, if you get asylum support. This is called a fee remission.",
+      "refundParagraph2": "If you believe you did not have to pay the fee for this appeal, you can ask the Tribunal to give your money back.",
+      "refundParagraph3": "Select the reason you believe you did not have to pay the fee.",
+      "selectOne": "<p>Select one</p>",
+      "noneOfTheseStatements": "None of these statements apply to me"
     },
     "asylumSupportPage": {
       "title": "What is your asylum support reference number?",
-      "legend1": "The Tribunal will check your reference number is valid after your submit your appeal.",
+      "legend1": "The Tribunal will check your reference number is valid after you submit your appeal.",
       "legend2": "If you do not know your reference number, contact <a href=\"https://www.migranthelpuk.org/\" target=\"_blank\">Migrant Help (opens in a new tab)</a> on 0808 8010 503 or <a href='mailto:proofofsupport@migranthelpuk.org' class='govuk-link--no-visited-state govuk-body govuk-!-margin-bottom-3'>proofofsupport@migranthelpuk.org</a>.",
       "attentionNotice": "Your asylum support reference number is not your Home Office reference number",
       "asylumSupportReferenceNumberLabel": "Enter your asylum support reference number",
@@ -3799,7 +3881,8 @@
     "feeWaiverPage": {
       "title": "Home Office fee waiver",
       "legend1": "You do not have to pay the fee for this appeal if you got a fee waiver for the application to the Home Office that you are now appealing.",
-      "legend2": "The Tribunal will check with the Home Office that you had a fee waiver after you submit the appeal."
+      "legend2": "The Tribunal will check with the Home Office that you had a fee waiver after you submit the appeal.",
+      "legendForRefund": "The Tribunal will check with the Home Office that you had a fee waiver."
     },
     "uploadLocalAuthorityLetter": {
       "title": "Upload local authority letter",
@@ -3836,11 +3919,13 @@
         }
       },
       "checkAndSendWantToApply": "I want to apply for help with fees",
-      "checkAndSendWillPayForAppeal": "I want to pay for the appeal now"
+      "checkAndSendWillPayForAppeal": "I want to pay for the appeal now",
+      "refundsNote": "The fee you paid for this appeal is £{{ fee }}. You may be able to get a full or partial refund if you:"
     },
     "stepsToHelpWithFees": {
       "title": "Apply for help with fees",
       "tips": "Follow these steps to submit a help with fees application along with this appeal.",
+      "tipsRefund": "Follow these steps to submit a help with fees application.",
       "bullet1": "Go to <a href=\"https://helpwithcourtfees.service.gov.uk/checklist/\" target=\"_blank\">apply for help with fees (opens in a new tab)</a>",
       "bullet2": "When you are asked to enter a court or tribunal form number, enter IAFT-1",
       "bullet3": "Make a note of the help with fees reference number you get when you complete your help with fees application",
@@ -3852,6 +3937,12 @@
       "paragraph": "You will have received this number when you applied for help with fees. This reference must not have been used for a previous appeal.",
       "helpWithFeesReferenceNumberLabel": "Enter your help with fees reference number",
       "hint": "For example, HWF-A1B-23C"
+    },
+    "feeSupportConfirmationPage": {
+      "title": "You have asked the Tribunal for a fee remission",
+      "whatHappensNext": "What happens next",
+      "bullet1": "A Legal Officer will check the information you sent and let you know if your fee will be refunded",
+      "bullet2": "This should be by <span class='govuk-body govuk-!-font-weight-bold'>{{ date }}</span> but it might take longer than that"
     }
   },
   "error": {

--- a/test/unit/controllers/application-overview.test.ts
+++ b/test/unit/controllers/application-overview.test.ts
@@ -1,10 +1,12 @@
 import { NextFunction, Request, Response } from 'express';
+import { SinonStub } from 'sinon';
 import {
   checkAppealEnded,
   checkEnableProvideMoreEvidenceSection,
   getAppealRefNumber,
   getAppellantName,
-  getApplicationOverview, getHearingDetails,
+  getApplicationOverview,
+  getHearingDetails,
   isAppealInProgress,
   isPostDecisionState,
   setupApplicationOverviewController,
@@ -128,6 +130,7 @@ describe('Confirmation Page Controller', () => {
     sandbox.stub(LaunchDarklyService.prototype, 'getVariation')
       .withArgs(req as Request, FEATURE_FLAGS.MAKE_APPLICATION, false).resolves(true)
       .withArgs(req as Request, FEATURE_FLAGS.FTPA, false).resolves(true)
+      .withArgs(req as Request, FEATURE_FLAGS.DLRM_REFUND_FEATURE_FLAG, false).resolves(true)
       .withArgs(req as Request, FEATURE_FLAGS.UPLOAD_ADDENDUM_EVIDENCE, false).resolves(true);
 
     next = sandbox.stub() as NextFunction;
@@ -143,7 +146,7 @@ describe('Confirmation Page Controller', () => {
     expect(routerGetStub).to.have.been.calledWith(paths.common.overview);
   });
 
-  it('getApplicationOverview should render application-overview.njk with options and IDAM name', async () => {
+  it('getApplicationOverview should render application-overview.njk with options and IDAM name#2', async () => {
     req.idam = {
       userDetails: {
         uid: 'anId',
@@ -201,6 +204,8 @@ describe('Confirmation Page Controller', () => {
       hearingDetails: null,
       showChangeRepresentation: false,
       showFtpaApplicationLink: false,
+      showAskForFeeRemission: false,
+      showAskForSomethingInEndedState: false,
       isPostDecisionState: false
     });
   });
@@ -252,10 +257,26 @@ describe('Confirmation Page Controller', () => {
       completed: true
     }];
 
+    const appNextStep = {
+      decision: 'allowed',
+      descriptionParagraphs: [
+        'A judge has <b> {{ applicationNextStep.decision }} </b> your appeal. <br>',
+        '<p>The Decision and Reasons document includes the reasons the judge made this decision. You should read it carefully.</p><br> <a href={{ paths.common.decisionAndReasonsViewer }}>Read the Decision and Reasons document</a>'
+      ],
+      info: {
+        title: 'Appeal Information',
+        text: 'If you disagree with this decision, you have until <span class="govuk-!-font-weight-bold">{{ applicationNextStep.deadline }}</span> to apply for permission to appeal to the Upper Tribunal.',
+        url: '<a href="{{ paths.ftpa.ftpaApplication }}">Apply for permission to appeal to the Upper Tribunal</a>'
+      },
+      cta: {},
+      allowedAskForMoreTime: false,
+      deadline: '13 March 2024'
+    };
+
     expect(res.render).to.have.been.calledOnce.calledWith('application-overview.njk', {
       name: 'Alex Developer',
       appealRefNumber: 'PA/12345/2025',
-      applicationNextStep: sinon.match.any,
+      applicationNextStep: appNextStep,
       history: expectedHistory,
       stages: expectedStages,
       saved: false,
@@ -273,6 +294,8 @@ describe('Confirmation Page Controller', () => {
       hearingDetails: null,
       showChangeRepresentation: true,
       showFtpaApplicationLink: false,
+      showAskForFeeRemission: false,
+      showAskForSomethingInEndedState: false,
       isPostDecisionState: true
     });
   });
@@ -326,10 +349,26 @@ describe('Confirmation Page Controller', () => {
       completed: true
     }];
 
+    const appNextStep = {
+      decision: 'allowed',
+      descriptionParagraphs: [
+        'A judge has <b> {{ applicationNextStep.decision }} </b> your appeal. <br>',
+        '<p>The Decision and Reasons document includes the reasons the judge made this decision. You should read it carefully.</p><br> <a href={{ paths.common.decisionAndReasonsViewer }}>Read the Decision and Reasons document</a>'
+      ],
+      info: {
+        title: 'Appeal Information',
+        text: 'If you disagree with this decision, you have until <span class="govuk-!-font-weight-bold">{{ applicationNextStep.deadline }}</span> to apply for permission to appeal to the Upper Tribunal.',
+        url: '<a href="{{ paths.ftpa.ftpaApplication }}">Apply for permission to appeal to the Upper Tribunal</a>'
+      },
+      cta: {},
+      allowedAskForMoreTime: false,
+      deadline: '13 March 2024'
+    };
+
     expect(res.render).to.have.been.calledOnce.calledWith('application-overview.njk', {
       name: 'Alex Developer',
       appealRefNumber: 'PA/12345/2025',
-      applicationNextStep: sinon.match.any,
+      applicationNextStep: appNextStep,
       history: expectedHistory,
       stages: expectedStages,
       saved: false,
@@ -342,77 +381,18 @@ describe('Confirmation Page Controller', () => {
       showAppealRequests: true,
       showAppealRequestsInAppealEndedStatus: false,
       showHearingRequests: false,
-      showPayLaterLink: true,
+      showPayLaterLink: false,
       ftpaFeatureEnabled: true,
       hearingDetails: null,
       showChangeRepresentation: true,
       showFtpaApplicationLink: false,
+      showAskForFeeRemission: false,
+      showAskForSomethingInEndedState: false,
       isPostDecisionState: true
     });
   });
 
-  it('getApplicationOverview should render application-overview.njk with options and IDAM name and no events', async () => {
-    req.idam = {
-      userDetails: {
-        uid: 'anId',
-        name: 'Alex Developer',
-        given_name: 'Alex',
-        family_name: 'Developer',
-        sub: 'email@test.com'
-      }
-    };
-    req.session.appeal.appealStatus = 'appealStarted';
-
-    await getApplicationOverview(updateAppealService as UpdateAppealService)(req as Request, res as Response, next);
-
-    const expectedStages = [{
-      title: 'Your appeal<br/> details',
-      ariaLabel: 'Your appeal details stage',
-      active: true,
-      completed: false
-    }, {
-      title: 'Your appeal<br/> argument',
-      ariaLabel: 'Your appeal argument stage',
-      active: false,
-      completed: false
-    }, {
-      title: 'Your hearing<br/> details',
-      ariaLabel: 'Your hearing details stage',
-      active: false,
-      completed: false
-    }, {
-      title: 'Your appeal<br/> decision',
-      ariaLabel: 'Your appeal decision stage',
-      active: false,
-      completed: false
-    }];
-
-    expect(res.render).to.have.been.calledOnce.calledWith('application-overview.njk', {
-      name: 'Alex Developer',
-      appealRefNumber: undefined,
-      applicationNextStep: expectedNextStep,
-      history: expectedHistory,
-      stages: expectedStages,
-      saved: false,
-      ended: false,
-      transferredToUt: false,
-      askForMoreTimeInFlight: false,
-      askForMoreTime: false,
-      saveAndAskForMoreTime: false,
-      provideMoreEvidenceSection: false,
-      showAppealRequests: false,
-      showAppealRequestsInAppealEndedStatus: false,
-      showHearingRequests: false,
-      showPayLaterLink: false,
-      ftpaFeatureEnabled: true,
-      hearingDetails: null,
-      showChangeRepresentation: false,
-      showFtpaApplicationLink: false,
-      isPostDecisionState: false
-    });
-  });
-
-  it('getApplicationOverview should render application-overview.njk with options and IDAM name', async () => {
+  it('getApplicationOverview should render application-overview.njk with options and IDAM name#1', async () => {
     req.idam = {
       userDetails: {
         uid: 'user-id',
@@ -470,6 +450,72 @@ describe('Confirmation Page Controller', () => {
       hearingDetails: null,
       showChangeRepresentation: false,
       showFtpaApplicationLink: false,
+      showAskForFeeRemission: false,
+      showAskForSomethingInEndedState: false,
+      isPostDecisionState: false
+    });
+  });
+
+  it('getApplicationOverview should render application-overview.njk with options and IDAM name and no events', async () => {
+    req.idam = {
+      userDetails: {
+        uid: 'anId',
+        name: 'Alex Developer',
+        given_name: 'Alex',
+        family_name: 'Developer',
+        sub: 'email@test.com'
+      }
+    };
+    req.session.appeal.appealStatus = 'appealStarted';
+    req.session.appeal.appealReferenceNumber = 'appealNumber';
+
+    await getApplicationOverview(updateAppealService as UpdateAppealService)(req as Request, res as Response, next);
+
+    const expectedStages = [{
+      title: 'Your appeal<br/> details',
+      ariaLabel: 'Your appeal details stage',
+      active: true,
+      completed: false
+    }, {
+      title: 'Your appeal<br/> argument',
+      ariaLabel: 'Your appeal argument stage',
+      active: false,
+      completed: false
+    }, {
+      title: 'Your hearing<br/> details',
+      ariaLabel: 'Your hearing details stage',
+      active: false,
+      completed: false
+    }, {
+      title: 'Your appeal<br/> decision',
+      ariaLabel: 'Your appeal decision stage',
+      active: false,
+      completed: false
+    }];
+
+    expect(res.render).to.have.been.calledOnce.calledWith('application-overview.njk', {
+      name: 'Alex Developer',
+      appealRefNumber: 'appealNumber',
+      applicationNextStep: expectedNextStep,
+      history: expectedHistory,
+      stages: expectedStages,
+      saved: false,
+      ended: false,
+      transferredToUt: false,
+      askForMoreTimeInFlight: false,
+      askForMoreTime: false,
+      saveAndAskForMoreTime: false,
+      provideMoreEvidenceSection: false,
+      showAppealRequests: false,
+      showAppealRequestsInAppealEndedStatus: false,
+      showHearingRequests: false,
+      showPayLaterLink: false,
+      ftpaFeatureEnabled: true,
+      hearingDetails: null,
+      showChangeRepresentation: false,
+      showFtpaApplicationLink: false,
+      showAskForFeeRemission: false,
+      showAskForSomethingInEndedState: false,
       isPostDecisionState: false
     });
   });
@@ -545,8 +591,31 @@ describe('Confirmation Page Controller', () => {
       hearingDetails: null,
       showChangeRepresentation: false,
       showFtpaApplicationLink: false,
+      showAskForFeeRemission: false,
+      showAskForSomethingInEndedState: false,
       isPostDecisionState: false
     });
+  });
+
+  it('should render with only showAskForFeeRemission property', async function() {
+    req.idam = {
+      userDetails: {
+        uid: 'user-id',
+        name: 'Alex Developer',
+        given_name: 'Alex',
+        family_name: 'Developer',
+        sub: 'email@test.com'
+      }
+    };
+    req.session.appeal.appealStatus = 'appealStarted';
+    req.session.appeal.application.homeOfficeRefNumber = 'A1234567';
+    req.session.appeal.appealReferenceNumber = 'RP/50004/2020';
+    req.session.appeal.paymentStatus = 'Paid';
+
+    await getApplicationOverview(updateAppealService as UpdateAppealService)(req as Request, res as Response, next);
+
+    expect(res.render).to.have.been.calledOnce;
+    expect(res.render).to.have.been.calledWith('application-overview.njk', sinon.match.has('showAskForFeeRemission', true));
   });
 
   it('getApplicationOverview should render with appealRefNumber application-overview.njk with options and entered name', async () => {
@@ -621,8 +690,37 @@ describe('Confirmation Page Controller', () => {
       hearingDetails: null,
       showChangeRepresentation: false,
       showFtpaApplicationLink: false,
+      showAskForFeeRemission: false,
+      showAskForSomethingInEndedState: false,
       isPostDecisionState: false
     });
+  });
+
+  it('should render showAskForSomethingInEndedState property when the state in ended', async () => {
+    req.idam = {
+      userDetails: {
+        uid: 'user-id',
+        name: 'Alex Developer',
+        given_name: 'Alex',
+        family_name: 'Developer',
+        sub: 'email@test.com'
+      }
+    };
+    req.session.appeal.appealStatus = 'ended';
+    req.session.appeal.application.homeOfficeRefNumber = 'A1234567';
+    req.session.appeal.appealReferenceNumber = 'RP/50004/2020';
+    req.session.appeal.application.personalDetails.givenNames = 'Appellant';
+    req.session.appeal.application.personalDetails.familyName = 'Name';
+    req.session.appeal.hearing = {
+      hearingCentre: 'taylorHouse',
+      date: '2024-04-09T20:30:00.000',
+      time: '240'
+    };
+
+    await getApplicationOverview(updateAppealService as UpdateAppealService)(req as Request, res as Response, next);
+
+    expect(res.render).to.have.been.calledOnce;
+    expect(res.render).to.have.been.calledWith('application-overview.njk', sinon.match.has('showAskForSomethingInEndedState', true));
   });
 
   it('getApplicationOverview should catch an exception and call next()', async () => {
@@ -745,6 +843,11 @@ describe('Confirmation Page Controller', () => {
 
   it('showAppealRequests should return true when in appealSubmitted state', () => {
     const result = showAppealRequestSection(States.APPEAL_SUBMITTED.id, true);
+    expect(result).to.equal(true);
+  });
+
+  it('showAppealRequests should return true when in paymentPending state', () => {
+    const result = showAppealRequestSection(States.PENDING_PAYMENT.id, true);
     expect(result).to.equal(true);
   });
 
@@ -973,5 +1076,89 @@ describe('Confirmation Page Controller', () => {
     };
     const result = showFtpaApplicationLink(appeal, true);
     expect(result).to.equal(true);
+  });
+
+  describe('getApplicationOverview with DLRM refund enabled paymentLink', function () {
+    const tests = [
+      { args: 'approved', expected: false },
+      { args: 'partiallyApproved', expected: false },
+      { args: 'rejected', expected: true }
+    ];
+
+    tests.forEach(({ args, expected }) => {
+      it(`getApplicationOverview with DLRM refund enabled and remissionOption ${args} should render application-overview.njk with option showPayLaterLink ${expected}`, async function () {
+        const recordRemissionEvent = [{
+          'id': 'recordRemissionDecision',
+          'createdDate': '2024-03-07T15:36:26.099'
+        } as HistoryEvent];
+        mockCcdService = {
+          getCaseHistory: sandbox.stub().returns(recordRemissionEvent)
+        } as Partial<CcdService>;
+
+        updateAppealService = {
+          getAuthenticationService: sandbox.stub().returns(mockAuthenticationService),
+          getCcdService: sandbox.stub().returns(mockCcdService)
+        };
+
+        req.session.appeal.appealStatus = 'appealSubmitted';
+        req.session.appeal.application.homeOfficeRefNumber = 'A1234567';
+        req.session.appeal.appealReferenceNumber = 'RP/50004/2020';
+        req.session.appeal.application.personalDetails.givenNames = 'Appellant';
+        req.session.appeal.application.personalDetails.familyName = 'Name';
+        req.session.appeal.application.appealType = 'protection';
+        req.session.appeal.paAppealTypeAipPaymentOption = 'payLater';
+        req.session.appeal.application.remissionOption = 'feeWaiverFromHo';
+        req.session.appeal.application.remissionDecision = args;
+
+        await getApplicationOverview(updateAppealService as UpdateAppealService)(req as Request, res as Response, next);
+
+        const stubRender = res.render as SinonStub;
+        expect(stubRender.getCall(0).args[0]).to.equal('application-overview.njk');
+        expect(stubRender.getCall(0).args[1].showPayLaterLink).to.equal(expected);
+      });
+    });
+  });
+
+  describe('getApplicationOverview with DLRM refund enabled paymentLink and refund confirmation completed', function () {
+    const tests = [
+      { refundConfirmation: false, status: 'Paid', expected: false },
+      { refundConfirmation: true, status: 'Paid', expected: true },
+      { refundConfirmation: false, status: 'Payment pending', expected: true }
+    ];
+
+    tests.forEach(({ refundConfirmation, status, expected }) => {
+      it(`getApplicationOverview with DLRM refund enabled and refundConfirmation is ${refundConfirmation} and paymentStatus is ${status} should render application-overview.njk with option showPayLaterLink ${expected}`, async function () {
+        const recordRemissionEvent = [{
+          'id': 'recordRemissionDecision',
+          'createdDate': '2024-03-07T15:36:26.099'
+        } as HistoryEvent];
+        mockCcdService = {
+          getCaseHistory: sandbox.stub().returns(recordRemissionEvent)
+        } as Partial<CcdService>;
+
+        updateAppealService = {
+          getAuthenticationService: sandbox.stub().returns(mockAuthenticationService),
+          getCcdService: sandbox.stub().returns(mockCcdService)
+        };
+
+        req.session.appeal.appealStatus = 'appealSubmitted';
+        req.session.appeal.application.homeOfficeRefNumber = 'A1234567';
+        req.session.appeal.appealReferenceNumber = 'RP/50004/2020';
+        req.session.appeal.application.personalDetails.givenNames = 'Appellant';
+        req.session.appeal.application.personalDetails.familyName = 'Name';
+        req.session.appeal.application.appealType = 'protection';
+        req.session.appeal.paAppealTypeAipPaymentOption = 'payLater';
+        req.session.appeal.application.remissionOption = 'feeWaiverFromHo';
+        req.session.appeal.application.remissionDecision = 'rejected';
+        req.session.appeal.application.refundConfirmationApplied = refundConfirmation;
+        req.session.appeal.paymentStatus = status;
+
+        await getApplicationOverview(updateAppealService as UpdateAppealService)(req as Request, res as Response, next);
+
+        const stubRender = res.render as SinonStub;
+        expect(stubRender.getCall(0).args[0]).to.equal('application-overview.njk');
+        expect(stubRender.getCall(0).args[1].showPayLaterLink).to.equal(expected);
+      });
+    });
   });
 });

--- a/test/unit/controllers/ask-for-fee-remission/asylum-support-refund.test.ts
+++ b/test/unit/controllers/ask-for-fee-remission/asylum-support-refund.test.ts
@@ -1,0 +1,191 @@
+import express, { NextFunction, Request, Response } from 'express';
+import {
+  getAsylumSupport,
+  postAsylumSupport,
+  setupAsylumSupportRefundController
+} from '../../../../app/controllers/ask-for-fee-remission/asylum-support-refund';
+import { FEATURE_FLAGS } from '../../../../app/data/constants';
+import { paths } from '../../../../app/paths';
+import LaunchDarklyService from '../../../../app/service/launchDarkly-service';
+import Logger from '../../../../app/utils/logger';
+import i18n from '../../../../locale/en.json';
+import { expect, sinon } from '../../../utils/testUtils';
+
+describe('Asylum support refund Controller', function () {
+  let sandbox: sinon.SinonSandbox;
+  let req: Partial<Request>;
+  let res: Partial<Response>;
+  let next: NextFunction;
+  const logger: Logger = new Logger();
+
+  beforeEach(() => {
+    sandbox = sinon.createSandbox();
+    req = {
+      body: {},
+      session: {
+        appeal: {
+          application: {
+            isAppealLate: false
+          }
+        } as Appeal
+      } as Partial<Express.Session>,
+      cookies: {
+        '__auth-token': 'atoken'
+      },
+      idam: {
+        userDetails: {
+          uid: 'idamUID'
+        }
+      },
+      app: {
+        locals: {
+          logger
+        }
+      } as any
+    } as Partial<Request>;
+
+    res = {
+      render: sandbox.stub(),
+      send: sandbox.stub(),
+      redirect: sandbox.spy()
+    } as Partial<Response>;
+
+    next = sandbox.stub() as NextFunction;
+  });
+
+  afterEach(() => {
+    sandbox.restore();
+  });
+
+  describe('setupAsylumSupportRefundController', () => {
+    beforeEach(() => {
+      sandbox.stub(LaunchDarklyService.prototype, 'getVariation')
+        .withArgs(req as Request, FEATURE_FLAGS.DLRM_REFUND_FEATURE_FLAG, false).resolves(true);
+    });
+
+    afterEach(() => {
+      sandbox.restore();
+    });
+
+    it('should setup the routes', () => {
+      const routerGetStub: sinon.SinonStub = sandbox.stub(express.Router as never, 'get');
+      const routerPOSTStub: sinon.SinonStub = sandbox.stub(express.Router as never, 'post');
+      const middleware = [];
+
+      setupAsylumSupportRefundController(middleware);
+      expect(routerGetStub).to.have.been.calledWith(paths.appealSubmitted.asylumSupportRefund);
+      expect(routerPOSTStub).to.have.been.calledWith(paths.appealSubmitted.asylumSupportRefund);
+    });
+
+    it('should render appeal-application/fee-support/asylum-support.njk', async () => {
+      await getAsylumSupport(req as Request, res as Response, next);
+      const asylumSupportRefNumber = null;
+      expect(res.render).to.have.been.calledOnce.calledWith('appeal-application/fee-support/asylum-support.njk', {
+        previousPage: paths.appealSubmitted.feeSupportRefund,
+        formAction: paths.appealSubmitted.asylumSupportRefund,
+        asylumSupportRefNumber,
+        refundJourney: true
+      });
+    });
+
+    it('should validate and redirect CYA page', async () => {
+      req.body['asylumSupportRefNumber'] = '12345';
+      await postAsylumSupport()(req as Request, res as Response, next);
+      expect(req.session.appeal.application.lateAsylumSupportRefNumber).to.be.eql('12345');
+      expect(res.redirect).to.have.been.calledWith(paths.appealSubmitted.checkYourAnswersRefund);
+    });
+
+    it('when in edit mode should validate and redirect check-and-send.njk and reset isEdit flag', async () => {
+      req.body['asylumSupportRefNumber'] = '12345';
+      req.query = { 'edit': '' };
+      await postAsylumSupport()(req as Request, res as Response, next);
+      expect(req.session.appeal.application.lateAsylumSupportRefNumber).to.be.eql('12345');
+      expect(res.redirect).to.have.been.calledWithMatch(new RegExp(`${paths.appealSubmitted.checkYourAnswersRefund}(?!.*\\bedit\\b)`));
+      expect(req.session.appeal.application.isEdit).to.be.undefined;
+    });
+
+    it('when called with edit param should render fee-waiver.njk and update session', async () => {
+      req.query = { 'edit': '' };
+      await getAsylumSupport(req as Request, res as Response, next);
+      expect(req.session.appeal.application.isEdit).to.have.eq(true);
+      expect(res.render).to.have.been.calledOnce.calledWith('appeal-application/fee-support/asylum-support.njk');
+    });
+
+    it('should fail validation and render appeal-application/fee-support/asylum-support.njk with error', async () => {
+      req.body['asylumSupportRefNumber'] = '';
+
+      const error = {
+        key: 'asylumSupportRefNumber',
+        text: 'Enter your asylum support reference number',
+        href: '#asylumSupportRefNumber'
+      };
+      await postAsylumSupport()(req as Request, res as Response, next);
+      expect(res.render).to.have.been.calledWith(
+        'appeal-application/fee-support/asylum-support.njk',
+        {
+          errors: {
+            asylumSupportRefNumber: error
+          },
+          errorList: [error],
+          previousPage: paths.appealSubmitted.asylumSupportRefund,
+          pageTitle: i18n.pages.asylumSupportPage.title,
+          formAction: paths.appealSubmitted.asylumSupportRefund,
+          refundJourney: true
+        });
+    });
+
+    it('should catch exception and call next with the error', async () => {
+      const error = new Error('an error');
+      res.render = sandbox.stub().throws(error);
+      await postAsylumSupport()(req as Request, res as Response, next);
+      expect(next).to.have.been.calledOnce.calledWith(error);
+    });
+
+    it('should reset values from other journeys if it present', async () => {
+      req.body = {
+        'asylumSupportRefNumber': '1324'
+      };
+
+      let application = req.session.appeal.application;
+      application.lateHelpWithFeesOption = 'test value';
+      application.lateHelpWithFeesRefNumber = 'test value';
+      application.lateLocalAuthorityLetters = [];
+
+      await postAsylumSupport()(req as Request, res as Response, next);
+      expect(application.lateHelpWithFeesOption).to.be.null;
+      expect(application.lateHelpWithFeesRefNumber).to.be.null;
+      expect(application.lateLocalAuthorityLetters).to.be.null;
+    });
+  });
+
+  describe('When Flag is switched off expectations', () => {
+    beforeEach(() => {
+      sandbox.stub(LaunchDarklyService.prototype, 'getVariation')
+        .withArgs(req as Request, FEATURE_FLAGS.DLRM_REFUND_FEATURE_FLAG, false).resolves(false);
+    });
+
+    afterEach(() => {
+      sandbox.restore();
+    });
+
+    it('should redirect to overview page when feature flag OFF', async () => {
+      await getAsylumSupport(req as Request, res as Response, next);
+      expect(res.redirect).to.have.been.calledOnce.calledWith(paths.common.overview);
+    });
+
+    it('should redirect to overview page when feature flag OFF', async () => {
+      await postAsylumSupport()(req as Request, res as Response, next);
+      expect(res.redirect).to.have.been.calledOnce.calledWith(paths.common.overview);
+    });
+  });
+
+  describe('Exception when error thrown', () => {
+    it('getAsylumSupport should catch exception and call next with the error', async () => {
+      const error = new Error('an error');
+      sandbox.stub(LaunchDarklyService.prototype, 'getVariation').throws(error);
+      await getAsylumSupport(req as Request, res as Response, next);
+      expect(next).to.have.been.calledOnce.calledWith(error);
+    });
+  });
+
+});

--- a/test/unit/controllers/ask-for-fee-remission/check-your-answers-refund.test.ts
+++ b/test/unit/controllers/ask-for-fee-remission/check-your-answers-refund.test.ts
@@ -1,0 +1,295 @@
+import { NextFunction, Request, Response } from 'express';
+import {
+  createSummaryRowsFrom,
+  getCheckYourAnswersRefund,
+  postCheckYourAnswersRefund,
+  setupCheckYourAnswersRefundController
+} from '../../../../app/controllers/ask-for-fee-remission/check-your-answers-refund';
+
+import { FEATURE_FLAGS } from '../../../../app/data/constants';
+import { Events } from '../../../../app/data/events';
+import { paths } from '../../../../app/paths';
+import LaunchDarklyService from '../../../../app/service/launchDarkly-service';
+import UpdateAppealService from '../../../../app/service/update-appeal-service';
+import Logger from '../../../../app/utils/logger';
+import { addSummaryRow } from '../../../../app/utils/summary-list';
+import i18n from '../../../../locale/en.json';
+import { expect, sinon } from '../../../utils/testUtils';
+
+const express = require('express');
+
+function getMockedSummaryRows(appealType = 'protection'): SummaryRow[] {
+  return [{
+    key: { text: 'In the UK' },
+    value: { html: 'No' },
+    actions: { items: [{ href: '/in-the-uk?edit', text: 'Change' }] }
+  }, {
+    key: { text: 'Appeal type' },
+    value: { html: 'Protection' },
+    actions: { items: [{ href: '/appeal-type?edit', text: 'Change' }] }
+  }, {
+    key: { text: 'What date did you leave the UK after your Protection claim was refused?' },
+    value: { html: '19 February 2022' },
+    actions: { items: [{ href: '/ooc-protection-departure-date?edit', text: 'Change' }] }
+  }, {
+    key: { text: 'Outside UK when application was made' },
+    value: { html: 'No' },
+    actions: { items: [{ href: '/ooc-hr-eea?edit', text: 'Change' }] }
+  }, {
+    key: { text: 'Home Office reference number' },
+    value: { html: 'A1234567' },
+    actions: { items: [{ href: '/home-office-reference-number?edit', text: 'Change' }] }
+  }, {
+    key: { text: 'Date letter received' },
+    value: { html: '16 February 2020' },
+    actions: { items: [{ href: '/date-letter-received?edit', text: 'Change' }] }
+  }, {
+    key: { text: 'Address' },
+    value: { html: '28 The Street, Ukraine, 2378' },
+    actions: { items: [{ href: '/out-of-country-address?edit', text: 'Change' }] }
+  }, {
+    key: { text: 'Contact details' },
+    value: { html: 'pedro.jimenez@example.net<br>07123456789' },
+    actions: { items: [{ href: '/contact-preferences?edit', text: 'Change' }] }
+  }, {
+    key: { text: 'Sponsor' },
+    value: { html: 'Yes' },
+    actions: { items: [{ href: '/has-sponsor?edit', text: 'Change' }] }
+  }, {
+    key: { text: 'Sponsor\'s name' },
+    value: { html: 'Frank Smith' },
+    actions: { items: [{ href: '/sponsor-name?edit', text: 'Change' }] }
+  }, {
+    key: { text: 'Sponsor\'s address' },
+    value: { html: '39 The Street,<br>Ashtead<br>United Kingdom<br>KT21 1AA' },
+    actions: { items: [{ href: '/sponsor-address?edit', text: 'Change' }] }
+  }, {
+    key: { text: 'Sponsor\'s contact details' },
+    value: { html: 'frank.smith@example.net<br>07177777777' },
+    actions: { items: [{ href: '/sponsor-contact-preferences?edit', text: 'Change' }] }
+  }, {
+    key: { text: 'Sponsor has access to information' },
+    value: { html: 'Yes' },
+    actions: { items: [{ href: '/sponsor-authorisation?edit', text: 'Change' }] }
+  }, {
+    key: { text: 'Appeal type' },
+    value: { html: i18n.appealTypes[appealType].name },
+    actions: { items: [{ href: '/appeal-type?edit', text: 'Change' }] }
+  }, {
+    key: { text: 'Home Office decision letter' },
+    value: { html: '<a class=\'govuk-link\' target=\'_blank\' rel=\'noopener noreferrer\' href=\'/view/document/anId\'>name</a>' },
+    actions: { items: [{ href: '/home-office-upload-decision-letter?edit', text: 'Change' }] }
+  }, {
+    key: { text: 'Name' },
+    value: { html: 'Pedro Jimenez' },
+    actions: { items: [{ href: '/name?edit', text: 'Change' }] }
+  }, {
+    key: { text: 'Date of birth' },
+    value: { html: '10 October 1980' },
+    actions: { items: [{ href: '/date-birth?edit', text: 'Change' }] }
+  }, {
+    key: { text: 'Nationality' },
+    value: { html: 'Austria' },
+    actions: { items: [{ href: '/nationality?edit', text: 'Change' }] }
+  }];
+}
+
+describe('CYA Refund Controller', function () {
+  let sandbox: sinon.SinonSandbox;
+  let req: Partial<Request>;
+  let res: Partial<Response>;
+  let updateAppealService: Partial<UpdateAppealService>;
+  let next: NextFunction;
+  const logger: Logger = new Logger();
+
+  beforeEach(() => {
+    sandbox = sinon.createSandbox();
+    req = {
+      body: {},
+      session: {
+        appeal: {
+          application: {
+            isAppealLate: false
+          }
+        }
+      } as Partial<Express.Session>,
+      cookies: {
+        '__auth-token': 'atoken'
+      },
+      idam: {
+        userDetails: {
+          uid: 'idamUID'
+        }
+      },
+      app: {
+        locals: {
+          logger
+        }
+      } as any
+    } as Partial<Request>;
+
+    updateAppealService = {
+      submitEventRefactored: sandbox.stub().returns({
+        state: 'appealSubmitted',
+        case_data: { appealReferenceNumber: 'PA/1234567' }
+      })
+    };
+
+    res = {
+      render: sandbox.stub(),
+      send: sandbox.stub(),
+      redirect: sandbox.spy()
+    } as Partial<Response>;
+
+    next = sandbox.stub() as NextFunction;
+  });
+
+  afterEach(() => {
+    sandbox.restore();
+  });
+
+  describe('setupCheckYourAnswersRefundController', () => {
+    beforeEach(() => {
+      sandbox.stub(LaunchDarklyService.prototype, 'getVariation')
+        .withArgs(req as Request, FEATURE_FLAGS.DLRM_REFUND_FEATURE_FLAG, false).resolves(true);
+    });
+
+    afterEach(() => {
+      sandbox.restore();
+    });
+
+    it('should setup the routes', () => {
+      const routerGetStub: sinon.SinonStub = sandbox.stub(express.Router as never, 'get');
+      const routerPOSTStub: sinon.SinonStub = sandbox.stub(express.Router as never, 'post');
+      const middleware = [];
+
+      setupCheckYourAnswersRefundController(middleware, updateAppealService as UpdateAppealService);
+      expect(routerGetStub).to.have.been.calledWith(paths.appealSubmitted.checkYourAnswersRefund);
+      expect(routerPOSTStub).to.have.been.calledWith(paths.appealSubmitted.checkYourAnswersRefund);
+    });
+
+    it('should render check-and-send.njk', async () => {
+      req.session.appeal.application.lateRemissionOption = 'feeWaiverFromHo';
+      const summaryRows = [{
+        key: { text: 'Fee statement' },
+        value: { html: 'I got a fee waiver from the Home Office for my application to stay in the UK' },
+        actions: {
+          items: [
+            { href: '/fee-support-refund?edit', text: 'Change', 'visuallyHiddenText': 'Fee statement' }
+          ]
+        }
+      }];
+      await getCheckYourAnswersRefund(req as Request, res as Response, next);
+      expect(res.render).to.have.been.calledOnce.calledWith('ask-for-fee-remission/check-and-send.njk', {
+        previousPage: { attributes: { onclick: 'history.go(-1); return false;' } },
+        summaryRows
+      });
+    });
+
+    it('should redirect to confirmation-refund page', async () => {
+      const appeal: Appeal = {
+        ...req.session.appeal,
+        application: {
+          ...req.session.appeal.application,
+          refundRequested: true
+        }
+      };
+
+      await postCheckYourAnswersRefund(updateAppealService as UpdateAppealService)(req as Request, res as Response, next);
+
+      expect(updateAppealService.submitEventRefactored).to.have.been.calledWith(Events.REQUEST_FEE_REMISSION, appeal, 'idamUID', 'atoken');
+      expect(res.redirect).to.have.been.calledWith(paths.appealSubmitted.confirmationRefund);
+    });
+
+    it('should create fee rows when fee support values are present and dlrm-refund set aside enabled', async () => {
+      req.session.appeal.application.lateRemissionOption = 'asylumSupportFromHo';
+      req.session.appeal.application.lateAsylumSupportRefNumber = 'refNumber';
+      req.session.appeal.application.lateHelpWithFeesRefNumber = 'HWF12345';
+      req.session.appeal.application.lateLocalAuthorityLetters = [{ fileId: 'fileId', name: 'filename' }];
+      const editParameter = '?edit';
+      const fileLine = `<a class='govuk-link' target='_blank' rel='noopener noreferrer' href='${paths.common.documentViewer}/fileId'>filename</a>`;
+
+      const rows: any[] = await createSummaryRowsFrom(req as Request);
+      const asylumSupportRefNumberRow = addSummaryRow('Asylum support reference number', ['refNumber'], paths.appealSubmitted.asylumSupportRefund + editParameter);
+      const helpWithFeesRefNumberRow = addSummaryRow('Help with fees reference number', ['HWF12345'], paths.appealSubmitted.helpWithFeesReferenceNumberRefund + editParameter);
+      const localAuthorityLettersRow = addSummaryRow('Local authority letter', [fileLine], paths.appealSubmitted.localAuthorityLetterRefund + editParameter);
+      const mockedRows: SummaryRow[] = getMockedSummaryRows();
+
+      mockedRows.push(asylumSupportRefNumberRow);
+      mockedRows.push(helpWithFeesRefNumberRow);
+      mockedRows.push(localAuthorityLettersRow);
+
+      const helpWithFeesOptionTestData = [
+        {
+          input: 'wantToApply',
+          expectedResponse: 'I want to apply for help with fees'
+        },
+        {
+          input: 'alreadyApplied',
+          expectedResponse: 'I have already applied for help with fees'
+        }
+      ];
+
+      const remissionOptionTestData = [
+        {
+          input: 'asylumSupportFromHo',
+          expectedResponse: 'I get asylum support from the Home Office'
+        },
+        {
+          input: 'feeWaiverFromHo',
+          expectedResponse: 'I got a fee waiver from the Home Office for my application to stay in the UK'
+        },
+        {
+          input: 'under18GetSupportFromLocalAuthority',
+          expectedResponse: 'I am under 18 and get housing or other support from the local authority'
+        },
+        {
+          input: 'parentGetSupportFromLocalAuthority',
+          expectedResponse: 'I am the parent, guardian or sponsor of someone under 18 who gets housing or other support from the local authority'
+        },
+        {
+          input: 'iWantToGetHelpWithFees',
+          expectedResponse: 'None of these statements apply to me'
+        }
+      ];
+
+      helpWithFeesOptionTestData.forEach(({ input, expectedResponse }) => {
+        req.session.appeal.application.lateHelpWithFeesOption = input;
+        const helpWithFeesRow = addSummaryRow('Help with fees', [expectedResponse], paths.appealSubmitted.helpWithFeesRefund + editParameter);
+        mockedRows.push(helpWithFeesRow);
+
+        remissionOptionTestData.forEach(({ input, expectedResponse }) => {
+          it('Should correctly build the rows', () => {
+            req.session.appeal.application.lateRemissionOption = input;
+            const remissionOptionRow = addSummaryRow('Fee statement', [expectedResponse], paths.appealSubmitted.feeSupportRefund + editParameter);
+            mockedRows.push(remissionOptionRow);
+            expect(rows).to.be.deep.equal(mockedRows);
+            mockedRows.pop();
+          });
+        });
+        mockedRows.pop();
+      });
+    });
+  });
+
+  describe('When Flag is switched off expectations', () => {
+    beforeEach(() => {
+      sandbox.stub(LaunchDarklyService.prototype, 'getVariation')
+        .withArgs(req as Request, FEATURE_FLAGS.DLRM_REFUND_FEATURE_FLAG, false).resolves(false);
+    });
+
+    afterEach(() => {
+      sandbox.restore();
+    });
+
+    it('should redirect to overview page when feature flag OFF', async () => {
+      await getCheckYourAnswersRefund(req as Request, res as Response, next);
+      expect(res.redirect).to.have.been.calledOnce.calledWith(paths.common.overview);
+    });
+
+    it('should redirect to overview page when feature flag OFF', async () => {
+      await postCheckYourAnswersRefund(updateAppealService as UpdateAppealService)(req as Request, res as Response, next);
+      expect(res.redirect).to.have.been.calledOnce.calledWith(paths.common.overview);
+    });
+  });
+});

--- a/test/unit/controllers/ask-for-fee-remission/confirmation-page.test.ts
+++ b/test/unit/controllers/ask-for-fee-remission/confirmation-page.test.ts
@@ -1,0 +1,74 @@
+import express, { NextFunction, Request, Response } from 'express';
+import {
+  getConfirmationPage,
+  setConfirmationRefundController
+} from '../../../../app/controllers/ask-for-fee-remission/confirmation-page';
+import { paths } from '../../../../app/paths';
+import { addDaysToDate } from '../../../../app/utils/date-utils';
+import Logger from '../../../../app/utils/logger';
+import { expect, sinon } from '../../../utils/testUtils';
+
+describe('Ask for a refund confirmation page Controller', function () {
+  let sandbox: sinon.SinonSandbox;
+  let req: Partial<Request>;
+  let res: Partial<Response>;
+  let next: NextFunction;
+  const logger: Logger = new Logger();
+
+  beforeEach(() => {
+    sandbox = sinon.createSandbox();
+    req = {
+      body: {},
+      session: {
+        appeal: {
+          application: {
+            isAppealLate: false
+          }
+        }
+      } as Partial<Express.Session>,
+      cookies: {
+        '__auth-token': 'atoken'
+      },
+      idam: {
+        userDetails: {
+          uid: 'idamUID'
+        }
+      },
+      app: {
+        locals: {
+          logger
+        }
+      } as any
+    } as Partial<Request>;
+
+    res = {
+      render: sandbox.stub(),
+      send: sandbox.stub(),
+      redirect: sandbox.spy()
+    } as Partial<Response>;
+
+    next = sandbox.stub() as NextFunction;
+  });
+
+  afterEach(() => {
+    sandbox.restore();
+  });
+  describe('setConfirmationRefundController', () => {
+
+    it('should setup the routes', () => {
+      const routerGetStub: sinon.SinonStub = sandbox.stub(express.Router as never, 'get');
+      const middleware = [];
+
+      setConfirmationRefundController(middleware);
+      expect(routerGetStub).to.have.been.calledWith(paths.appealSubmitted.confirmationRefund);
+    });
+
+    it('getConfirmationPage should render confirmation-page.njk after submission', () => {
+      getConfirmationPage(req as Request, res as Response, next);
+      expect(res.render).to.have.been.calledOnce.calledWith('ask-for-fee-remission/confirmation-page.njk', {
+        date: addDaysToDate(14)
+      });
+    });
+  });
+
+});

--- a/test/unit/controllers/ask-for-fee-remission/fee-support-refund.test.ts
+++ b/test/unit/controllers/ask-for-fee-remission/fee-support-refund.test.ts
@@ -1,0 +1,283 @@
+import { NextFunction, Request, Response } from 'express';
+import {
+  getFeeSupport,
+  getFeeSupportRedirectPage,
+  getOptionsQuestion,
+  postFeeSupport,
+  setupFeeSupportRefundController
+} from '../../../../app/controllers/ask-for-fee-remission/fee-support-refund';
+import { FEATURE_FLAGS } from '../../../../app/data/constants';
+import { paths } from '../../../../app/paths';
+import LaunchDarklyService from '../../../../app/service/launchDarkly-service';
+import Logger from '../../../../app/utils/logger';
+import i18n from '../../../../locale/en.json';
+import { expect, sinon } from '../../../utils/testUtils';
+
+const express = require('express');
+
+describe('Fee support refund Controller', () => {
+  let sandbox: sinon.SinonSandbox;
+  let req: Partial<Request>;
+  let res: Partial<Response>;
+  let next: NextFunction;
+  const logger: Logger = new Logger();
+
+  beforeEach(() => {
+    sandbox = sinon.createSandbox();
+    req = {
+      body: {},
+      session: {
+        appeal: {
+          application: {}
+        }
+      } as Partial<Express.Session>,
+      cookies: {
+        '__auth-token': 'atoken'
+      },
+      idam: {
+        userDetails: {
+          uid: 'idamUID'
+        }
+      },
+      app: {
+        locals: {
+          logger
+        }
+      } as any
+    } as Partial<Request>;
+
+    res = {
+      render: sandbox.stub(),
+      send: sandbox.stub(),
+      redirect: sinon.spy()
+    } as Partial<Response>;
+
+    next = sandbox.stub() as NextFunction;
+  });
+
+  afterEach(() => {
+    sandbox.restore();
+  });
+
+  describe('setupFeeSupportRefundController', () => {
+    beforeEach(() => {
+      sandbox.stub(LaunchDarklyService.prototype, 'getVariation')
+        .withArgs(req as Request, FEATURE_FLAGS.DLRM_REFUND_FEATURE_FLAG, false).resolves(true);
+    });
+
+    afterEach(() => {
+      sandbox.restore();
+    });
+
+    it('should setup the routes', () => {
+      const routerGetStub: sinon.SinonStub = sandbox.stub(express.Router, 'get');
+      const routerPostStub: sinon.SinonStub = sandbox.stub(express.Router, 'post');
+      const middleware = [];
+      setupFeeSupportRefundController(middleware);
+      expect(routerGetStub).to.have.been.calledWith(paths.appealSubmitted.feeSupportRefund);
+      expect(routerPostStub).to.have.been.calledWith(paths.appealSubmitted.feeSupportRefund);
+    });
+
+    it('should return the question', () => {
+      const expectedQuestion = {
+        title: i18n.pages.remissionOptionPage.refundTitle,
+        hint: i18n.pages.remissionOptionPage.selectOne,
+        options: [
+          {
+            value: i18n.pages.remissionOptionPage.options.asylumSupportFromHo.value,
+            text: i18n.pages.remissionOptionPage.options.asylumSupportFromHo.text,
+            checked: false
+          },
+          {
+            value: i18n.pages.remissionOptionPage.options.feeWaiverFromHo.value,
+            text: i18n.pages.remissionOptionPage.options.feeWaiverFromHo.text,
+            checked: false
+          },
+          {
+            value: i18n.pages.remissionOptionPage.options.under18GetSupportFromLocalAuthority.value,
+            text: i18n.pages.remissionOptionPage.options.under18GetSupportFromLocalAuthority.text,
+            checked: false
+          },
+          {
+            value: i18n.pages.remissionOptionPage.options.parentGetSupportFromLocalAuthority.value,
+            text: i18n.pages.remissionOptionPage.options.parentGetSupportFromLocalAuthority.text,
+            checked: false
+          },
+          {
+            value: i18n.pages.remissionOptionPage.options.iWantToGetHelpWithFees.value,
+            text: i18n.pages.remissionOptionPage.options.iWantToGetHelpWithFees.text,
+            checked: false
+          }
+        ],
+        inline: false
+      };
+      req.session.appeal.application.appealType = 'protection';
+      const question = getOptionsQuestion(req.session.appeal);
+
+      expect(question).to.be.eql(expectedQuestion);
+    });
+
+    it('should return the question with option checked', () => {
+      const expectedQuestion = {
+        title: i18n.pages.remissionOptionPage.refundTitle,
+        hint: i18n.pages.remissionOptionPage.selectOne,
+        options: [
+          {
+            value: i18n.pages.remissionOptionPage.options.asylumSupportFromHo.value,
+            text: i18n.pages.remissionOptionPage.options.asylumSupportFromHo.text,
+            checked: true
+          },
+          {
+            value: i18n.pages.remissionOptionPage.options.feeWaiverFromHo.value,
+            text: i18n.pages.remissionOptionPage.options.feeWaiverFromHo.text,
+            checked: false
+          },
+          {
+            value: i18n.pages.remissionOptionPage.options.under18GetSupportFromLocalAuthority.value,
+            text: i18n.pages.remissionOptionPage.options.under18GetSupportFromLocalAuthority.text,
+            checked: false
+          },
+          {
+            value: i18n.pages.remissionOptionPage.options.parentGetSupportFromLocalAuthority.value,
+            text: i18n.pages.remissionOptionPage.options.parentGetSupportFromLocalAuthority.text,
+            checked: false
+          },
+          {
+            value: i18n.pages.remissionOptionPage.options.iWantToGetHelpWithFees.value,
+            text: i18n.pages.remissionOptionPage.options.iWantToGetHelpWithFees.text,
+            checked: false
+          }
+        ],
+        inline: false
+      };
+      req.session.appeal.application.lateRemissionOption = 'asylumSupportFromHo';
+      const question = getOptionsQuestion(req.session.appeal);
+
+      expect(question).to.be.eql(expectedQuestion);
+    });
+
+    it('should render fee-support.njk template', async () => {
+      await getFeeSupport(req as Request, res as Response, next);
+
+      expect(res.render).to.have.been.calledOnce.calledWith('ask-for-fee-remission/fee-support-refund.njk', {
+        previousPage: paths.common.overview,
+        pageTitle: i18n.pages.remissionOptionPage.refundTitle,
+        formAction: paths.appealSubmitted.feeSupportRefund,
+        question: sinon.match.any
+      });
+    });
+
+    it('should redirect to the asylum support page', async () => {
+      req.body['answer'] = 'asylumSupportFromHo';
+      req.session.appeal.application.appealType = 'protection';
+      await postFeeSupport()(req as Request, res as Response, next);
+      expect(res.redirect).to.have.been.calledOnce.calledWith(paths.appealSubmitted.asylumSupportRefund);
+    });
+
+    it('when in edit mode should validate and redirect asylum-support-refund.njk and reset isEdit flag', async () => {
+      req.body['answer'] = 'asylumSupportFromHo';
+      req.query = { 'edit': '' };
+      await postFeeSupport()(req as Request, res as Response, next);
+      expect(req.session.appeal.application.lateRemissionOption).to.be.eql('asylumSupportFromHo');
+      expect(res.redirect).to.have.been.calledWithMatch(new RegExp(`${paths.appealSubmitted.asylumSupportRefund}(?!.*\\bedit\\b)`));
+      expect(req.session.appeal.application.isEdit).to.be.undefined;
+    });
+
+    it('when called with edit param should render fee-support-refund.njk and update session', async () => {
+      req.query = { 'edit': '' };
+      await getFeeSupport(req as Request, res as Response, next);
+      expect(req.session.appeal.application.isEdit).to.have.eq(true);
+      expect(res.render).to.have.been.calledOnce.calledWith('ask-for-fee-remission/fee-support-refund.njk');
+    });
+
+    it('should redirect to correct path according to the fee support selected value', async () => {
+      const testData = [
+        {
+          input: 'asylumSupportFromHo',
+          expected: paths.appealSubmitted.asylumSupportRefund,
+          description: 'Asylum support page'
+        },
+        {
+          input: 'feeWaiverFromHo',
+          expected: paths.appealSubmitted.feeWaiverRefund,
+          description: 'Fee waiver page'
+        },
+        {
+          input: 'under18GetSupportFromLocalAuthority',
+          expected: paths.appealSubmitted.localAuthorityLetterRefund,
+          description: 'Upload local authority letter page'
+        },
+        {
+          input: 'parentGetSupportFromLocalAuthority',
+          expected: paths.appealSubmitted.localAuthorityLetterRefund,
+          description: 'Upload local authority letter page'
+        },
+        {
+          input: 'iWantToGetHelpWithFees',
+          expected: paths.appealSubmitted.helpWithFeesRefund,
+          description: 'Help with fees page'
+        }
+      ];
+
+      testData.forEach(({ input, expected, description }) => {
+        it(`should be ${description}`, () => {
+          const result = getFeeSupportRedirectPage(input);
+          expect(result).to.deep.equal(expected);
+        });
+      });
+    });
+
+    it('should fail validation and render appeal-application/fee-support/fee-support.njk', async () => {
+      const error = {
+        key: 'answer',
+        text: 'Select the statement that applies to you',
+        href: '#answer'
+      };
+
+      await postFeeSupport()(req as Request, res as Response, next);
+      expect(res.render).to.have.been.calledOnce.calledWith(
+        'ask-for-fee-remission/fee-support-refund.njk',
+        {
+          errors: {
+            answer: error
+          },
+          errorList: [error],
+          previousPage: paths.common.overview,
+          pageTitle: i18n.pages.remissionOptionPage.refundTitle,
+          formAction: paths.appealSubmitted.feeSupportRefund,
+          question: sinon.match.any
+        });
+    });
+  });
+
+  describe('When Flag is switched off expectations', () => {
+    beforeEach(() => {
+      sandbox.stub(LaunchDarklyService.prototype, 'getVariation')
+        .withArgs(req as Request, FEATURE_FLAGS.DLRM_REFUND_FEATURE_FLAG, false).resolves(false);
+    });
+
+    afterEach(() => {
+      sandbox.restore();
+    });
+
+    it('should redirect to overview page when feature flag OFF', async () => {
+      await postFeeSupport()(req as Request, res as Response, next);
+      expect(res.redirect).to.have.been.calledOnce.calledWith(paths.common.overview);
+    });
+
+    it('should redirect to overview page when feature flag OFF', async () => {
+      await getFeeSupport(req as Request, res as Response, next);
+      expect(res.redirect).to.have.been.calledOnce.calledWith(paths.common.overview);
+    });
+  });
+
+  describe('Exception when error thrown', () => {
+    it('getFeeSupport should catch exception and call next with the error', async () => {
+      const error = new Error('an error');
+      sandbox.stub(LaunchDarklyService.prototype, 'getVariation').throws(error);
+      await getFeeSupport(req as Request, res as Response, next);
+      expect(next).to.have.been.calledOnce.calledWith(error);
+    });
+  });
+
+});

--- a/test/unit/controllers/ask-for-fee-remission/fee-waiver-refund.test.ts
+++ b/test/unit/controllers/ask-for-fee-remission/fee-waiver-refund.test.ts
@@ -1,0 +1,151 @@
+import express, { NextFunction, Request, Response } from 'express';
+import {
+  getFeeWaiver,
+  postFeeWaiver,
+  setupFeeWaiverRefundController
+} from '../../../../app/controllers/ask-for-fee-remission/fee-waiver-refund';
+
+import { FEATURE_FLAGS } from '../../../../app/data/constants';
+import { paths } from '../../../../app/paths';
+import LaunchDarklyService from '../../../../app/service/launchDarkly-service';
+import Logger from '../../../../app/utils/logger';
+import { expect, sinon } from '../../../utils/testUtils';
+
+describe('Fee waiver Refund Controller', function () {
+  let sandbox: sinon.SinonSandbox;
+  let req: Partial<Request>;
+  let res: Partial<Response>;
+  let next: NextFunction;
+  const logger: Logger = new Logger();
+
+  beforeEach(() => {
+    sandbox = sinon.createSandbox();
+    req = {
+      body: {},
+      session: {
+        appeal: {
+          application: {
+            isAppealLate: false
+          }
+        }
+      } as Partial<Express.Session>,
+      cookies: {
+        '__auth-token': 'atoken'
+      },
+      idam: {
+        userDetails: {
+          uid: 'idamUID'
+        }
+      },
+      app: {
+        locals: {
+          logger
+        }
+      } as any
+    } as Partial<Request>;
+
+    res = {
+      render: sandbox.stub(),
+      send: sandbox.stub(),
+      redirect: sandbox.spy()
+    } as Partial<Response>;
+
+    next = sandbox.stub() as NextFunction;
+  });
+
+  afterEach(() => {
+    sandbox.restore();
+  });
+  describe('setupFeeWaiverController', () => {
+    beforeEach(() => {
+      sandbox.stub(LaunchDarklyService.prototype, 'getVariation')
+        .withArgs(req as Request, FEATURE_FLAGS.DLRM_REFUND_FEATURE_FLAG, false).resolves(true);
+    });
+
+    afterEach(() => {
+      sandbox.restore();
+    });
+
+    it('should setup the routes', () => {
+      const routerGetStub: sinon.SinonStub = sandbox.stub(express.Router as never, 'get');
+      const routerPOSTStub: sinon.SinonStub = sandbox.stub(express.Router as never, 'post');
+      const middleware = [];
+
+      setupFeeWaiverRefundController(middleware);
+      expect(routerGetStub).to.have.been.calledWith(paths.appealSubmitted.feeWaiverRefund);
+      expect(routerPOSTStub).to.have.been.calledWith(paths.appealSubmitted.feeWaiverRefund);
+    });
+
+    it('should render fee-waiver.njk', async () => {
+      await getFeeWaiver(req as Request, res as Response, next);
+      expect(res.render).to.have.been.calledOnce.calledWith('appeal-application/fee-support/fee-waiver.njk', {
+        previousPage: paths.appealSubmitted.feeSupportRefund,
+        refundJourney: true
+      });
+    });
+
+    it('should redirect CYA page', async () => {
+      await postFeeWaiver()(req as Request, res as Response, next);
+      expect(res.redirect).to.have.been.calledWith(paths.appealSubmitted.checkYourAnswersRefund);
+    });
+
+    it('when in edit mode should redirect check-and-send.njk and reset isEdit flag', async () => {
+      req.query = { 'edit': '' };
+      await postFeeWaiver()(req as Request, res as Response, next);
+      expect(res.redirect).to.have.been.calledWithMatch(new RegExp(`${paths.appealSubmitted.checkYourAnswersRefund}(?!.*\\bedit\\b)`));
+      expect(req.session.appeal.application.isEdit).to.be.undefined;
+    });
+
+    it('when called with edit param should render fee-waiver.njk and update session', async () => {
+      req.query = { 'edit': '' };
+      await getFeeWaiver(req as Request, res as Response, next);
+      expect(req.session.appeal.application.isEdit).to.have.eq(true);
+      expect(res.render).to.have.been.calledOnce.calledWith('appeal-application/fee-support/fee-waiver.njk');
+    });
+
+    it('should reset values from other journeys if it present', async () => {
+      let application = req.session.appeal.application;
+      application.lateRemissionOption = 'test value';
+      application.lateAsylumSupportRefNumber = 'test value';
+      application.lateHelpWithFeesOption = 'test value';
+      application.lateHelpWithFeesRefNumber = 'test value';
+      application.lateLocalAuthorityLetters = [];
+
+      await postFeeWaiver()(req as Request, res as Response, next);
+      expect(application.lateRemissionOption).to.be.eq('test value');
+      expect(application.lateHelpWithFeesOption).to.be.null;
+      expect(application.lateHelpWithFeesRefNumber).to.be.null;
+      expect(application.lateLocalAuthorityLetters).to.be.null;
+    });
+  });
+
+  describe('When Flag is switched off expectations', () => {
+    beforeEach(() => {
+      sandbox.stub(LaunchDarklyService.prototype, 'getVariation')
+        .withArgs(req as Request, FEATURE_FLAGS.DLRM_REFUND_FEATURE_FLAG, false).resolves(false);
+    });
+
+    afterEach(() => {
+      sandbox.restore();
+    });
+
+    it('should redirect to overview page when feature flag OFF', async () => {
+      await getFeeWaiver(req as Request, res as Response, next);
+      expect(res.redirect).to.have.been.calledOnce.calledWith(paths.common.overview);
+    });
+
+    it('should redirect to overview page when feature flag OFF', async () => {
+      await postFeeWaiver()(req as Request, res as Response, next);
+      expect(res.redirect).to.have.been.calledOnce.calledWith(paths.common.overview);
+    });
+  });
+
+  describe('Exception when error thrown', () => {
+    it('getFeeWaiver should catch exception and call next with the error', async () => {
+      const error = new Error('an error');
+      sandbox.stub(LaunchDarklyService.prototype, 'getVariation').throws(error);
+      await getFeeWaiver(req as Request, res as Response, next);
+      expect(next).to.have.been.calledOnce.calledWith(error);
+    });
+  });
+});

--- a/test/unit/controllers/ask-for-fee-remission/help-with-fees-reference-number-refund.test.ts
+++ b/test/unit/controllers/ask-for-fee-remission/help-with-fees-reference-number-refund.test.ts
@@ -1,0 +1,213 @@
+import express, { NextFunction, Request, Response } from 'express';
+import {
+  getHelpWithFeesRefNumber,
+  postHelpWithFeesRefNumber,
+  setupHelpWithFeesReferenceNumberRefundController
+} from '../../../../app/controllers/ask-for-fee-remission/help-with-fees-reference-number-refund';
+import { FEATURE_FLAGS } from '../../../../app/data/constants';
+import { paths } from '../../../../app/paths';
+import LaunchDarklyService from '../../../../app/service/launchDarkly-service';
+import Logger from '../../../../app/utils/logger';
+import i18n from '../../../../locale/en.json';
+import { expect, sinon } from '../../../utils/testUtils';
+
+describe('Help with fees reference number refund Controller', function () {
+  let sandbox: sinon.SinonSandbox;
+  let req: Partial<Request>;
+  let res: Partial<Response>;
+  let next: NextFunction;
+  const logger: Logger = new Logger();
+
+  beforeEach(() => {
+    sandbox = sinon.createSandbox();
+    req = {
+      body: {},
+      session: {
+        appeal: {
+          application: {
+            isAppealLate: false
+          }
+        } as Appeal
+      } as Partial<Express.Session>,
+      cookies: {
+        '__auth-token': 'atoken'
+      },
+      idam: {
+        userDetails: {
+          uid: 'idamUID'
+        }
+      },
+      app: {
+        locals: {
+          logger
+        }
+      } as any
+    } as Partial<Request>;
+
+    res = {
+      render: sandbox.stub(),
+      send: sandbox.stub(),
+      redirect: sandbox.spy()
+    } as Partial<Response>;
+
+    next = sandbox.stub() as NextFunction;
+  });
+
+  afterEach(() => {
+    sandbox.restore();
+  });
+
+  describe('setupHelpWithFeesReferenceNumberRefundController', () => {
+    beforeEach(() => {
+      sandbox.stub(LaunchDarklyService.prototype, 'getVariation')
+        .withArgs(req as Request, FEATURE_FLAGS.DLRM_REFUND_FEATURE_FLAG, false).resolves(true);
+    });
+
+    afterEach(() => {
+      sandbox.restore();
+    });
+
+    it('should setup the routes', () => {
+      const routerGetStub: sinon.SinonStub = sandbox.stub(express.Router as never, 'get');
+      const routerPOSTStub: sinon.SinonStub = sandbox.stub(express.Router as never, 'post');
+      const middleware = [];
+
+      setupHelpWithFeesReferenceNumberRefundController(middleware);
+      expect(routerGetStub).to.have.been.calledWith(paths.appealSubmitted.helpWithFeesReferenceNumberRefund);
+      expect(routerPOSTStub).to.have.been.calledWith(paths.appealSubmitted.helpWithFeesReferenceNumberRefund);
+    });
+
+    it('should render appeal-application/fee-support/help-with-fees-reference-number.njk', async () => {
+      await getHelpWithFeesRefNumber(req as Request, res as Response, next);
+      const helpWithFeesReferenceNumber = null;
+      expect(res.render).to.have.been.calledOnce.calledWith('appeal-application/fee-support/help-with-fees-reference-number.njk', {
+        previousPage: { attributes: { onclick: 'history.go(-1); return false;' } },
+        formAction: paths.appealSubmitted.helpWithFeesReferenceNumberRefund,
+        helpWithFeesReferenceNumber,
+        refundJourney: true,
+        errors: null
+      });
+    });
+
+    it('should validate and redirect to CYA page', async () => {
+      req.body['helpWithFeesRefNumber'] = 'HWF-111';
+      await postHelpWithFeesRefNumber()(req as Request, res as Response, next);
+      expect(req.session.appeal.application.lateHelpWithFeesRefNumber).to.be.eql('HWF-111');
+      expect(res.redirect).to.have.been.calledWith(paths.appealSubmitted.checkYourAnswersRefund);
+    });
+
+    it('when in edit mode should validate and redirect check-and-send.njk and reset isEdit flag', async () => {
+      req.body['helpWithFeesRefNumber'] = 'HWF-111';
+      req.query = { 'edit': '' };
+      await postHelpWithFeesRefNumber()(req as Request, res as Response, next);
+      expect(req.session.appeal.application.lateHelpWithFeesRefNumber).to.be.eql('HWF-111');
+      expect(res.redirect).to.have.been.calledWithMatch(new RegExp(`${paths.appealSubmitted.checkYourAnswersRefund}(?!.*\\bedit\\b)`));
+      expect(req.session.appeal.application.isEdit).to.be.undefined;
+    });
+
+    it('when called with edit param should render fee-waiver.njk and update session', async () => {
+      req.query = { 'edit': '' };
+      await getHelpWithFeesRefNumber(req as Request, res as Response, next);
+      expect(req.session.appeal.application.isEdit).to.have.eq(true);
+      expect(res.render).to.have.been.calledOnce.calledWith('appeal-application/fee-support/help-with-fees-reference-number.njk');
+    });
+
+    it('should fail validation if value is empty and render appeal-application/fee-support/help-with-fees-reference-number.njk with error', async () => {
+      req.body['helpWithFeesRefNumber'] = '';
+
+      const error = {
+        key: 'helpWithFeesRefNumber',
+        text: 'Enter your Help with Fees reference number',
+        href: '#helpWithFeesRefNumber'
+      };
+      await postHelpWithFeesRefNumber()(req as Request, res as Response, next);
+      expect(res.render).to.have.been.calledWith(
+        'appeal-application/fee-support/help-with-fees-reference-number.njk',
+        {
+          errors: {
+            helpWithFeesRefNumber: error
+          },
+          errorList: [error],
+          previousPage: paths.appealSubmitted.helpWithFeesReferenceNumberRefund,
+          pageTitle: i18n.pages.helpWithFeesReference.title,
+          formAction: paths.appealSubmitted.helpWithFeesReferenceNumberRefund,
+          refundJourney: true
+        });
+    });
+
+    it('should fail validation if value doesnt match the regex and render appeal-application/fee-support/help-with-fees-reference-number.njk with error', async () => {
+      req.body['helpWithFeesRefNumber'] = '123';
+
+      const error = {
+        key: 'helpWithFeesRefNumber',
+        text: 'Your Help with Fees reference number must start with HWF, like HWF-A1B-23C',
+        href: '#helpWithFeesRefNumber'
+      };
+      await postHelpWithFeesRefNumber()(req as Request, res as Response, next);
+      expect(res.render).to.have.been.calledWith(
+        'appeal-application/fee-support/help-with-fees-reference-number.njk',
+        {
+          errors: {
+            helpWithFeesRefNumber: error
+          },
+          errorList: [error],
+          previousPage: paths.appealSubmitted.helpWithFeesReferenceNumberRefund,
+          pageTitle: i18n.pages.helpWithFeesReference.title,
+          formAction: paths.appealSubmitted.helpWithFeesReferenceNumberRefund,
+          refundJourney: true
+        });
+    });
+
+    it('should catch exception and call next with the error', async () => {
+      const error = new Error('an error');
+      res.render = sandbox.stub().throws(error);
+      await postHelpWithFeesRefNumber()(req as Request, res as Response, next);
+      expect(next).to.have.been.calledOnce.calledWith(error);
+    });
+
+    it('should reset values from other journeys if it present', async () => {
+      req.body = {
+        'helpWithFeesRefNumber': 'HWF-1324'
+      };
+
+      let application = req.session.appeal.application;
+      application.lateAsylumSupportRefNumber = 'test value';
+      application.lateLocalAuthorityLetters = [];
+
+      await postHelpWithFeesRefNumber()(req as Request, res as Response, next);
+      expect(application.lateAsylumSupportRefNumber).to.be.null;
+      expect(application.lateLocalAuthorityLetters).to.be.null;
+    });
+  });
+
+  describe('When Flag is switched off expectations', () => {
+    beforeEach(() => {
+      sandbox.stub(LaunchDarklyService.prototype, 'getVariation')
+        .withArgs(req as Request, FEATURE_FLAGS.DLRM_REFUND_FEATURE_FLAG, false).resolves(false);
+    });
+
+    afterEach(() => {
+      sandbox.restore();
+    });
+
+    it('should redirect to overview page when feature flag OFF', async () => {
+      await getHelpWithFeesRefNumber(req as Request, res as Response, next);
+      expect(res.redirect).to.have.been.calledOnce.calledWith(paths.common.overview);
+    });
+
+    it('should redirect to overview page when feature flag OFF', async () => {
+      await postHelpWithFeesRefNumber()(req as Request, res as Response, next);
+      expect(res.redirect).to.have.been.calledOnce.calledWith(paths.common.overview);
+    });
+  });
+
+  describe('Exception when error thrown', () => {
+    it('getHelpWithFeesRefNumber should catch exception and call next with the error', async () => {
+      const error = new Error('an error');
+      sandbox.stub(LaunchDarklyService.prototype, 'getVariation').throws(error);
+      await getHelpWithFeesRefNumber(req as Request, res as Response, next);
+      expect(next).to.have.been.calledOnce.calledWith(error);
+    });
+  });
+
+});

--- a/test/unit/controllers/ask-for-fee-remission/help-with-fees-refund.test.ts
+++ b/test/unit/controllers/ask-for-fee-remission/help-with-fees-refund.test.ts
@@ -1,0 +1,244 @@
+import { NextFunction, Request, Response } from 'express';
+import {
+  getApplyOption,
+  getHelpWithFees,
+  getHelpWithFeesRedirectPage,
+  postHelpWithFees,
+  setupHelpWithFeesRefundController
+} from '../../../../app/controllers/ask-for-fee-remission/help-with-fees-refund';
+import { FEATURE_FLAGS } from '../../../../app/data/constants';
+import { paths } from '../../../../app/paths';
+import LaunchDarklyService from '../../../../app/service/launchDarkly-service';
+import Logger from '../../../../app/utils/logger';
+import i18n from '../../../../locale/en.json';
+import { expect, sinon } from '../../../utils/testUtils';
+
+const express = require('express');
+
+describe('Help with fees refund Controller', () => {
+  let sandbox: sinon.SinonSandbox;
+  let req: Partial<Request>;
+  let res: Partial<Response>;
+  let next: NextFunction;
+  const logger: Logger = new Logger();
+
+  beforeEach(() => {
+    sandbox = sinon.createSandbox();
+    req = {
+      body: {},
+      session: {
+        appeal: {
+          application: {}
+        }
+      } as Partial<Express.Session>,
+      cookies: {
+        '__auth-token': 'atoken'
+      },
+      idam: {
+        userDetails: {
+          uid: 'idamUID'
+        }
+      },
+      app: {
+        locals: {
+          logger
+        }
+      } as any
+    } as Partial<Request>;
+
+    res = {
+      render: sandbox.stub(),
+      send: sandbox.stub(),
+      redirect: sinon.spy()
+    } as Partial<Response>;
+
+    next = sandbox.stub() as NextFunction;
+  });
+
+  afterEach(() => {
+    sandbox.restore();
+  });
+
+  describe('setupHelpWithFeesRefundController', () => {
+    beforeEach(() => {
+      sandbox.stub(LaunchDarklyService.prototype, 'getVariation')
+        .withArgs(req as Request, FEATURE_FLAGS.DLRM_REFUND_FEATURE_FLAG, false).resolves(true);
+      req.session.appeal.feeWithHearing = '140';
+      req.session.appeal.application.decisionHearingFeeOption = 'decisionWithHearing';
+    });
+
+    afterEach(() => {
+      sandbox.restore();
+    });
+
+    it('should setup the routes', () => {
+      const routerGetStub: sinon.SinonStub = sandbox.stub(express.Router, 'get');
+      const routerPostStub: sinon.SinonStub = sandbox.stub(express.Router, 'post');
+      const middleware = [];
+      setupHelpWithFeesRefundController(middleware);
+      expect(routerGetStub).to.have.been.calledWith(paths.appealSubmitted.helpWithFeesRefund);
+      expect(routerPostStub).to.have.been.calledWith(paths.appealSubmitted.helpWithFeesRefund);
+    });
+
+    it('should return the question', () => {
+      const expectedQuestion = {
+        title: i18n.pages.helpWithFees.radioButtonsTitle,
+        helpWithFeesHint: i18n.pages.helpWithFees.refundsNote.replace('{{ fee }}', '140'),
+        options: [
+          {
+            value: i18n.pages.helpWithFees.options.wantToApply.value,
+            text: i18n.pages.helpWithFees.options.wantToApply.text,
+            checked: false
+          },
+          {
+            value: i18n.pages.helpWithFees.options.alreadyApplied.value,
+            text: i18n.pages.helpWithFees.options.alreadyApplied.text,
+            checked: false
+          }
+        ],
+        inline: false
+      };
+      req.session.appeal.application.appealType = 'protection';
+      const question = getApplyOption(req.session.appeal);
+
+      expect(question).to.be.eql(expectedQuestion);
+    });
+
+    it('should return the question with option checked', () => {
+      const expectedQuestion = {
+        title: i18n.pages.helpWithFees.radioButtonsTitle,
+        helpWithFeesHint: i18n.pages.helpWithFees.refundsNote.replace('{{ fee }}', '140'),
+        options: [
+          {
+            value: i18n.pages.helpWithFees.options.wantToApply.value,
+            text: i18n.pages.helpWithFees.options.wantToApply.text,
+            checked: true
+          },
+          {
+            value: i18n.pages.helpWithFees.options.alreadyApplied.value,
+            text: i18n.pages.helpWithFees.options.alreadyApplied.text,
+            checked: false
+          }
+        ],
+        inline: false
+      };
+      req.session.appeal.application.appealType = 'protection';
+      req.session.appeal.application.lateHelpWithFeesOption = 'wantToApply';
+      const question = getApplyOption(req.session.appeal);
+
+      expect(question).to.be.eql(expectedQuestion);
+    });
+
+    it('should render help-with-fees.njk template', async () => {
+      await getHelpWithFees(req as Request, res as Response, next);
+
+      expect(res.render).to.have.been.calledOnce.calledWith('appeal-application/fee-support/help-with-fees.njk', {
+        previousPage: paths.appealSubmitted.feeSupportRefund,
+        formAction: paths.appealSubmitted.helpWithFeesRefund,
+        question: sinon.match.any,
+        continueCancelButtons: true,
+        refundJourney: true
+      });
+    });
+
+    it('should redirect to the steps to apply for help with fees page', async () => {
+      req.body['answer'] = 'wantToApply';
+      req.session.appeal.application.appealType = 'protection';
+      await postHelpWithFees()(req as Request, res as Response, next);
+      expect(res.redirect).to.have.been.calledOnce.calledWith(paths.appealSubmitted.stepsToApplyForHelpWithFeesRefund);
+    });
+
+    it('when in edit mode should validate and redirect asylum-support-refund.njk and reset isEdit flag', async () => {
+      req.body['answer'] = 'wantToApply';
+      req.query = { 'edit': '' };
+      await postHelpWithFees()(req as Request, res as Response, next);
+      expect(req.session.appeal.application.lateHelpWithFeesOption).to.be.eql('wantToApply');
+      expect(res.redirect).to.have.been.calledWithMatch(new RegExp(`${paths.appealSubmitted.stepsToApplyForHelpWithFeesRefund}(?!.*\\bedit\\b)`));
+      expect(req.session.appeal.application.isEdit).to.be.undefined;
+    });
+
+    it('when called with edit param should render help-with-fees.njk and update session', async () => {
+      req.query = { 'edit': '' };
+      await getHelpWithFees(req as Request, res as Response, next);
+      expect(req.session.appeal.application.isEdit).to.have.eq(true);
+      expect(res.render).to.have.been.calledOnce.calledWith('appeal-application/fee-support/help-with-fees.njk');
+    });
+
+    it('should redirect to correct path according to the help with fees selected value', async () => {
+      const testData = [
+        {
+          input: 'wantToApply',
+          expected: paths.appealSubmitted.stepsToApplyForHelpWithFeesRefund,
+          description: 'Steps to apply for help with fees refund page'
+        },
+        {
+          input: 'alreadyApplied',
+          expected: paths.appealSubmitted.helpWithFeesReferenceNumberRefund,
+          description: 'Help with fees reference number page'
+        }
+      ];
+
+      testData.forEach(({ input, expected, description }) => {
+        it(`should be ${description}`, () => {
+          const result = getHelpWithFeesRedirectPage(input);
+          expect(result).to.deep.equal(expected);
+        });
+      });
+    });
+
+    it('should fail validation and render appeal-application/fee-support/help-with-fees.njk', async () => {
+      const error = {
+        key: 'answer',
+        text: i18n.validationErrors.helpWithFees,
+        href: '#answer'
+      };
+
+      await postHelpWithFees()(req as Request, res as Response, next);
+      expect(res.render).to.have.been.calledOnce.calledWith(
+        'appeal-application/fee-support/help-with-fees.njk',
+        {
+          errors: {
+            answer: error
+          },
+          errorList: [error],
+          previousPage: paths.appealSubmitted.feeSupportRefund,
+          pageTitle: i18n.pages.helpWithFees.title,
+          question: getApplyOption(req.session.appeal),
+          formAction: paths.appealSubmitted.helpWithFeesRefund,
+          continueCancelButtons: true,
+          refundJourney: true
+        });
+    });
+  });
+
+  describe('When Flag is switched off expectations', () => {
+    beforeEach(() => {
+      sandbox.stub(LaunchDarklyService.prototype, 'getVariation')
+        .withArgs(req as Request, FEATURE_FLAGS.DLRM_REFUND_FEATURE_FLAG, false).resolves(false);
+    });
+
+    afterEach(() => {
+      sandbox.restore();
+    });
+
+    it('should redirect to overview page when feature flag OFF', async () => {
+      await postHelpWithFees()(req as Request, res as Response, next);
+      expect(res.redirect).to.have.been.calledOnce.calledWith(paths.common.overview);
+    });
+
+    it('should redirect to overview page when feature flag OFF', async () => {
+      await getHelpWithFees(req as Request, res as Response, next);
+      expect(res.redirect).to.have.been.calledOnce.calledWith(paths.common.overview);
+    });
+  });
+
+  describe('Exception when error thrown', () => {
+    it('getFeeSupport should catch exception and call next with the error', async () => {
+      const error = new Error('an error');
+      sandbox.stub(LaunchDarklyService.prototype, 'getVariation').throws(error);
+      await getHelpWithFees(req as Request, res as Response, next);
+      expect(next).to.have.been.calledOnce.calledWith(error);
+    });
+  });
+
+});

--- a/test/unit/controllers/ask-for-fee-remission/steps-to-help-with-fees-refund.test.ts
+++ b/test/unit/controllers/ask-for-fee-remission/steps-to-help-with-fees-refund.test.ts
@@ -1,0 +1,136 @@
+import express, { NextFunction, Request, Response } from 'express';
+import {
+  getStepsToHelpWithFees,
+  postStepsToHelpWithFees,
+  setupStepToHelpWithFeesRefundController
+} from '../../../../app/controllers/ask-for-fee-remission/steps-to-help-with-fees-refund';
+
+import { FEATURE_FLAGS } from '../../../../app/data/constants';
+import { paths } from '../../../../app/paths';
+import LaunchDarklyService from '../../../../app/service/launchDarkly-service';
+import Logger from '../../../../app/utils/logger';
+import { expect, sinon } from '../../../utils/testUtils';
+
+describe('Steps to help with fees Refund Controller', function () {
+  let sandbox: sinon.SinonSandbox;
+  let req: Partial<Request>;
+  let res: Partial<Response>;
+  let next: NextFunction;
+  const logger: Logger = new Logger();
+
+  beforeEach(() => {
+    sandbox = sinon.createSandbox();
+    req = {
+      body: {},
+      session: {
+        appeal: {
+          application: {
+            isAppealLate: false
+          }
+        }
+      } as Partial<Express.Session>,
+      cookies: {
+        '__auth-token': 'atoken'
+      },
+      idam: {
+        userDetails: {
+          uid: 'idamUID'
+        }
+      },
+      app: {
+        locals: {
+          logger
+        }
+      } as any
+    } as Partial<Request>;
+
+    res = {
+      render: sandbox.stub(),
+      send: sandbox.stub(),
+      redirect: sandbox.spy()
+    } as Partial<Response>;
+
+    next = sandbox.stub() as NextFunction;
+  });
+
+  afterEach(() => {
+    sandbox.restore();
+  });
+  describe('setupStepToHelpWithFeesRefundController', () => {
+    beforeEach(() => {
+      sandbox.stub(LaunchDarklyService.prototype, 'getVariation')
+        .withArgs(req as Request, FEATURE_FLAGS.DLRM_REFUND_FEATURE_FLAG, false).resolves(true);
+    });
+
+    afterEach(() => {
+      sandbox.restore();
+    });
+
+    it('should setup the routes', () => {
+      const routerGetStub: sinon.SinonStub = sandbox.stub(express.Router as never, 'get');
+      const routerPOSTStub: sinon.SinonStub = sandbox.stub(express.Router as never, 'post');
+      const middleware = [];
+
+      setupStepToHelpWithFeesRefundController(middleware);
+      expect(routerGetStub).to.have.been.calledWith(paths.appealSubmitted.stepsToApplyForHelpWithFeesRefund);
+      expect(routerPOSTStub).to.have.been.calledWith(paths.appealSubmitted.stepsToApplyForHelpWithFeesRefund);
+    });
+
+    it('should render steps-to-help-with-fees.njk', async () => {
+      await getStepsToHelpWithFees(req as Request, res as Response, next);
+      expect(res.render).to.have.been.calledOnce.calledWith('appeal-application/fee-support/steps-to-help-with-fees.njk', {
+        previousPage: paths.appealSubmitted.helpWithFeesRefund,
+        refundJourney: true
+      });
+    });
+
+    it('should redirect help-with-fees-ref-number.njk', async () => {
+      await postStepsToHelpWithFees()(req as Request, res as Response, next);
+      expect(res.redirect).to.have.been.calledWith(paths.appealSubmitted.helpWithFeesReferenceNumberRefund);
+    });
+
+    it('when in edit mode should redirect check-and-send.njk and reset isEdit flag', async () => {
+      req.query = { 'edit': '' };
+      await postStepsToHelpWithFees()(req as Request, res as Response, next);
+      expect(res.redirect).to.have.been.calledWithMatch(new RegExp(`${paths.appealSubmitted.helpWithFeesReferenceNumberRefund}(?!.*\\bedit\\b)`));
+      expect(req.session.appeal.application.isEdit).to.be.undefined;
+    });
+
+    it('when called with edit param should render fee-waiver.njk and update session', async () => {
+      req.query = { 'edit': '' };
+      await getStepsToHelpWithFees(req as Request, res as Response, next);
+      expect(req.session.appeal.application.isEdit).to.have.eq(true);
+      expect(res.render).to.have.been.calledOnce.calledWith('appeal-application/fee-support/steps-to-help-with-fees.njk');
+    });
+  });
+
+  describe('When Flag is switched off expectations', () => {
+    beforeEach(() => {
+      sandbox.stub(LaunchDarklyService.prototype, 'getVariation')
+        .withArgs(req as Request, FEATURE_FLAGS.DLRM_REFUND_FEATURE_FLAG, false).resolves(false);
+    });
+
+    afterEach(() => {
+      sandbox.restore();
+    });
+
+    it('should redirect to overview page when feature flag OFF', async () => {
+      await getStepsToHelpWithFees(req as Request, res as Response, next);
+      expect(res.redirect).to.have.been.calledOnce.calledWith(paths.common.overview);
+    });
+
+    it('should redirect to overview page when feature flag OFF', async () => {
+      await postStepsToHelpWithFees()(req as Request, res as Response, next);
+      expect(res.redirect).to.have.been.calledOnce.calledWith(paths.common.overview);
+    });
+  });
+
+  describe('Exception when error thrown', () => {
+    it('getFeeWaiver should catch exception and call next with the error', async () => {
+      const error = new Error('an error');
+      sandbox.stub(LaunchDarklyService.prototype, 'getVariation').throws(error);
+      await getStepsToHelpWithFees(req as Request, res as Response, next);
+      expect(next).to.have.been.calledOnce.calledWith(error);
+    });
+  });
+});

--- a/test/unit/controllers/ask-for-fee-remission/upload-local-authority-letter-refund.test.ts
+++ b/test/unit/controllers/ask-for-fee-remission/upload-local-authority-letter-refund.test.ts
@@ -1,0 +1,251 @@
+import express, { NextFunction, Request, Response } from 'express';
+import { validate } from '../../../../app/controllers/appeal-application/upload-local-authority-letter';
+import {
+  deleteLocalAuthorityLetterRefund,
+  getLocalAuthorityLetterRefund,
+  postLocalAuthorityLetterRefund,
+  SetupLocalAuthorityLetterRefundController,
+  uploadLocalAuthorityLetterRefund
+} from '../../../../app/controllers/ask-for-fee-remission/upload-local-authority-letter-refund';
+import { FEATURE_FLAGS } from '../../../../app/data/constants';
+import { paths } from '../../../../app/paths';
+import { DocumentManagementService } from '../../../../app/service/document-management-service';
+import LaunchDarklyService from '../../../../app/service/launchDarkly-service';
+import UpdateAppealService from '../../../../app/service/update-appeal-service';
+import Logger from '../../../../app/utils/logger';
+import { createStructuredError } from '../../../../app/utils/validations/fields-validations';
+import i18n from '../../../../locale/en.json';
+import { expect, sinon } from '../../../utils/testUtils';
+
+describe('Local authority letter refund Controller', function () {
+  let sandbox: sinon.SinonSandbox;
+  let req: Partial<Request>;
+  let res: Partial<Response>;
+  let updateAppealService: Partial<UpdateAppealService>;
+  let documentManagementService: Partial<DocumentManagementService>;
+
+  let next: NextFunction;
+  const logger: Logger = new Logger();
+
+  beforeEach(() => {
+    sandbox = sinon.createSandbox();
+    req = {
+      body: {},
+      query: {},
+      cookies: {
+        '__auth-token': 'atoken'
+      },
+      idam: {
+        userDetails: {
+          uid: 'idamUID'
+        }
+      },
+      session: {
+        appeal: {
+          application: {
+            personalDetails: {}
+          }
+        } as Appeal
+      } as Partial<Express.Session>,
+      app: {
+        locals: {
+          logger
+        }
+      } as any
+    } as Partial<Request>;
+
+    res = {
+      render: sandbox.stub(),
+      send: sandbox.stub(),
+      redirect: sinon.spy(),
+      locals: {}
+    } as Partial<Response>;
+
+    next = sandbox.stub() as NextFunction;
+    updateAppealService = { submitEventRefactored: sandbox.stub() } as Partial<UpdateAppealService>;
+    documentManagementService = {
+      uploadFile: sandbox.stub(),
+      deleteFile: sandbox.stub()
+    } as Partial<DocumentManagementService>;
+  });
+
+  afterEach(() => {
+    sandbox.restore();
+  });
+
+  describe('SetupLocalAuthorityLetterRefundController', () => {
+    beforeEach(() => {
+      sandbox.stub(LaunchDarklyService.prototype, 'getVariation')
+        .withArgs(req as Request, FEATURE_FLAGS.DLRM_REFUND_FEATURE_FLAG, false).resolves(true);
+    });
+
+    afterEach(() => {
+      sandbox.restore();
+    });
+
+    it('should setup the routes', () => {
+      const routerGetStub: sinon.SinonStub = sandbox.stub(express.Router as never, 'get');
+      const routerPOSTStub: sinon.SinonStub = sandbox.stub(express.Router as never, 'post');
+      const middleware = [];
+      new SetupLocalAuthorityLetterRefundController().initialise(middleware, updateAppealService, documentManagementService as DocumentManagementService);
+
+      expect(routerGetStub).to.have.been.calledWith(paths.appealSubmitted.localAuthorityLetterRefund);
+      expect(routerPOSTStub).to.have.been.calledWith(paths.appealSubmitted.localAuthorityLetterRefund);
+      expect(routerPOSTStub).to.have.been.calledWith(paths.appealSubmitted.localAuthorityLetterUploadRefund);
+      expect(routerGetStub).to.have.been.calledWith(paths.appealSubmitted.localAuthorityLetterDeleteRefund);
+    });
+
+    it('should render template', async () => {
+      await getLocalAuthorityLetterRefund(req as Request, res as Response, next);
+
+      expect(res.render).to.have.been.calledOnce.calledWith('appeal-application/fee-support/upload-local-authority-letter.njk');
+    });
+
+    it('should render template and update edit flag in session', async () => {
+      req.query = { 'edit': '' };
+      await getLocalAuthorityLetterRefund(req as Request, res as Response, next);
+
+      expect(res.render).to.have.been.calledOnce.calledWith('appeal-application/fee-support/upload-local-authority-letter.njk');
+      expect(req.session.appeal.application.isEdit).to.have.eq(true);
+    });
+
+    it('should render template with validation errors', async () => {
+      req.query = { error: 'error' };
+      const validationErrors = { uploadFile: createStructuredError('uploadFile', i18n.validationErrors.fileUpload[`${req.query.error}`]) };
+      await getLocalAuthorityLetterRefund(req as Request, res as Response, next);
+      expect(res.render).to.have.been.calledOnce.calledWith('appeal-application/fee-support/upload-local-authority-letter.njk', {
+        title: i18n.pages.uploadLocalAuthorityLetter.title,
+        evidenceListTitle: i18n.pages.uploadLocalAuthorityLetter.uploadedFileTitle,
+        formSubmitAction: paths.appealSubmitted.localAuthorityLetterRefund,
+        evidenceUploadAction: paths.appealSubmitted.localAuthorityLetterUploadRefund,
+        evidences: [],
+        evidenceCTA: paths.appealSubmitted.localAuthorityLetterDeleteRefund,
+        previousPage: paths.appealSubmitted.feeSupportRefund,
+        saveForLaterCTA: paths.common.overview,
+        error: validationErrors,
+        errorList: Object.values(validationErrors),
+        continueCancelButtons: true
+      });
+    });
+
+    it('should redirect to \'/local-authority-letter-refund\' if no letter uploaded', async () => {
+      await postLocalAuthorityLetterRefund()(req as Request, res as Response, next);
+
+      expect(res.redirect).to.have.been.calledWith(`${paths.appealSubmitted.localAuthorityLetterRefund}?error=noFileSelected`);
+    });
+
+    it('should redirect to \'/about-appeal\' if local authority letter upload present and not in editing mode', async () => {
+      req.session.appeal.application.lateLocalAuthorityLetters = [{ fileId: 'id', name: 'name' } as Evidence];
+      await postLocalAuthorityLetterRefund()(req as Request, res as Response, next);
+
+      expect(res.redirect).to.have.been.calledWith(paths.appealSubmitted.checkYourAnswersRefund);
+    });
+
+    it('should redirect to \'/check-answers\' if local authority letter upload present and in editing mode', async () => {
+      req.session.appeal.application.isEdit = true;
+      req.session.appeal.application.lateLocalAuthorityLetters = [{ fileId: 'id', name: 'name' } as Evidence];
+      await postLocalAuthorityLetterRefund()(req as Request, res as Response, next);
+
+      expect(res.redirect).to.have.been.calledWith(paths.appealSubmitted.checkYourAnswersRefund);
+    });
+
+    it('should call next if no multer errors', () => {
+      validate(req as Request, res as Response, next);
+
+      expect(next).to.have.been.called;
+    });
+
+    it('should redirect to \'/upload-local-authority-letter-refund\' with error code', async () => {
+      res.locals.errorCode = 'anError';
+      validate(req as Request, res as Response, next);
+
+      expect(res.redirect).to.have.been.called;
+    });
+
+    it('should upload a file', async () => {
+      const file = {
+        originalname: 'file.png',
+        mimetype: 'type'
+      };
+      req.file = file as Express.Multer.File;
+      await uploadLocalAuthorityLetterRefund(documentManagementService as DocumentManagementService)(req as Request, res as Response, next);
+
+      expect(documentManagementService.uploadFile).to.have.been.called;
+      expect(res.redirect).to.have.been.calledWith(paths.appealSubmitted.localAuthorityLetterRefund);
+    });
+
+    it('should redirect to \'/upload-local-authority-letter\' with no file selected error', async () => {
+      await uploadLocalAuthorityLetterRefund(documentManagementService as DocumentManagementService)(req as Request, res as Response, next);
+
+      expect(res.redirect).to.have.been.calledWith(`${paths.appealSubmitted.localAuthorityLetterRefund}?error=noFileSelected`);
+    });
+
+    it('should delete an evidence', async () => {
+      req.session.appeal.application.lateLocalAuthorityLetters = [{ fileId: 'anId', name: 'name' } as Evidence];
+      req.session.appeal.documentMap = [{ id: 'anId', url: 'documentStoreUrl' }];
+      req.query.id = 'anId';
+      await deleteLocalAuthorityLetterRefund(documentManagementService as DocumentManagementService)(req as Request, res as Response, next);
+
+      expect(documentManagementService.deleteFile).to.have.been.called;
+      expect(res.redirect).to.have.been.calledWith(paths.appealSubmitted.localAuthorityLetterRefund);
+    });
+
+    it('should catch error and call next with error', async () => {
+      const error = new Error('the error');
+      res.redirect = sandbox.stub().throws(error);
+      req.session.appeal.application.isEdit = true;
+      req.session.appeal.application.lateLocalAuthorityLetters = [{ fileId: 'id', name: 'name' } as Evidence];
+      await postLocalAuthorityLetterRefund()(req as Request, res as Response, next);
+
+      expect(next).to.have.been.calledOnce.calledWith(error);
+    });
+  });
+
+  describe('When Flag is switched off expectations', () => {
+    beforeEach(() => {
+      sandbox.stub(LaunchDarklyService.prototype, 'getVariation')
+        .withArgs(req as Request, FEATURE_FLAGS.DLRM_REFUND_FEATURE_FLAG, false).resolves(false);
+    });
+
+    afterEach(() => {
+      sandbox.restore();
+    });
+
+    it('should redirect to overview page when feature flag OFF', async () => {
+      await getLocalAuthorityLetterRefund(req as Request, res as Response, next);
+      expect(res.redirect).to.have.been.calledOnce.calledWith(paths.common.overview);
+    });
+
+    it('should redirect to overview page when feature flag OFF', async () => {
+      await postLocalAuthorityLetterRefund()(req as Request, res as Response, next);
+      expect(res.redirect).to.have.been.calledOnce.calledWith(paths.common.overview);
+    });
+  });
+
+  describe('Exception when error thrown', () => {
+    it('should catch an error and redirect with error', async () => {
+      const error = new Error('the error');
+      res.redirect = sandbox.stub().throws(error);
+      const file = {
+        originalname: 'file.png',
+        mimetype: 'type'
+      };
+      req.file = file as Express.Multer.File;
+      await uploadLocalAuthorityLetterRefund(documentManagementService as DocumentManagementService)(req as Request, res as Response, next);
+
+      expect(next).to.have.been.calledWith(error);
+    });
+
+    it('should catch an error and call next with error', async () => {
+      const error = new Error('the error');
+      res.redirect = sandbox.stub().throws(error);
+      req.session.appeal.application.lateLocalAuthorityLetters = [{ fileId: 'anId', name: 'name' } as Evidence];
+      req.session.appeal.documentMap = [{ id: 'anId', url: 'documentStoreUrl' }];
+      req.query.id = 'anId';
+      await deleteLocalAuthorityLetterRefund(documentManagementService as DocumentManagementService)(req as Request, res as Response, next);
+
+      expect(next).to.have.been.calledWith(error);
+    });
+  });
+
+});

--- a/test/unit/controllers/check-and-send.test.ts
+++ b/test/unit/controllers/check-and-send.test.ts
@@ -170,7 +170,7 @@ describe('createSummaryRowsFrom', () => {
       it(`should be ${description}`, () => {
         req.session.appeal.application.helpWithFeesOption = input;
         const helpWithFeesRow = addSummaryRow('Help with fees', [expectedResponse], paths.appealStarted.helpWithFees + editParameter);
-        mockedRows.push(localAuthorityLettersRow);
+        mockedRows.push(helpWithFeesRow);
         expect(rows).to.be.deep.equal(mockedRows);
         mockedRows.pop();
       });
@@ -323,7 +323,19 @@ describe('Check and Send Controller', () => {
       expect(res.render).to.have.been.calledOnce.calledWith('appeal-application/check-and-send.njk', {
         summaryRows: sinon.match.any,
         previousPage: paths.appealStarted.taskList,
+        dlrmFeeRemissionFlag: true,
         hasRemissionOption: true
+      });
+    });
+
+    it('should render check-and-send-page.njk, dlrmFeeRemissionFlag with dlrmFeeRemissionFlag flag is ON', async () => {
+      sandbox.stub(LaunchDarklyService.prototype, 'getVariation').withArgs(req as Request, FEATURE_FLAGS.DLRM_FEE_REMISSION_FEATURE_FLAG, false).resolves(true);
+      req.session.appeal = createDummyAppealApplication();
+      await getCheckAndSend(paymentService as PaymentService)(req as Request, res as Response, next);
+      expect(res.render).to.have.been.calledOnce.calledWith('appeal-application/check-and-send.njk', {
+        summaryRows: sinon.match.any,
+        previousPage: paths.appealStarted.taskList,
+        dlrmFeeRemissionFlag: true
       });
     });
 
@@ -499,12 +511,19 @@ describe('Check and Send Controller', () => {
   });
 
   describe('getFinishPayment', () => {
+    beforeEach(() => {
+      sandbox.stub(LaunchDarklyService.prototype, 'getVariation').withArgs(req as Request, FEATURE_FLAGS.DLRM_REFUND_FEATURE_FLAG, false).resolves(true);
+    });
+
     it('should finish a payment and redirect to confirmation', async () => {
       req.session.appeal.paymentReference = 'aReference';
       updateAppealService.submitEventRefactored = sandbox.stub().resolves({
         paymentStatus: 'Paid',
         paymentDate: 'aDate',
-        isFeePaymentEnabled: 'Yes'
+        isFeePaymentEnabled: 'Yes',
+        application: {
+          refundConfirmationApplied: false
+        }
       } as Partial<Appeal>);
 
       await getFinishPayment(updateAppealService as UpdateAppealService, paymentService as PaymentService)(req as Request, res as Response, next);
@@ -512,6 +531,7 @@ describe('Check and Send Controller', () => {
       expect(req.session.appeal.paymentStatus).to.be.eql('Paid');
       expect(req.session.appeal.paymentDate).to.be.eql('aDate');
       expect(req.session.appeal.isFeePaymentEnabled).to.be.eql('Yes');
+      expect(req.session.appeal.application.refundConfirmationApplied).to.be.eql(false);
       expect(res.redirect).to.have.been.calledWith(paths.appealSubmitted.confirmation);
     });
 
@@ -521,7 +541,10 @@ describe('Check and Send Controller', () => {
       updateAppealService.submitEventRefactored = sandbox.stub().resolves({
         paymentStatus: 'Paid',
         paymentDate: 'aDate',
-        isFeePaymentEnabled: 'Yes'
+        isFeePaymentEnabled: 'Yes',
+        application: {
+          refundConfirmationApplied: false
+        }
       } as Partial<Appeal>);
 
       await getFinishPayment(updateAppealService as UpdateAppealService, paymentService as PaymentService)(req as Request, res as Response, next);
@@ -529,6 +552,7 @@ describe('Check and Send Controller', () => {
       expect(req.session.appeal.paymentStatus).to.be.eql('Paid');
       expect(req.session.appeal.paymentDate).to.be.eql('aDate');
       expect(req.session.appeal.isFeePaymentEnabled).to.be.eql('Yes');
+      expect(req.session.appeal.application.refundConfirmationApplied).to.be.eql(false);
       expect(res.redirect).to.have.been.calledWith(paths.common.confirmationPayment);
     });
 
@@ -538,7 +562,10 @@ describe('Check and Send Controller', () => {
       updateAppealService.submitEventRefactored = sandbox.stub().resolves({
         paymentStatus: 'Paid',
         paymentDate: 'aDate',
-        isFeePaymentEnabled: 'Yes'
+        isFeePaymentEnabled: 'Yes',
+        application: {
+          refundConfirmationApplied: false
+        }
       } as Partial<Appeal>);
 
       await getFinishPayment(updateAppealService as UpdateAppealService, paymentService as PaymentService)(req as Request, res as Response, next);
@@ -546,6 +573,7 @@ describe('Check and Send Controller', () => {
       expect(req.session.appeal.paymentStatus).to.be.eql('Paid');
       expect(req.session.appeal.paymentDate).to.be.eql('aDate');
       expect(req.session.appeal.isFeePaymentEnabled).to.be.eql('Yes');
+      expect(req.session.appeal.application.refundConfirmationApplied).to.be.eql(false);
       expect(res.redirect).to.have.been.calledWith(paths.common.confirmationPayment);
     });
 

--- a/test/unit/controllers/clarifying-questions/anything-else-question.test.ts
+++ b/test/unit/controllers/clarifying-questions/anything-else-question.test.ts
@@ -119,7 +119,6 @@ describe('Clarifying Questions: Anything else question-page controller', () => {
     it('should catch error and call next with error', () => {
       const error = new Error('an error');
       res.render = sandbox.stub().throws(error);
-
       getAnythingElseQuestionPage(req as Request, res as Response, next);
       expect(next).to.have.been.calledOnce.calledWith(error);
     });

--- a/test/unit/controllers/confirmation-page.test.ts
+++ b/test/unit/controllers/confirmation-page.test.ts
@@ -1,11 +1,17 @@
 import { NextFunction, Request, Response } from 'express';
+import { SinonSpy } from 'sinon';
+import { postAsylumSupport } from '../../../app/controllers/appeal-application/asylum-support';
 import {
   getConfirmationPage,
   getConfirmationPaidPage,
   setConfirmationController
 } from '../../../app/controllers/appeal-application/confirmation-page';
+import { FEATURE_FLAGS } from '../../../app/data/constants';
+import { Events } from '../../../app/data/events';
 import { States } from '../../../app/data/states';
 import { paths } from '../../../app/paths';
+import LaunchDarklyService from '../../../app/service/launchDarkly-service';
+import UpdateAppealService from '../../../app/service/update-appeal-service';
 import { addDaysToDate } from '../../../app/utils/date-utils';
 import Logger from '../../../app/utils/logger';
 import i18n from '../../../locale/en.json';
@@ -18,6 +24,7 @@ describe('Confirmation Page Controller', () => {
   let req: Partial<Request>;
   let res: Partial<Response>;
   let next: NextFunction;
+  let updateAppealService: Partial<UpdateAppealService>;
   const logger: Logger = new Logger();
 
   beforeEach(() => {
@@ -48,6 +55,15 @@ describe('Confirmation Page Controller', () => {
     } as Partial<Response>;
 
     next = sandbox.stub() as NextFunction;
+
+    updateAppealService = {
+      submitEvent: sandbox.stub(),
+      submitEventRefactored: sandbox.stub().returns({
+        case_data: {
+          asylumSupportRefNumber: 'A1234567'
+        }
+      })
+    };
   });
 
   afterEach(() => {
@@ -57,7 +73,7 @@ describe('Confirmation Page Controller', () => {
   it('should setup the routes', () => {
     const routerGetStub: sinon.SinonStub = sandbox.stub(express.Router, 'get');
     const middleware = [];
-    setConfirmationController(middleware);
+    setConfirmationController(middleware, updateAppealService as UpdateAppealService);
     expect(routerGetStub).to.have.been.calledWith(paths.appealSubmitted.confirmation, middleware);
   });
 
@@ -198,14 +214,14 @@ describe('Confirmation Page Controller', () => {
     expect(next).to.have.been.calledOnce.calledWith(error);
   });
 
-  it('getConfirmationPaidPage should render confirmation.njk for a paPayLater appeal', () => {
+  it('getConfirmationPaidPage should render confirmation.njk for a paPayLater appeal', async () => {
     const { appeal } = req.session;
     appeal.application.isAppealLate = false;
     appeal.appealStatus = States.APPEAL_SUBMITTED.id;
     appeal.application.appealType = 'protection';
     appeal.paAppealTypeAipPaymentOption = 'payLater';
 
-    getConfirmationPaidPage(req as Request, res as Response, next);
+    await getConfirmationPaidPage(updateAppealService as UpdateAppealService)(req as Request, res as Response, next);
     expect(res.render).to.have.been.calledOnce.calledWith('templates/confirmation-page.njk', {
       date: addDaysToDate(5),
       title: i18n.pages.confirmationPaid.title,
@@ -214,7 +230,7 @@ describe('Confirmation Page Controller', () => {
     });
   });
 
-  it('getConfirmationPaidPage should render confirmation.njk for a paPayNow in-time appeal paid immediately after submission', () => {
+  it('getConfirmationPaidPage should render confirmation.njk for a paPayNow in-time appeal paid immediately after submission', async () => {
     req.session.payingImmediately = true;
     const { appeal } = req.session;
     appeal.application.isAppealLate = false;
@@ -222,7 +238,7 @@ describe('Confirmation Page Controller', () => {
     appeal.application.appealType = 'protection';
     appeal.paAppealTypeAipPaymentOption = 'payNow';
 
-    getConfirmationPaidPage(req as Request, res as Response, next);
+    await getConfirmationPaidPage(updateAppealService as UpdateAppealService)(req as Request, res as Response, next);
     expect(res.render).to.have.been.calledOnce.calledWith('templates/confirmation-page.njk', {
       date: addDaysToDate(5),
       title: i18n.pages.successPage.inTime.panel,
@@ -232,7 +248,7 @@ describe('Confirmation Page Controller', () => {
     });
   });
 
-  it('getConfirmationPaidPage should render confirmation.njk for a paPayNow out-of-time appeal paid immeditaley after submission', () => {
+  it('getConfirmationPaidPage should render confirmation.njk for a paPayNow out-of-time appeal paid immeditaley after submission', async () => {
     req.session.payingImmediately = true;
     const { appeal } = req.session;
     appeal.application.isAppealLate = true;
@@ -240,7 +256,7 @@ describe('Confirmation Page Controller', () => {
     appeal.application.appealType = 'protection';
     appeal.paAppealTypeAipPaymentOption = 'payNow';
 
-    getConfirmationPaidPage(req as Request, res as Response, next);
+    await getConfirmationPaidPage(updateAppealService as UpdateAppealService)(req as Request, res as Response, next);
     expect(res.render).to.have.been.calledOnce.calledWith('templates/confirmation-page.njk', {
       date: addDaysToDate(5),
       title: i18n.pages.successPage.outOfTime.panel,
@@ -250,7 +266,7 @@ describe('Confirmation Page Controller', () => {
     });
   });
 
-  it('getConfirmationPaidPage should render confirmation.njk for a paPayNow in-time appeal paid not immediately', () => {
+  it('getConfirmationPaidPage should render confirmation.njk for a paPayNow in-time appeal paid not immediately', async () => {
     req.session.payingImmediately = false;
     const { appeal } = req.session;
     appeal.application.isAppealLate = false;
@@ -258,7 +274,7 @@ describe('Confirmation Page Controller', () => {
     appeal.application.appealType = 'protection';
     appeal.paAppealTypeAipPaymentOption = 'payNow';
 
-    getConfirmationPaidPage(req as Request, res as Response, next);
+    await getConfirmationPaidPage(updateAppealService as UpdateAppealService)(req as Request, res as Response, next);
     expect(res.render).to.have.been.calledOnce.calledWith('templates/confirmation-page.njk', {
       date: addDaysToDate(5),
       title: i18n.pages.confirmationPaidLater.title,
@@ -268,7 +284,7 @@ describe('Confirmation Page Controller', () => {
     });
   });
 
-  it('getConfirmationPaidPage should render confirmation.njk for a paPayNow out-of-time appeal paid not immediately', () => {
+  it('getConfirmationPaidPage should render confirmation.njk for a paPayNow out-of-time appeal paid not immediately', async () => {
     req.session.payingImmediately = false;
     const { appeal } = req.session;
     appeal.application.isAppealLate = true;
@@ -276,7 +292,7 @@ describe('Confirmation Page Controller', () => {
     appeal.application.appealType = 'protection';
     appeal.paAppealTypeAipPaymentOption = 'payNow';
 
-    getConfirmationPaidPage(req as Request, res as Response, next);
+    await getConfirmationPaidPage(updateAppealService as UpdateAppealService)(req as Request, res as Response, next);
     expect(res.render).to.have.been.calledOnce.calledWith('templates/confirmation-page.njk', {
       date: addDaysToDate(5),
       title: i18n.pages.confirmationPaidLater.title,
@@ -286,14 +302,14 @@ describe('Confirmation Page Controller', () => {
     });
   });
 
-  it('getConfirmationPaidPage should render confirmation.njk for on time EA appeal', () => {
+  it('getConfirmationPaidPage should render confirmation.njk for on time EA appeal', async () => {
     req.session.payingImmediately = false;
     const { appeal } = req.session;
     appeal.application.isAppealLate = false;
     appeal.appealStatus = States.APPEAL_SUBMITTED.id;
     appeal.application.appealType = 'refusalOfEu';
 
-    getConfirmationPaidPage(req as Request, res as Response, next);
+    await getConfirmationPaidPage(updateAppealService as UpdateAppealService)(req as Request, res as Response, next);
     expect(res.render).to.have.been.calledOnce.calledWith('templates/confirmation-page.njk', {
       date: addDaysToDate(5),
       title: i18n.pages.successPage.inTime.panel,
@@ -303,14 +319,14 @@ describe('Confirmation Page Controller', () => {
     });
   });
 
-  it('getConfirmationPaidPage should render confirmation.njk for a late EA appeal', () => {
+  it('getConfirmationPaidPage should render confirmation.njk for a late EA appeal', async () => {
     req.session.payingImmediately = false;
     const { appeal } = req.session;
     appeal.application.isAppealLate = true;
     appeal.appealStatus = States.APPEAL_SUBMITTED.id;
     appeal.application.appealType = 'refusalOfEu';
 
-    getConfirmationPaidPage(req as Request, res as Response, next);
+    await getConfirmationPaidPage(updateAppealService as UpdateAppealService)(req as Request, res as Response, next);
     expect(res.render).to.have.been.calledOnce.calledWith('templates/confirmation-page.njk', {
       date: addDaysToDate(5),
       title: i18n.pages.successPage.outOfTime.panel,

--- a/test/unit/controllers/detail-viewers.test.ts
+++ b/test/unit/controllers/detail-viewers.test.ts
@@ -1,5 +1,6 @@
-import { NextFunction, Request, Response } from 'express';
+import { application, NextFunction, Request, Response } from 'express';
 import {
+  addFeeSupportStatus,
   findDocumentInReheardHearingDocCollection,
   getAppealDetailsViewer,
   getApplicationTitle,
@@ -42,7 +43,7 @@ import { expectedEventsWithCmaRequirements } from '../mockData/events/expectatio
 
 const express = require('express');
 
-describe('Detail viewer Controller', () => {
+describe('DetailViewController', () => {
   let sandbox: sinon.SinonSandbox;
   let req: Partial<Request>;
   let res: Partial<Response>;
@@ -610,8 +611,8 @@ describe('Detail viewer Controller', () => {
           { key: { text: 'Address' }, value: { html: '60 GREAT PORTLAND STREET  LONDON United Kingdom W1W 7RT' } },
           { key: { text: 'Contact details' }, value: { html: 'test@email.com<br>7759991234' } }
         ],
-        'feeDetailsRows': [
-        ]
+        'feeDetailsRows': [],
+        'feeHistoryRows': []
       };
     });
 
@@ -663,8 +664,7 @@ describe('Detail viewer Controller', () => {
       });
     });
 
-    it('should render detail-viewers/details-with-fees-viewer.njk when dlrm fee remission flag is ON and has' +
-      ' sponsor not in Uk', async () => {
+    it('should render detail-viewers/details-with-fees-viewer.njk when dlrm fee remission flag is ON and has sponsor not in Uk', async () => {
       sandbox.stub(LaunchDarklyService.prototype, 'getVariation').withArgs(req as Request, FEATURE_FLAGS.DLRM_FEE_REMISSION_FEATURE_FLAG, false).resolves(true);
 
       expectedSummaryRowsWithDlrmFeeRemission.aboutAppealRows[0].value.html = 'No'; // appellant in uk
@@ -758,6 +758,35 @@ describe('Detail viewer Controller', () => {
       req.session.appeal.application.remissionOption = 'asylumSupportFromHo';
       req.session.appeal.application.asylumSupportRefNumber = 'supportRefNumber';
       req.session.appeal.feeWithHearing = '140';
+
+      await getAppealDetailsViewer(req as Request, res as Response, next);
+      expect(res.render).to.have.been.calledWith('templates/details-with-fees-viewer.njk', {
+        title: i18n.pages.detailViewers.appealDetails.title,
+        aboutTheAppealTitle: i18n.pages.checkYourAnswers.rowTitles.aboutTheAppeal,
+        personalDetailsTitle: i18n.pages.checkYourAnswers.rowTitles.personalDetails,
+        feeDetailsTitle: i18n.pages.checkYourAnswers.rowTitles.feeDetails,
+        previousPage: paths.common.overview,
+        data: expectedSummaryRowsWithDlrmFeeRemission
+      });
+    });
+
+    it('should render detail-viewers/details-with-fees-viewer.njk when dlrm fee remission and and DLRM fee' +
+      ' refund flags are ON and remissionOption is asylumSupportFromHo', async () => {
+      sandbox.stub(LaunchDarklyService.prototype, 'getVariation')
+        .withArgs(req as Request, FEATURE_FLAGS.DLRM_FEE_REMISSION_FEATURE_FLAG, false).resolves(true)
+        .withArgs(req as Request, FEATURE_FLAGS.DLRM_REFUND_FEATURE_FLAG, false).resolves(true);
+      expectedSummaryRowsWithDlrmFeeRemission.feeDetailsRows.push(
+        { key: { text: 'Fee amount' }, value: { html: '£140' } },
+        { key: { text: 'Payment status' }, value: { html: 'Paid' } },
+        { key: { text: 'Fee support status' }, value: {  html: 'Fee support requested' } },
+        { key: { text: 'Asylum Support reference number' }, value: { html: 'supportRefNumber' } }
+      );
+
+      req.session.appeal.paAppealTypeAipPaymentOption = 'payLater';
+      req.session.appeal.application.remissionOption = 'asylumSupportFromHo';
+      req.session.appeal.application.asylumSupportRefNumber = 'supportRefNumber';
+      req.session.appeal.feeWithHearing = '140';
+      req.session.appeal.paymentStatus = 'Paid';
 
       await getAppealDetailsViewer(req as Request, res as Response, next);
       expect(res.render).to.have.been.calledWith('templates/details-with-fees-viewer.njk', {
@@ -887,6 +916,458 @@ describe('Detail viewer Controller', () => {
       res.render = sandbox.stub().throws(error);
       await getAppealDetailsViewer(req as Request, res as Response, next);
       expect(next).to.have.been.calledOnce.calledWith(error);
+    });
+
+    describe('Remission decision', async () => {
+      const previousRemissionDetails = [{
+        id: '1',
+        feeAmount: '1000',
+        amountRemitted: '1000',
+        amountLeftToPay: '1000',
+        remissionDecision: 'Approved',
+        asylumSupportReference: 'refNum'
+      } as RemissionDetails, {
+        id: '1',
+        feeAmount: '1000',
+        amountRemitted: '1000',
+        amountLeftToPay: '1000',
+        remissionDecision: 'Partially approved',
+        remissionDecisionReason: 'Decision 1',
+        helpWithFeesReferenceNumber: 'Help with fees'
+      } as RemissionDetails, {
+        id: '1',
+        feeAmount: '2000',
+        amountRemitted: '1000',
+        amountLeftToPay: '1000',
+        remissionDecision: 'Rejected',
+        remissionDecisionReason: 'Decision 2',
+        localAuthorityLetters: [{
+          id: '1',
+          fileId: 'file Id 1',
+          name: 'file_1_name',
+          tag: 'tag1'
+        }] as Evidence[]
+      } as RemissionDetails ];
+
+      const expectedSummaryRowsWithDlrmFeeRemission = {
+        'aboutAppealRows': [
+          { key: { text: 'In the UK' }, value: { html: 'Yes' } },
+          { key: { text: 'Home Office reference number' }, value: { html: 'A1234567' } },
+          { key: { text: 'Date letter sent' }, value: { html: '16 February 2020' } },
+          { key: { text: 'Home Office decision letter' },
+            value: {
+              html: "<a class='govuk-link' target='_blank' rel='noopener noreferrer' href='/view/document/f1d73cba-a117-4a0c-acf3-d8b787c984d7'>unnamed.jpg</a><br><a class='govuk-link' target='_blank' rel='noopener noreferrer' href='/view/document/3d8bf49d-766f-4f41-b814-e82a04dec002'>Screenshot 2021-06-10 at 13.01.57.png</a>"
+            }
+          },
+          { key: { text: 'Sponsor' }, value: { html: 'No' } },
+          { key: { text: 'Appeal type' }, value: { html: 'Protection' } },
+          { key: { text: 'Decision Type' }, value: { html: 'Decision with a hearing' } },
+          { key: { text: 'Reason for late appeal' }, value: { html: 'a reason for being late' } },
+          { key: { text: 'Supporting evidence' },
+            value: {
+              html: "<a class='govuk-link' target='_blank' rel='noopener noreferrer' href='/view/document/318c373c-dd10-4deb-9590-04282653715d'>MINI-UK-66-reg.jpg</a>"
+            }
+          }
+        ],
+        'personalDetailsRows': [
+          { key: { text: 'Name' }, value: { html: 'Pablo Ramirez' } },
+          { key: { text: 'Date of birth' }, value: { html: '20 July 1988' } },
+          { key: { text: 'Nationality' }, value: { html: 'Albania' } },
+          { key: { text: 'Address' }, value: { html: '60 GREAT PORTLAND STREET  LONDON United Kingdom W1W 7RT' } },
+          { key: { text: 'Contact details' }, value: { html: 'test@email.com<br>7759991234' } }
+        ],
+        'feeDetailsRows': [
+          { key: { text: 'Fee amount' }, value: { html: '£140' } },
+          { key: { text: 'Payment status' }, value: {  html: 'No payment needed' } },
+          { key: { text: 'Fee support status' }, value: { html: 'Fee support request approved' } },
+          { key: { text: 'Asylum Support reference number' }, value: { html: 'supportRefNumber' } }
+        ],
+        'feeHistoryRows': [
+          [
+            { key: { text: 'Date of application' }, value: { html: '15 June 2021' } },
+            { key: { text: 'Asylum Support reference number' }, value: { html: 'refNum' } },
+            { key: { text: 'Fee support status' }, value: {  html: 'Fee support request granted' } },
+            { key: { text: 'Fee to refund' }, value: { html: '£140' } }
+          ],
+          [
+            { key: { text: 'Date of application' }, value: { html: '15 June 2021' } },
+            { key: { text: 'Help with fees reference number' }, value: { html: 'Help with fees' } },
+            { key: { text: 'Fee support status' }, value: {  html: 'Fee support request partially granted' } },
+            { key: { text: 'Reason for decision' }, value: {  html: 'Decision 1' } },
+            { key: { text: 'Fee to refund' }, value: { html: '£130' } }
+          ], [
+            { key: { text: 'Date of application' }, value: { html: '15 June 2021' } },
+            { key: { text: 'Local Authority letter' }, value: { html: "<a class='govuk-link' target='_blank' rel='noopener noreferrer' href='/view/document/file Id 1'>file_1_name</a>" } },
+            { key: { text: 'Fee support status' }, value: {  html: 'Fee support requested refused' } },
+            { key: { text: 'Reason for decision' }, value: {  html: 'Decision 2' } }
+          ]
+        ]
+      };
+      const historyEvent = {
+        id: 'recordRemissionDecision',
+        event: {
+          eventName: '',
+          description: ''
+        },
+        user: {
+          id: '',
+          lastName: '',
+          firstName: ''
+        },
+        createdDate: '2021-06-15T14:23:34.581353',
+        caseTypeVersion: 1,
+        state: {
+          id: '',
+          name: ''
+        },
+        data: '' } as HistoryEvent;
+
+      it('should render detail-viewers/details-with-fees-viewer.njk with history entries when dlrm fee remission and fee refund flags are ON and there are previousRemissionDetails', async () => {
+        sandbox.stub(LaunchDarklyService.prototype, 'getVariation')
+          .withArgs(req as Request, FEATURE_FLAGS.DLRM_FEE_REMISSION_FEATURE_FLAG, false).resolves(true)
+          .withArgs(req as Request, FEATURE_FLAGS.DLRM_REFUND_FEATURE_FLAG, false).resolves(true);
+        req.session.appeal.paAppealTypeAipPaymentOption = 'payLater';
+        req.session.appeal.application.remissionOption = 'asylumSupportFromHo';
+        req.session.appeal.application.asylumSupportRefNumber = 'supportRefNumber';
+        req.session.appeal.feeWithHearing = '140';
+        req.session.appeal.paymentStatus = 'Paid';
+        req.session.appeal.application.remissionDecision = 'approved';
+
+        req.session.appeal.application.previousRemissionDetails = previousRemissionDetails;
+        req.session.appeal.history = [ historyEvent, historyEvent, historyEvent ];
+
+        await getAppealDetailsViewer(req as Request, res as Response, next);
+        expect(res.render).to.have.been.calledWith('templates/details-with-fees-viewer.njk', {
+          title: i18n.pages.detailViewers.appealDetails.title,
+          aboutTheAppealTitle: i18n.pages.checkYourAnswers.rowTitles.aboutTheAppeal,
+          personalDetailsTitle: i18n.pages.checkYourAnswers.rowTitles.personalDetails,
+          feeDetailsTitle: i18n.pages.checkYourAnswers.rowTitles.feeDetails,
+          previousPage: paths.common.overview,
+          data: expectedSummaryRowsWithDlrmFeeRemission
+        });
+      });
+      it('should render detail-viewers/details-with-fees-viewer.njk with history entries when dlrm fee remission and fee refund flags are ON and there is no remission decision yet', async () => {
+        sandbox.stub(LaunchDarklyService.prototype, 'getVariation')
+          .withArgs(req as Request, FEATURE_FLAGS.DLRM_FEE_REMISSION_FEATURE_FLAG, false).resolves(true)
+          .withArgs(req as Request, FEATURE_FLAGS.DLRM_REFUND_FEATURE_FLAG, false).resolves(true);
+        req.session.appeal.paAppealTypeAipPaymentOption = 'payLater';
+        req.session.appeal.application.remissionOption = 'asylumSupportFromHo';
+        req.session.appeal.application.asylumSupportRefNumber = 'supportRefNumber';
+        req.session.appeal.feeWithHearing = '140';
+        req.session.appeal.paymentStatus = 'Paid';
+        req.session.appeal.application.previousRemissionDetails = previousRemissionDetails;
+        req.session.appeal.history = [ historyEvent, historyEvent, historyEvent ];
+
+        const feeDetails = [
+          { key: { text: 'Fee amount' }, value: { html: '£140' } },
+          { key: { text: 'Payment status' }, value: {  html: 'Paid' } },
+          { key: { text: 'Fee support status' }, value: { html: 'Fee support requested' } },
+          { key: { text: 'Asylum Support reference number' }, value: { html: 'supportRefNumber' } }
+        ];
+        const expectedSummaryRowsWithDlrmFeeRemissionCustom = {
+          ...expectedSummaryRowsWithDlrmFeeRemission,
+          'feeDetailsRows': feeDetails
+        };
+        await getAppealDetailsViewer(req as Request, res as Response, next);
+        expect(res.render).to.have.been.calledWith('templates/details-with-fees-viewer.njk', {
+          title: i18n.pages.detailViewers.appealDetails.title,
+          aboutTheAppealTitle: i18n.pages.checkYourAnswers.rowTitles.aboutTheAppeal,
+          personalDetailsTitle: i18n.pages.checkYourAnswers.rowTitles.personalDetails,
+          feeDetailsTitle: i18n.pages.checkYourAnswers.rowTitles.feeDetails,
+          previousPage: paths.common.overview,
+          data: expectedSummaryRowsWithDlrmFeeRemissionCustom
+        });
+      });
+
+      it('should render detail-viewers/details-with-fees-viewer.njk with history entries when dlrm fee remission and fee refund flags are ON and there are previousRemissionDetails and recordRemissionDecision are more than previousRemissionDetails', async () => {
+        sandbox.stub(LaunchDarklyService.prototype, 'getVariation')
+          .withArgs(req as Request, FEATURE_FLAGS.DLRM_FEE_REMISSION_FEATURE_FLAG, false).resolves(true)
+          .withArgs(req as Request, FEATURE_FLAGS.DLRM_REFUND_FEATURE_FLAG, false).resolves(true);
+        req.session.appeal.paAppealTypeAipPaymentOption = 'payLater';
+        req.session.appeal.application.remissionOption = 'asylumSupportFromHo';
+        req.session.appeal.application.asylumSupportRefNumber = 'supportRefNumber';
+        req.session.appeal.feeWithHearing = '140';
+        req.session.appeal.paymentStatus = 'Paid';
+        req.session.appeal.application.remissionDecision = 'approved';
+
+        req.session.appeal.application.previousRemissionDetails = previousRemissionDetails;
+
+        const historyEventDayBefore = {
+          id: 'recordRemissionDecision',
+          event: {
+            eventName: '',
+            description: ''
+          },
+          user: {
+            id: '',
+            lastName: '',
+            firstName: ''
+          },
+          createdDate: '2021-06-14T14:23:34.581353',
+          caseTypeVersion: 1,
+          state: {
+            id: '',
+            name: ''
+          },
+          data: '' } as HistoryEvent;
+        req.session.appeal.history = [ historyEventDayBefore, historyEvent, historyEvent, historyEvent ];
+
+        await getAppealDetailsViewer(req as Request, res as Response, next);
+        expect(res.render).to.have.been.calledWith('templates/details-with-fees-viewer.njk', {
+          title: i18n.pages.detailViewers.appealDetails.title,
+          aboutTheAppealTitle: i18n.pages.checkYourAnswers.rowTitles.aboutTheAppeal,
+          personalDetailsTitle: i18n.pages.checkYourAnswers.rowTitles.personalDetails,
+          feeDetailsTitle: i18n.pages.checkYourAnswers.rowTitles.feeDetails,
+          previousPage: paths.common.overview,
+          data: expectedSummaryRowsWithDlrmFeeRemission
+        });
+      });
+    });
+
+    it('should render detail-viewers/details-with-fees-viewer.njk with history entries when dlrm fee remission and fee refund flags are ON and feeUpdateTribunalAction is additionalPayment', async () => {
+      sandbox.stub(LaunchDarklyService.prototype, 'getVariation')
+        .withArgs(req as Request, FEATURE_FLAGS.DLRM_FEE_REMISSION_FEATURE_FLAG, false).resolves(true)
+        .withArgs(req as Request, FEATURE_FLAGS.DLRM_REFUND_FEATURE_FLAG, false).resolves(true);
+      req.session.appeal.paAppealTypeAipPaymentOption = 'payLater';
+      req.session.appeal.application.remissionOption = 'asylumSupportFromHo';
+      req.session.appeal.application.asylumSupportRefNumber = 'supportRefNumber';
+      req.session.appeal.application.feeUpdateReason = 'decisionTypeChanged';
+      req.session.appeal.feeWithHearing = '140';
+      req.session.appeal.paymentStatus = 'Paid';
+      req.session.appeal.newFeeAmount = '1400';
+      req.session.appeal.application.paidAmount = '1400';
+      req.session.appeal.application.remissionDecision = 'approved';
+      req.session.appeal.application.feeUpdateTribunalAction = 'additionalPayment';
+      req.session.appeal.application.manageFeeRequestedAmount = '1000';
+
+      expectedSummaryRowsWithDlrmFeeRemission.feeDetailsRows = [
+        { key: { text: 'Fee amount' }, value: { html: '£14' } },
+        { key: { text: 'Fee amount paid' }, value: { html: '£14' } },
+        { key: { text: 'Reason for fee change' }, value: { html: 'Decision type changed' } },
+        { key: { text: 'Payment status' }, value: {  html: 'Additional payment requested' } },
+        { key: { text: 'Fee to pay' }, value: { html: '£10' } },
+        { key: { text: 'Asylum Support reference number' }, value: { html: 'supportRefNumber' } }
+      ];
+
+      await getAppealDetailsViewer(req as Request, res as Response, next);
+      expect(res.render).to.have.been.calledWith('templates/details-with-fees-viewer.njk', {
+        title: i18n.pages.detailViewers.appealDetails.title,
+        aboutTheAppealTitle: i18n.pages.checkYourAnswers.rowTitles.aboutTheAppeal,
+        personalDetailsTitle: i18n.pages.checkYourAnswers.rowTitles.personalDetails,
+        feeDetailsTitle: i18n.pages.checkYourAnswers.rowTitles.feeDetails,
+        previousPage: paths.common.overview,
+        data: expectedSummaryRowsWithDlrmFeeRemission
+      });
+    });
+
+    it('should render detail-viewers/details-with-fees-viewer.njk with history entries when dlrm fee remission and fee refund flags are ON and feeUpdateTribunalAction is additionalPayment with previousFeeAmount', async () => {
+      sandbox.stub(LaunchDarklyService.prototype, 'getVariation')
+        .withArgs(req as Request, FEATURE_FLAGS.DLRM_FEE_REMISSION_FEATURE_FLAG, false).resolves(true)
+        .withArgs(req as Request, FEATURE_FLAGS.DLRM_REFUND_FEATURE_FLAG, false).resolves(true);
+      req.session.appeal.paAppealTypeAipPaymentOption = 'payLater';
+      req.session.appeal.application.remissionOption = 'asylumSupportFromHo';
+      req.session.appeal.application.asylumSupportRefNumber = 'supportRefNumber';
+      req.session.appeal.application.feeUpdateReason = 'decisionTypeChanged';
+      req.session.appeal.feeWithHearing = '140';
+      req.session.appeal.paymentStatus = 'Paid';
+      req.session.appeal.newFeeAmount = '1400';
+      req.session.appeal.previousFeeAmountGbp = '800';
+      req.session.appeal.application.paidAmount = '1400';
+      req.session.appeal.application.remissionDecision = 'approved';
+      req.session.appeal.application.feeUpdateTribunalAction = 'additionalPayment';
+      req.session.appeal.application.manageFeeRequestedAmount = '1000';
+
+      expectedSummaryRowsWithDlrmFeeRemission.feeDetailsRows = [
+        { key: { text: 'Fee amount' }, value: { html: '£14' } },
+        { key: { text: 'Fee amount paid' }, value: { html: '£8' } },
+        { key: { text: 'Reason for fee change' }, value: { html: 'Decision type changed' } },
+        { key: { text: 'Payment status' }, value: {  html: 'Additional payment requested' } },
+        { key: { text: 'Fee to pay' }, value: { html: '£10' } },
+        { key: { text: 'Asylum Support reference number' }, value: { html: 'supportRefNumber' } }
+      ];
+
+      await getAppealDetailsViewer(req as Request, res as Response, next);
+      expect(res.render).to.have.been.calledWith('templates/details-with-fees-viewer.njk', {
+        title: i18n.pages.detailViewers.appealDetails.title,
+        aboutTheAppealTitle: i18n.pages.checkYourAnswers.rowTitles.aboutTheAppeal,
+        personalDetailsTitle: i18n.pages.checkYourAnswers.rowTitles.personalDetails,
+        feeDetailsTitle: i18n.pages.checkYourAnswers.rowTitles.feeDetails,
+        previousPage: paths.common.overview,
+        data: expectedSummaryRowsWithDlrmFeeRemission
+      });
+    });
+
+    it('should render detail-viewers/details-with-fees-viewer.njk with history entries when dlrm fee remission and fee refund flags are ON and feeUpdateTribunalAction is refund', async () => {
+      sandbox.stub(LaunchDarklyService.prototype, 'getVariation')
+        .withArgs(req as Request, FEATURE_FLAGS.DLRM_FEE_REMISSION_FEATURE_FLAG, false).resolves(true)
+        .withArgs(req as Request, FEATURE_FLAGS.DLRM_REFUND_FEATURE_FLAG, false).resolves(true);
+      req.session.appeal.paAppealTypeAipPaymentOption = 'payLater';
+      req.session.appeal.application.remissionOption = 'asylumSupportFromHo';
+      req.session.appeal.application.asylumSupportRefNumber = 'supportRefNumber';
+      req.session.appeal.application.feeUpdateReason = 'feeRemissionChanged';
+      req.session.appeal.feeWithHearing = '140';
+      req.session.appeal.paymentStatus = 'Paid';
+      req.session.appeal.newFeeAmount = '1400';
+      req.session.appeal.application.paidAmount = '1400';
+      req.session.appeal.application.remissionDecision = 'approved';
+      req.session.appeal.application.feeUpdateTribunalAction = 'refund';
+      req.session.appeal.application.manageFeeRefundedAmount = '1000';
+
+      expectedSummaryRowsWithDlrmFeeRemission.feeDetailsRows = [
+        { key: { text: 'Fee amount' }, value: { html: '£14' } },
+        { key: { text: 'Fee amount paid' }, value: { html: '£14' } },
+        { key: { text: 'Reason for fee change' }, value: { html: 'Fee remission changed' } },
+        { key: { text: 'Payment status' }, value: {  html: 'To be refunded' } },
+        { key: { text: 'Amount to be refunded' }, value: { html: '£10' } },
+        { key: { text: 'Asylum Support reference number' }, value: { html: 'supportRefNumber' } }
+      ];
+
+      await getAppealDetailsViewer(req as Request, res as Response, next);
+      expect(res.render).to.have.been.calledWith('templates/details-with-fees-viewer.njk', {
+        title: i18n.pages.detailViewers.appealDetails.title,
+        aboutTheAppealTitle: i18n.pages.checkYourAnswers.rowTitles.aboutTheAppeal,
+        personalDetailsTitle: i18n.pages.checkYourAnswers.rowTitles.personalDetails,
+        feeDetailsTitle: i18n.pages.checkYourAnswers.rowTitles.feeDetails,
+        previousPage: paths.common.overview,
+        data: expectedSummaryRowsWithDlrmFeeRemission
+      });
+    });
+
+    it('should render detail-viewers/details-with-fees-viewer.njk with history entries when dlrm fee remission and fee refund flags are ON and feeUpdateTribunalAction is refund with previousFeeAmount', async () => {
+      sandbox.stub(LaunchDarklyService.prototype, 'getVariation')
+        .withArgs(req as Request, FEATURE_FLAGS.DLRM_FEE_REMISSION_FEATURE_FLAG, false).resolves(true)
+        .withArgs(req as Request, FEATURE_FLAGS.DLRM_REFUND_FEATURE_FLAG, false).resolves(true);
+      req.session.appeal.paAppealTypeAipPaymentOption = 'payLater';
+      req.session.appeal.application.remissionOption = 'asylumSupportFromHo';
+      req.session.appeal.application.asylumSupportRefNumber = 'supportRefNumber';
+      req.session.appeal.application.feeUpdateReason = 'feeRemissionChanged';
+      req.session.appeal.feeWithHearing = '140';
+      req.session.appeal.paymentStatus = 'Paid';
+      req.session.appeal.newFeeAmount = '1400';
+      req.session.appeal.previousFeeAmountGbp = '800';
+      req.session.appeal.application.paidAmount = '1400';
+      req.session.appeal.application.remissionDecision = 'approved';
+      req.session.appeal.application.feeUpdateTribunalAction = 'refund';
+      req.session.appeal.application.manageFeeRefundedAmount = '1000';
+
+      expectedSummaryRowsWithDlrmFeeRemission.feeDetailsRows = [
+        { key: { text: 'Fee amount' }, value: { html: '£14' } },
+        { key: { text: 'Fee amount paid' }, value: { html: '£8' } },
+        { key: { text: 'Reason for fee change' }, value: { html: 'Fee remission changed' } },
+        { key: { text: 'Payment status' }, value: {  html: 'To be refunded' } },
+        { key: { text: 'Amount to be refunded' }, value: { html: '£10' } },
+        { key: { text: 'Asylum Support reference number' }, value: { html: 'supportRefNumber' } }
+      ];
+
+      await getAppealDetailsViewer(req as Request, res as Response, next);
+      expect(res.render).to.have.been.calledWith('templates/details-with-fees-viewer.njk', {
+        title: i18n.pages.detailViewers.appealDetails.title,
+        aboutTheAppealTitle: i18n.pages.checkYourAnswers.rowTitles.aboutTheAppeal,
+        personalDetailsTitle: i18n.pages.checkYourAnswers.rowTitles.personalDetails,
+        feeDetailsTitle: i18n.pages.checkYourAnswers.rowTitles.feeDetails,
+        previousPage: paths.common.overview,
+        data: expectedSummaryRowsWithDlrmFeeRemission
+      });
+    });
+
+    it('should render detail-viewers/details-with-fees-viewer.njk with history entries when dlrm fee remission and fee refund flags are ON and feeUpdateTribunalAction is no noAction', async () => {
+      sandbox.stub(LaunchDarklyService.prototype, 'getVariation')
+        .withArgs(req as Request, FEATURE_FLAGS.DLRM_FEE_REMISSION_FEATURE_FLAG, false).resolves(true)
+        .withArgs(req as Request, FEATURE_FLAGS.DLRM_REFUND_FEATURE_FLAG, false).resolves(true);
+      req.session.appeal.paAppealTypeAipPaymentOption = 'payLater';
+      req.session.appeal.application.remissionOption = 'asylumSupportFromHo';
+      req.session.appeal.application.asylumSupportRefNumber = 'supportRefNumber';
+      req.session.appeal.application.feeUpdateReason = 'appealNotValid';
+      req.session.appeal.feeWithHearing = '140';
+      req.session.appeal.paymentStatus = 'Paid';
+      req.session.appeal.newFeeAmount = '1400';
+      req.session.appeal.application.paidAmount = '1400';
+      req.session.appeal.application.remissionDecision = 'approved';
+      req.session.appeal.application.feeUpdateTribunalAction = 'noAction';
+
+      expectedSummaryRowsWithDlrmFeeRemission.feeDetailsRows = [
+        { key: { text: 'Fee amount' }, value: { html: '£14' } },
+        { key: { text: 'Fee amount paid' }, value: { html: '£14' } },
+        { key: { text: 'Reason for fee change' }, value: { html: 'Appeal not valid' } },
+        { key: { text: 'Payment status' }, value: {  html: 'Paid' } },
+        { key: { text: 'Asylum Support reference number' }, value: { html: 'supportRefNumber' } }
+      ];
+
+      await getAppealDetailsViewer(req as Request, res as Response, next);
+      expect(res.render).to.have.been.calledWith('templates/details-with-fees-viewer.njk', {
+        title: i18n.pages.detailViewers.appealDetails.title,
+        aboutTheAppealTitle: i18n.pages.checkYourAnswers.rowTitles.aboutTheAppeal,
+        personalDetailsTitle: i18n.pages.checkYourAnswers.rowTitles.personalDetails,
+        feeDetailsTitle: i18n.pages.checkYourAnswers.rowTitles.feeDetails,
+        previousPage: paths.common.overview,
+        data: expectedSummaryRowsWithDlrmFeeRemission
+      });
+    });
+
+    it('should render detail-viewers/details-with-fees-viewer.njk with history entries when dlrm fee remission and fee refund flags are ON and feeUpdateTribunalAction is no noAction with previousFeeAmount', async () => {
+      sandbox.stub(LaunchDarklyService.prototype, 'getVariation')
+        .withArgs(req as Request, FEATURE_FLAGS.DLRM_FEE_REMISSION_FEATURE_FLAG, false).resolves(true)
+        .withArgs(req as Request, FEATURE_FLAGS.DLRM_REFUND_FEATURE_FLAG, false).resolves(true);
+      req.session.appeal.paAppealTypeAipPaymentOption = 'payLater';
+      req.session.appeal.application.remissionOption = 'asylumSupportFromHo';
+      req.session.appeal.application.asylumSupportRefNumber = 'supportRefNumber';
+      req.session.appeal.application.feeUpdateReason = 'appealNotValid';
+      req.session.appeal.feeWithHearing = '140';
+      req.session.appeal.paymentStatus = 'Paid';
+      req.session.appeal.newFeeAmount = '1400';
+      req.session.appeal.previousFeeAmountGbp = '800';
+
+      req.session.appeal.application.paidAmount = '1400';
+      req.session.appeal.application.remissionDecision = 'approved';
+      req.session.appeal.application.feeUpdateTribunalAction = 'noAction';
+
+      expectedSummaryRowsWithDlrmFeeRemission.feeDetailsRows = [
+        { key: { text: 'Fee amount' }, value: { html: '£14' } },
+        { key: { text: 'Fee amount paid' }, value: { html: '£8' } },
+        { key: { text: 'Reason for fee change' }, value: { html: 'Appeal not valid' } },
+        { key: { text: 'Payment status' }, value: {  html: 'Paid' } },
+        { key: { text: 'Asylum Support reference number' }, value: { html: 'supportRefNumber' } }
+      ];
+
+      await getAppealDetailsViewer(req as Request, res as Response, next);
+      expect(res.render).to.have.been.calledWith('templates/details-with-fees-viewer.njk', {
+        title: i18n.pages.detailViewers.appealDetails.title,
+        aboutTheAppealTitle: i18n.pages.checkYourAnswers.rowTitles.aboutTheAppeal,
+        personalDetailsTitle: i18n.pages.checkYourAnswers.rowTitles.personalDetails,
+        feeDetailsTitle: i18n.pages.checkYourAnswers.rowTitles.feeDetails,
+        previousPage: paths.common.overview,
+        data: expectedSummaryRowsWithDlrmFeeRemission
+      });
+    });
+
+    it('should render detail-viewers/details-with-fees-viewer.njk with history entries when dlrm fee remission and fee refund flags are ON and feeUpdateTribunalAction is no noAction but it has no remission', async () => {
+      sandbox.stub(LaunchDarklyService.prototype, 'getVariation')
+        .withArgs(req as Request, FEATURE_FLAGS.DLRM_FEE_REMISSION_FEATURE_FLAG, false).resolves(true)
+        .withArgs(req as Request, FEATURE_FLAGS.DLRM_REFUND_FEATURE_FLAG, false).resolves(true);
+      req.session.appeal.paAppealTypeAipPaymentOption = 'payLater';
+      req.session.appeal.feeWithHearing = '140';
+      req.session.appeal.paymentStatus = 'Paid';
+      req.session.appeal.newFeeAmount = '1400';
+      req.session.appeal.application.paidAmount = '1400';
+      req.session.appeal.application.feeUpdateTribunalAction = 'noAction';
+      req.session.appeal.application.feeUpdateReason = 'appealWithdrawn';
+
+      expectedSummaryRowsWithDlrmFeeRemission.feeDetailsRows = [
+        { key: { text: 'Fee amount' }, value: { html: '£14' } },
+        { key: { text: 'Fee amount paid' }, value: { html: '£14' } },
+        { key: { text: 'Reason for fee change' }, value: { html: 'Appeal withdrawn' } },
+        { key: { text: 'Payment status' }, value: {  html: 'Paid' } }
+      ];
+
+      await getAppealDetailsViewer(req as Request, res as Response, next);
+      expect(res.render).to.have.been.calledWith('templates/details-with-fees-viewer.njk', {
+        title: i18n.pages.detailViewers.appealDetails.title,
+        aboutTheAppealTitle: i18n.pages.checkYourAnswers.rowTitles.aboutTheAppeal,
+        personalDetailsTitle: i18n.pages.checkYourAnswers.rowTitles.personalDetails,
+        feeDetailsTitle: i18n.pages.checkYourAnswers.rowTitles.feeDetails,
+        previousPage: paths.common.overview,
+        data: expectedSummaryRowsWithDlrmFeeRemission
+      });
     });
   });
 
@@ -1706,6 +2187,304 @@ describe('Detail viewer Controller', () => {
         getHearingNoticeViewer(req as Request, res as Response, next);
         expect(next).to.have.been.calledWith(error);
       });
+    });
+  });
+
+  describe('should render reheard notice of hearing', () => {
+    const document = {
+      fileId: 'a3d396eb-277d-4b66-81c8-627f57212ec8',
+      name: 'PA 50002 2021-perez-hearing-notice.PDF',
+      id: '1',
+      tag: 'hearingNotice',
+      dateUploaded: '2021-06-01'
+    };
+
+    const reheardHearingDocumentsCollection = {
+      'id': '1',
+      'value': {
+        'reheardHearingDocs': [
+          {
+            fileId: 'a3d396eb-277d-4b66-81c8-627f57212ec8',
+            name: 'PA 50002 2021-perez-hearing-notice.PDF',
+            id: '1',
+            tag: 'reheardHearingNotice',
+            dateUploaded: '2021-06-01'
+          }
+        ]
+      }
+    };
+    it('should render templates/details-viewer.njk with hearing notice document', () => {
+      req.session.appeal.reheardHearingDocumentsCollection = [reheardHearingDocumentsCollection];
+      req.params.id = 'a3d396eb-277d-4b66-81c8-627f57212ec8';
+      const expectedSummaryRows = [
+        {
+          key: { text: i18n.pages.detailViewers.common.dateUploaded },
+          value: { html: '01 June 2021' }
+        },
+        {
+          key: { text: i18n.pages.detailViewers.common.document },
+          value: { html: `<a class='govuk-link' target='_blank' rel='noopener noreferrer' href='/view/document/${document.fileId}'>PA 50002 2021-perez-hearing-notice(PDF)</a>` }
+        }];
+
+      getHearingNoticeViewer(req as Request, res as Response, next);
+      expect(res.render).to.have.been.calledWith('templates/details-viewer.njk', {
+        title: i18n.pages.detailViewers.hearingNotice.title,
+        data: expectedSummaryRows,
+        previousPage: paths.common.overview
+      });
+
+      it('should catch error and call next with it', () => {
+        req.session.appeal.hearingDocuments = [document];
+        const error = new Error('an error');
+        res.render = sandbox.stub().throws(error);
+
+        getHearingNoticeViewer(req as Request, res as Response, next);
+        expect(next).to.have.been.calledWith(error);
+      });
+    });
+  });
+
+  describe('should render latest notice of hearing', () => {
+    const document = {
+      fileId: 'a3d396eb-277d-4b66-81c8-627f57212ec8',
+      name: 'PA 50002 2021-perez-hearing-notice.PDF',
+      id: '1',
+      tag: 'hearingNotice',
+      dateUploaded: '2021-06-01'
+    };
+    const documentRelisted = {
+      fileId: 'a3d396eb-277d-4b66-81c8-627f57212ec8',
+      name: 'PA 50002 2021-perez-hearing-notice.PDF',
+      id: '1',
+      tag: 'hearingNoticeRelisted',
+      dateUploaded: '2021-06-01'
+    };
+
+    const reheardHearingDocumentsCollection = {
+      'id': '1',
+      'value': {
+        'reheardHearingDocs': [
+          {
+            fileId: 'a3d396eb-277d-4b66-81c8-627f57212ec7',
+            name: 'PA 50002 2021-perez-hearing-notice.PDF',
+            id: '1',
+            tag: 'reheardHearingNotice',
+            dateUploaded: '2021-06-02'
+          },
+          {
+            fileId: 'a3d396eb-277d-4b66-81c8-627f57212ec7',
+            name: 'PA 50002 2021-perez-hearing-notice.PDF',
+            id: '2',
+            tag: 'reheardHearingNoticeRelisted',
+            dateUploaded: '2021-06-03'
+          }
+        ]
+      }
+    };
+    it('should render hearing notice if latest', () => {
+      req.session.appeal.reheardHearingDocumentsCollection = [reheardHearingDocumentsCollection];
+      document.dateUploaded = '2021-06-05';
+      req.session.appeal.hearingDocuments = [document, documentRelisted];
+      req.params.id = 'latest';
+      const expectedSummaryRows = [
+        {
+          key: { text: i18n.pages.detailViewers.common.dateUploaded },
+          value: { html: '05 June 2021' }
+        },
+        {
+          key: { text: i18n.pages.detailViewers.common.document },
+          value: { html: `<a class='govuk-link' target='_blank' rel='noopener noreferrer' href='/view/document/a3d396eb-277d-4b66-81c8-627f57212ec8'>PA 50002 2021-perez-hearing-notice(PDF)</a>` }
+        }];
+
+      getHearingNoticeViewer(req as Request, res as Response, next);
+      expect(res.render).to.have.been.calledWith('templates/details-viewer.njk', {
+        title: i18n.pages.detailViewers.hearingNotice.title,
+        data: expectedSummaryRows,
+        previousPage: paths.common.overview
+      });
+
+      it('should render reheard hearing notice if latest', () => {
+        req.session.appeal.reheardHearingDocumentsCollection = [reheardHearingDocumentsCollection];
+        req.session.appeal.hearingDocuments = [document];
+        req.params.id = 'latest';
+        const expectedSummaryRows = [
+          {
+            key: { text: i18n.pages.detailViewers.common.dateUploaded },
+            value: { html: '01 June 2021' }
+          },
+          {
+            key: { text: i18n.pages.detailViewers.common.document },
+            value: { html: `<a class='govuk-link' target='_blank' rel='noopener noreferrer' href='/view/document/a3d396eb-277d-4b66-81c8-627f57212ec7'>PA 50002 2021-perez-hearing-notice(PDF)</a>` }
+          }];
+
+        getHearingNoticeViewer(req as Request, res as Response, next);
+        expect(res.render).to.have.been.calledWith('templates/details-viewer.njk', {
+          title: i18n.pages.detailViewers.hearingNotice.title,
+          data: expectedSummaryRows,
+          previousPage: paths.common.overview
+        });
+
+        it('should catch error and call next with it', () => {
+          req.session.appeal.hearingDocuments = [document];
+          const error = new Error('an error');
+          res.render = sandbox.stub().throws(error);
+
+          getHearingNoticeViewer(req as Request, res as Response, next);
+          expect(next).to.have.been.calledWith(error);
+        });
+      });
+    });
+    it('should render hearing notice if latest', () => {
+      req.session.appeal.reheardHearingDocumentsCollection = [reheardHearingDocumentsCollection];
+      document.dateUploaded = '2021-06-05';
+      req.session.appeal.hearingDocuments = [document, documentRelisted];
+      req.params.id = 'latest';
+      const expectedSummaryRows = [
+        {
+          key: { text: i18n.pages.detailViewers.common.dateUploaded },
+          value: { html: '05 June 2021' }
+        },
+        {
+          key: { text: i18n.pages.detailViewers.common.document },
+          value: { html: `<a class='govuk-link' target='_blank' rel='noopener noreferrer' href='/view/document/a3d396eb-277d-4b66-81c8-627f57212ec8'>PA 50002 2021-perez-hearing-notice(PDF)</a>` }
+        }];
+
+      getHearingNoticeViewer(req as Request, res as Response, next);
+      expect(res.render).to.have.been.calledWith('templates/details-viewer.njk', {
+        title: i18n.pages.detailViewers.hearingNotice.title,
+        data: expectedSummaryRows,
+        previousPage: paths.common.overview
+      });
+    });
+    it('should render old stored reheard edited hearing notice if latest', () => {
+      req.session.appeal.reheardHearingDocumentsCollection = [reheardHearingDocumentsCollection];
+      req.session.appeal.hearingDocuments = [document];
+      documentRelisted.dateUploaded = '2022-06-01';
+      req.session.appeal.reheardHearingDocuments = [documentRelisted];
+      req.params.id = 'latest';
+      const expectedSummaryRows = [
+        {
+          key: { text: i18n.pages.detailViewers.common.dateUploaded },
+          value: { html: '01 June 2022' }
+        },
+        {
+          key: { text: i18n.pages.detailViewers.common.document },
+          value: { html: `<a class='govuk-link' target='_blank' rel='noopener noreferrer' href='/view/document/a3d396eb-277d-4b66-81c8-627f57212ec8'>PA 50002 2021-perez-hearing-notice(PDF)</a>` }
+        }];
+
+      getHearingNoticeViewer(req as Request, res as Response, next);
+      expect(res.render).to.have.been.calledWith('templates/details-viewer.njk', {
+        title: i18n.pages.detailViewers.hearingNotice.title,
+        data: expectedSummaryRows,
+        previousPage: paths.common.overview
+      });
+    });
+  });
+
+  describe('findDocumentInReheardHearingDocCollection', () => {
+    it('should return the document if it exists in the collection', () => {
+      const collections = [
+        { value: { reheardHearingDocs: [{ fileId: '123' }] } }
+      ];
+      const result = findDocumentInReheardHearingDocCollection(collections, '123');
+      expect(result).to.deep.equal({ fileId: '123' });
+    });
+
+    it('should return undefined if the document does not exist in the collection', () => {
+      const collections = [
+        { value: { reheardHearingDocs: [{ fileId: '123' }] } }
+      ];
+      const result = findDocumentInReheardHearingDocCollection(collections, '456');
+      expect(result).to.be.undefined;
+    });
+
+    it('should handle collections with undefined values', () => {
+      const collections = [
+        { value: undefined },
+        { value: { reheardHearingDocs: [{ fileId: '123' }] } }
+      ];
+      const result = findDocumentInReheardHearingDocCollection(collections, '123');
+      expect(result).to.deep.equal({ fileId: '123' });
+    });
+
+    it('should handle empty collections', () => {
+      const collections: any[] = [];
+      const result = findDocumentInReheardHearingDocCollection(collections, '123');
+      expect(result).to.be.undefined;
+    });
+  });
+
+  describe('getHearingNoticeDocument', () => {
+    it('should return the document if it exists in primary hearing documents', () => {
+      const req = {
+        session: {
+          appeal: {
+            hearingDocuments: [{ fileId: '123' }],
+            reheardHearingDocumentsCollection: []
+          }
+        },
+        params: { id: '123' }
+      };
+      const result = getHearingNoticeDocument(req);
+      expect(result).to.deep.equal({ fileId: '123' });
+    });
+
+    it('should return the document if it exists in reheard hearing documents', () => {
+      const req = {
+        session: {
+          appeal: {
+            hearingDocuments: [],
+            reheardHearingDocumentsCollection: [
+              { value: { reheardHearingDocs: [{ fileId: '123' }] } }
+            ]
+          }
+        },
+        params: { id: '123' }
+      };
+      const result = getHearingNoticeDocument(req);
+      expect(result).to.deep.equal({ fileId: '123' });
+    });
+
+    it('should throw an error if the document does not exist in any collection', () => {
+      const req = {
+        session: {
+          appeal: {
+            hearingDocuments: [],
+            reheardHearingDocumentsCollection: []
+          }
+        },
+        params: { id: '123' }
+      };
+      expect(() => getHearingNoticeDocument(req)).to.throw('No hearing notice with {fileId: 123} found.');
+    });
+
+    it('should handle undefined reheard hearing documents collection', () => {
+      const req = {
+        session: {
+          appeal: {
+            hearingDocuments: [],
+            reheardHearingDocumentsCollection: undefined
+          }
+        },
+        params: { id: '123' }
+      };
+      expect(() => getHearingNoticeDocument(req)).to.throw('No hearing notice with {fileId: 123} found.');
+    });
+
+    it('should handle undefined primary hearing documents', () => {
+      const req = {
+        session: {
+          appeal: {
+            hearingDocuments: undefined,
+            reheardHearingDocumentsCollection: [
+              { value: { reheardHearingDocs: [{ fileId: '123' }] } }
+            ]
+          }
+        },
+        params: { id: '123' }
+      };
+      const result = getHearingNoticeDocument(req);
+      expect(result).to.deep.equal({ fileId: '123' });
     });
   });
 
@@ -4512,6 +5291,136 @@ describe('Detail viewer Controller', () => {
     });
   });
 
+  describe('should render updated decision and reasons page', () => {
+    const documents = [
+      {
+        fileId: '976fa409-4aab-40a4-a3f9-0c918f7293c8',
+        name: 'PA 50012 2022-bond20-Decision-and-reasons-FINAL.pdf',
+        id: '2',
+        tag: 'finalDecisionAndReasonsPdf',
+        dateUploaded: '2022-01-26'
+      },
+      {
+        fileId: '723e6179-9a9d-47d9-9c76-80ccc23917db',
+        name: 'PA 50012 2022-bond20-Decision-and-reasons-Cover-letter.PDF',
+        id: '1',
+        tag: 'decisionAndReasonsCoverLetter',
+        dateUploaded: '2022-01-26'
+      }
+    ];
+    const updatedDecisionAndReasons: DecisionAndReasons[] = [
+      {
+        id: '2',
+        documentAndReasonsDocument: {
+          fileId: '976fa409-4aab-40a4-a3f9-0c918f7293c8',
+          name: 'PA 50012 2022-bond20-Decision-and-reasons-AMENDED.pdf'
+        },
+        updatedDecisionDate: '2023-12-15',
+        dateCoverLetterDocumentUploaded: '2023-12-15',
+        dateDocumentAndReasonsDocumentUploaded: '2023-12-15',
+        summariseChanges: 'Summarise explanation',
+        coverLetterDocument: {
+          fileId: '723e6179-9a9d-47d9-9c76-80ccc23917db',
+          name: 'PA 50012 2022-bond20-Decision-and-reasons-Cover-letter-AMENDED.PDF'
+        }
+      },
+      {
+        id: '1',
+        updatedDecisionDate: '2023-10-15',
+        dateCoverLetterDocumentUploaded: '2023-10-15',
+        coverLetterDocument: {
+          fileId: '723e6179-9a9d-47d9-9c76-80ccc23917db',
+          name: 'PA 50012 2022-bond20-Decision-and-reasons-Cover-letter-AMENDED.PDF'
+        }
+      }
+    ];
+    it('should render templates/updated-details-viewer.njk with updated decision and reasons collection', async () => {
+      req.session.appeal.finalDecisionAndReasonsDocuments = documents;
+      req.session.appeal.updatedDecisionAndReasons = updatedDecisionAndReasons;
+      const expectedSummaryRows = {
+        decision: [
+          {
+            key: { text: i18n.pages.detailViewers.common.dateUploaded },
+            value: { html: '26 January 2022' }
+          },
+          {
+            key: { text: i18n.pages.detailViewers.common.document },
+            value: { html: `<a class='govuk-link' target='_blank' rel='noopener noreferrer' href='/view/document/723e6179-9a9d-47d9-9c76-80ccc23917db'>PA 50012 2022-bond20-Decision-and-reasons-Cover-letter(PDF)</a>` }
+          },
+          {
+            key: { text: i18n.pages.detailViewers.common.dateUploaded },
+            value: { html: '26 January 2022' }
+          },
+          {
+            key: { text: i18n.pages.detailViewers.common.document },
+            value: { html: `<a class='govuk-link' target='_blank' rel='noopener noreferrer' href='/view/document/976fa409-4aab-40a4-a3f9-0c918f7293c8'>PA 50012 2022-bond20-Decision-and-reasons-FINAL(PDF)</a>` }
+          }
+        ]
+      };
+
+      const expectedSummaryList: SummaryList[] = [
+        {
+          summaryRows: [
+            {
+              key: { text: i18n.pages.detailViewers.common.dateUploaded },
+              value: { html: '15 December 2023' }
+            },
+            {
+              key: { text: i18n.pages.detailViewers.common.document },
+              value: { html: `<a class='govuk-link' target='_blank' rel='noopener noreferrer' href='/view/document/723e6179-9a9d-47d9-9c76-80ccc23917db'>PA 50012 2022-bond20-Decision-and-reasons-Cover-letter-AMENDED.PDF</a>` }
+            },
+            {
+              key: { text: i18n.pages.detailViewers.common.dateUploaded },
+              value: { html: '15 December 2023' }
+            },
+            {
+              key: { text: i18n.pages.detailViewers.common.document },
+              value: { html: `<a class='govuk-link' target='_blank' rel='noopener noreferrer' href='/view/document/976fa409-4aab-40a4-a3f9-0c918f7293c8'>PA 50012 2022-bond20-Decision-and-reasons-AMENDED.pdf</a>` }
+            },
+            {
+              key: { text: i18n.pages.detailViewers.decisionsAndReasons.summariseChanges },
+              value: { html: 'Summarise explanation' }
+            }
+          ],
+          title: i18n.pages.detailViewers.decisionsAndReasons.correctedSubTitle + '1'
+        },
+        {
+          summaryRows: [
+            {
+              key: { text: i18n.pages.detailViewers.common.dateUploaded },
+              value: { html: '15 October 2023' }
+            },
+            {
+              key: { text: i18n.pages.detailViewers.common.document },
+              value: { html: `<a class='govuk-link' target='_blank' rel='noopener noreferrer' href='/view/document/723e6179-9a9d-47d9-9c76-80ccc23917db'>PA 50012 2022-bond20-Decision-and-reasons-Cover-letter-AMENDED.PDF</a>` }
+            }
+          ],
+          title: i18n.pages.detailViewers.decisionsAndReasons.correctedSubTitle + '2'
+        }
+      ];
+
+      sandbox.stub(LaunchDarklyService.prototype, 'getVariation').withArgs(req as Request, FEATURE_FLAGS.DLRM_SETASIDE_FEATURE_FLAG, false).resolves(true);
+      await getUpdatedDecisionAndReasonsViewer(req as Request, res as Response, next);
+      expect(res.render).to.have.been.calledWith('templates/updated-details-viewer.njk', {
+        title: i18n.pages.detailViewers.decisionsAndReasons.title,
+        originalSubTitle: i18n.pages.detailViewers.decisionsAndReasons.originalSubTitle,
+        description: i18n.pages.detailViewers.decisionsAndReasons.description,
+        data: expectedSummaryRows,
+        updatedDecisions: expectedSummaryList,
+        previousPage: paths.common.overview
+      });
+
+      it('should catch error and call next with it', async () => {
+        req.session.appeal.finalDecisionAndReasonsDocuments = documents;
+        const error = new Error('an error');
+        res.render = sandbox.stub().throws(error);
+
+        await getUpdatedDecisionAndReasonsViewer(req as Request, res as Response, next);
+        expect(next).to.have.been.calledWith(error);
+      });
+    });
+  });
+
   describe('should render remittal documents page', () => {
     const remittalDocuments: RemittalDetails[] = [
       {
@@ -4622,4 +5531,99 @@ describe('Detail viewer Controller', () => {
     });
   });
 
+  describe('Amount to refund', () => {
+    const fee = { code: 'test', calculated_amount: 80, version: '1' };
+    beforeEach(() => {
+      const historyEvent = {
+        id: 'paymentAppeal',
+        event: {
+          eventName: '',
+          description: ''
+        },
+        user: {
+          id: '',
+          lastName: '',
+          firstName: ''
+        },
+        createdDate: '2021-06-15T14:23:34.581353',
+        caseTypeVersion: 1,
+        state: {
+          id: '',
+          name: ''
+        },
+        data: '' } as HistoryEvent;
+      req.session.appeal.history = [historyEvent];
+    });
+
+    it('should add amount to refund row for approved remission decision if it is not upfront remission', () => {
+      req.session.appeal.application.refundRequested = true;
+      req.session.appeal.application.remissionDecision = 'approved';
+      const feeDetailRows = [];
+
+      addFeeSupportStatus(true, feeDetailRows, req as Request, req.session.appeal.application, fee);
+
+      expect(feeDetailRows).to.be.an('array').that.is.not.empty;
+      expect(feeDetailRows).to.deep.include({
+        'key': {
+          'text': 'Amount to refund'
+        },
+        'value': {
+          'html': '£80'
+        }
+      });
+    });
+
+    it('should add amount to refund row for partiallyApproved remission decision if it is not upfront remission', () => {
+      req.session.appeal.application.refundRequested = true;
+      req.session.appeal.application.remissionDecision = 'partiallyApproved';
+      req.session.appeal.application.amountLeftToPay = '4000';
+      const feeDetailRows = [];
+
+      addFeeSupportStatus(true, feeDetailRows, req as Request, req.session.appeal.application, fee);
+
+      expect(feeDetailRows).to.be.an('array').that.is.not.empty;
+      expect(feeDetailRows).to.deep.include({
+        'key': {
+          'text': 'Amount to refund'
+        },
+        'value': {
+          'html': '£40'
+        }
+      });
+    });
+
+    it('should not add amount to refund row for partiallyApproved remission decision if it is upfront remission', () => {
+      req.session.appeal.application.refundRequested = false;
+      req.session.appeal.application.remissionDecision = 'partiallyApproved';
+      const feeDetailRows = [];
+
+      addFeeSupportStatus(true, feeDetailRows, req as Request, req.session.appeal.application, fee);
+
+      expect(feeDetailRows).to.not.deep.include({
+        'key': {
+          'text': 'Amount to refund'
+        },
+        'value': {
+          'text': '£80'
+        }
+      });
+    });
+
+    it('should not add amount to refund row for approved remission decision if it is upfront remission', () => {
+      req.session.appeal.application.refundRequested = false;
+      req.session.appeal.application.remissionDecision = 'partiallyApproved';
+      const feeDetailRows = [];
+
+      addFeeSupportStatus(true, feeDetailRows, req as Request, req.session.appeal.application, fee);
+
+      expect(feeDetailRows).to.not.deep.include({
+        'key': {
+          'text': 'Amount to refund'
+        },
+        'value': {
+          'text': '£80'
+        }
+      });
+    });
+  });
 });

--- a/test/unit/controllers/task-list.test.ts
+++ b/test/unit/controllers/task-list.test.ts
@@ -165,7 +165,6 @@ describe('Task List Controller', () => {
       } ];
     req.session.appeal.application.appealType = 'protection';
     req.session.appeal.application.decisionHearingFeeOption = 'someThing';
-
     await getTaskList(req as Request, res as Response, next);
     expect(res.render).to.have.been.calledOnce.calledWith('appeal-application/task-list.njk', { data: mockData });
   });

--- a/test/unit/service/launchDarkly-service.test.ts
+++ b/test/unit/service/launchDarkly-service.test.ts
@@ -17,7 +17,6 @@ describe('launchDarkly-service', () => {
     const secondInstance = LaunchDarklyService.getInstance();
 
     expect(firstInstance).eq(secondInstance);
-
     LaunchDarklyService.close();
   });
 });

--- a/test/unit/service/payments-service.test.ts
+++ b/test/unit/service/payments-service.test.ts
@@ -1,4 +1,5 @@
 import { Request, Response } from 'express';
+import { any } from 'joi';
 import * as paymentsApi from '../../../app/api/payments-api';
 import { paths } from '../../../app/paths';
 import { AuthenticationService } from '../../../app/service/authentication-service';
@@ -45,7 +46,11 @@ describe('Payments Service', () => {
       },
       session: {
         appeal: {
-          ccdCaseId: 'aCcdCaseId'
+          ccdCaseId: 'aCcdCaseId',
+          application: {
+            contactDetails: {},
+            personalDetails: {}
+          }
         }
       }
     } as Partial<Request>;
@@ -87,6 +92,7 @@ describe('Payments Service', () => {
 
     it('should initiate a payment if payment reference is present and status is Success initiatePayment', async () => {
       req.session.appeal.paymentReference = 'aRef';
+      req.session.appeal.application.refundConfirmationApplied = false;
       paymentDetailsStub = sandbox.stub(paymentsApi, 'paymentDetails').resolves(JSON.stringify({ status: 'Success' }));
       await paymentService.initiatePayment(req as Request, res as Response, 'aFee');
 

--- a/test/unit/service/update-appeal-service.test.ts
+++ b/test/unit/service/update-appeal-service.test.ts
@@ -27,6 +27,7 @@ describe('update-appeal-service', () => {
   const serviceToken = 'serviceToken';
   const caseId = 'caseId';
   const appealReferenceNumber = 'PA/1234/2022';
+  const ccdReferenceNumberForDisplay = '1111 2222 3333 4444';
 
   beforeEach(async () => {
     sandbox = sinon.createSandbox();
@@ -80,6 +81,7 @@ describe('update-appeal-service', () => {
       'journeyType': 'aip',
       'homeOfficeReferenceNumber': 'A1234567',
       'appealReferenceNumber': 'PA/1234/2022',
+      'ccdReferenceNumberForDisplay': '1111 2222 3333 4444',
       'homeOfficeDecisionDate': '2019-01-02',
       'appellantFamilyName': 'Pedro',
       'appellantGivenNames': 'Jimenez',
@@ -173,7 +175,14 @@ describe('update-appeal-service', () => {
       isInterpreterServicesNeeded: 'false',
       isHearingRoomNeeded: 'true',
       isHearingLoopNeeded: 'true',
-      hearingCentre: 'birmingham'
+      hearingCentre: 'birmingham',
+      feeUpdateTribunalAction: 'refund',
+      feeUpdateReason: 'feeRemissionChanged',
+      manageFeeRefundedAmount: '1000',
+      manageFeeRequestedAmount: '1500',
+      paidAmount: '2000',
+      newFeeAmount: '2000',
+      previousFeeAmountGbp: '2000'
     };
 
   });
@@ -194,6 +203,7 @@ describe('update-appeal-service', () => {
       await updateAppealService.loadAppeal(req as Request);
       expect(req.session.appeal.ccdCaseId).eq(caseId);
       expect(req.session.appeal.appealReferenceNumber).eq(appealReferenceNumber);
+      expect(req.session.appeal.ccdReferenceNumber).eq(ccdReferenceNumberForDisplay);
       expect(req.session.appeal.application.appealType).eq('protection');
       expect(req.session.appeal.application.homeOfficeRefNumber).eq('A1234567');
       expect(req.session.appeal.application.personalDetails.familyName).eq('Pedro');
@@ -229,6 +239,13 @@ describe('update-appeal-service', () => {
       expect(req.session.appeal.application.sponsorFamilyName).eq('ABC XYZ');
       expect(req.session.appeal.application.sponsorNameForDisplay).eq('ABC XYZ');
       expect(req.session.appeal.application.sponsorAuthorisation).eq('ABC XYZ');
+      expect(req.session.appeal.application.feeUpdateTribunalAction).eq('refund');
+      expect(req.session.appeal.application.feeUpdateReason).eq('feeRemissionChanged');
+      expect(req.session.appeal.application.manageFeeRefundedAmount).eq('1000');
+      expect(req.session.appeal.application.manageFeeRequestedAmount).eq('1500');
+      expect(req.session.appeal.application.paidAmount).eq('2000');
+      expect(req.session.appeal.newFeeAmount).eq('2000');
+      expect(req.session.appeal.previousFeeAmountGbp).eq('2000');
     });
 
     it('load time extensions when no time extensions', async () => {
@@ -711,7 +728,7 @@ describe('update-appeal-service', () => {
         emptyApplication.application.contactDetails.email = 'abc@example.net';
         emptyApplication.application.contactDetails.wantsSms = true;
         emptyApplication.application.contactDetails.phone = '07123456789';
-        const caseData = updateAppealService.convertToCcdCaseData(emptyApplication);
+        const caseData = updateAppealService.convertToCcdCaseData(emptyApplication, true, true);
 
         expect(caseData).eql(
           {
@@ -721,6 +738,25 @@ describe('update-appeal-service', () => {
             gwfReferenceNumber: null,
             isHearingLoopNeeded: null,
             isHearingRoomNeeded: null,
+            isLateRemissionRequest: 'No',
+            asylumSupportRefNumber: null,
+            decisionHearingFeeOption: null,
+            feeSupportPersisted: 'No',
+            helpWithFeesOption: null,
+            helpWithFeesRefNumber: null,
+            localAuthorityLetters: null,
+            paAppealTypeAipPaymentOption: null,
+            pcqId: null,
+            refundConfirmationApplied: 'No',
+            refundRequested: 'No',
+            remissionDecision: null,
+            remissionOption: null,
+            rpDcAppealHearingOption: null,
+            lateAsylumSupportRefNumber: null,
+            lateHelpWithFeesOption: null,
+            lateHelpWithFeesRefNumber: null,
+            lateLocalAuthorityLetters: null,
+            lateRemissionOption: null,
             journeyType: 'aip',
             subscriptions: [
               {
@@ -740,7 +776,7 @@ describe('update-appeal-service', () => {
       it('converts contactDetails only email', () => {
         emptyApplication.application.contactDetails.wantsEmail = true;
         emptyApplication.application.contactDetails.email = 'abc@example.net';
-        const caseData = updateAppealService.convertToCcdCaseData(emptyApplication);
+        const caseData = updateAppealService.convertToCcdCaseData(emptyApplication, true, true);
 
         expect(caseData).eql(
           {
@@ -749,6 +785,25 @@ describe('update-appeal-service', () => {
             gwfReferenceNumber: null,
             isHearingLoopNeeded: null,
             isHearingRoomNeeded: null,
+            isLateRemissionRequest: 'No',
+            asylumSupportRefNumber: null,
+            decisionHearingFeeOption: null,
+            feeSupportPersisted: 'No',
+            helpWithFeesOption: null,
+            helpWithFeesRefNumber: null,
+            localAuthorityLetters: null,
+            paAppealTypeAipPaymentOption: null,
+            pcqId: null,
+            refundConfirmationApplied: 'No',
+            refundRequested: 'No',
+            remissionDecision: null,
+            remissionOption: null,
+            rpDcAppealHearingOption: null,
+            lateAsylumSupportRefNumber: null,
+            lateHelpWithFeesOption: null,
+            lateHelpWithFeesRefNumber: null,
+            lateLocalAuthorityLetters: null,
+            lateRemissionOption: null,
             appellantEmailAddress: 'abc@example.net',
             subscriptions: [
               {
@@ -768,7 +823,7 @@ describe('update-appeal-service', () => {
       it('converts contactDetails only phone', () => {
         emptyApplication.application.contactDetails.wantsSms = true;
         emptyApplication.application.contactDetails.phone = '07123456789';
-        const caseData = updateAppealService.convertToCcdCaseData(emptyApplication);
+        const caseData = updateAppealService.convertToCcdCaseData(emptyApplication, true, true);
 
         expect(caseData).eql(
           {
@@ -778,6 +833,25 @@ describe('update-appeal-service', () => {
             gwfReferenceNumber: null,
             isHearingLoopNeeded: null,
             isHearingRoomNeeded: null,
+            isLateRemissionRequest: 'No',
+            asylumSupportRefNumber: null,
+            decisionHearingFeeOption: null,
+            feeSupportPersisted: 'No',
+            helpWithFeesOption: null,
+            helpWithFeesRefNumber: null,
+            localAuthorityLetters: null,
+            paAppealTypeAipPaymentOption: null,
+            pcqId: null,
+            refundConfirmationApplied: 'No',
+            refundRequested: 'No',
+            remissionDecision: null,
+            remissionOption: null,
+            rpDcAppealHearingOption: null,
+            lateAsylumSupportRefNumber: null,
+            lateHelpWithFeesOption: null,
+            lateHelpWithFeesRefNumber: null,
+            lateLocalAuthorityLetters: null,
+            lateRemissionOption: null,
             subscriptions: [
               {
                 value: {
@@ -797,7 +871,7 @@ describe('update-appeal-service', () => {
     it('converts time extension when no previous time extensions or current time extensions', () => {
       emptyApplication.askForMoreTime = {};
 
-      const caseData = updateAppealService.convertToCcdCaseData(emptyApplication);
+      const caseData = updateAppealService.convertToCcdCaseData(emptyApplication, true);
 
       expect(caseData).contains(
         {
@@ -832,7 +906,7 @@ describe('update-appeal-service', () => {
 
       emptyApplication.documentMap = [{ id: 'fileId', url: 'someurl' }] as DocumentMap[];
 
-      const caseData = updateAppealService.convertToCcdCaseData(emptyApplication);
+      const caseData = updateAppealService.convertToCcdCaseData(emptyApplication, true, true);
 
       expect(caseData).to.deep.eq(
         {
@@ -841,7 +915,26 @@ describe('update-appeal-service', () => {
           'gwfReferenceNumber': null,
           'isHearingLoopNeeded': null,
           'isHearingRoomNeeded': null,
+          'isLateRemissionRequest': 'No',
+          'asylumSupportRefNumber': null,
+          'decisionHearingFeeOption': null,
+          'feeSupportPersisted': 'No',
+          'helpWithFeesOption': null,
+          'helpWithFeesRefNumber': null,
+          'localAuthorityLetters': null,
+          'paAppealTypeAipPaymentOption': null,
+          'pcqId': null,
+          'refundConfirmationApplied': 'No',
+          'refundRequested': 'No',
+          'remissionDecision': null,
+          'remissionOption': null,
+          'lateAsylumSupportRefNumber': null,
+          'lateHelpWithFeesOption': null,
+          'lateHelpWithFeesRefNumber': null,
+          'lateLocalAuthorityLetters': null,
+          'lateRemissionOption': null,
           'reviewTimeExtensionRequired': 'Yes',
+          'rpDcAppealHearingOption': null,
           'submitTimeExtensionReason': 'more time reason',
           'submitTimeExtensionEvidence': [
             {
@@ -856,6 +949,7 @@ describe('update-appeal-service', () => {
         }
       );
     });
+
     it('converts time extension to makeAnApplicationEvidence', () => {
       emptyApplication.documentMap = [{ id: 'fileId', url: 'someurl' }] as DocumentMap[];
       emptyApplication.makeAnApplicationEvidence = [
@@ -866,13 +960,31 @@ describe('update-appeal-service', () => {
         }
       ];
 
-      const caseData = updateAppealService.convertToCcdCaseData(emptyApplication);
+      const caseData = updateAppealService.convertToCcdCaseData(emptyApplication, true, true);
       expect(caseData).to.deep.eq({
         'journeyType': 'aip',
         'appellantInUk': 'undefined',
         'gwfReferenceNumber': null,
         'isHearingLoopNeeded': null,
         'isHearingRoomNeeded': null,
+        'asylumSupportRefNumber': null,
+        'decisionHearingFeeOption': null,
+        'feeSupportPersisted': 'No',
+        'helpWithFeesOption': null,
+        'helpWithFeesRefNumber': null,
+        'paAppealTypeAipPaymentOption': null,
+        'pcqId': null,
+        'isLateRemissionRequest': 'No',
+        'localAuthorityLetters': null,
+        'refundRequested': 'No',
+        'remissionDecision': null,
+        'remissionOption': null,
+        'rpDcAppealHearingOption': null,
+        'lateAsylumSupportRefNumber': null,
+        'lateHelpWithFeesOption': null,
+        'lateHelpWithFeesRefNumber': null,
+        'lateLocalAuthorityLetters': null,
+        'lateRemissionOption': null,
         'makeAnApplicationEvidence': [
           {
             'id': 'id',
@@ -882,7 +994,8 @@ describe('update-appeal-service', () => {
               'document_url': 'someurl'
             }
           }
-        ]
+        ],
+        'refundConfirmationApplied': 'No'
       });
     });
     it('converts uploadTheNoticeOfDecisionDocs', () => {
@@ -897,13 +1010,32 @@ describe('update-appeal-service', () => {
         }
       ];
 
-      const caseData = updateAppealService.convertToCcdCaseData(emptyApplication);
+      const caseData = updateAppealService.convertToCcdCaseData(emptyApplication, true, true);
       expect(caseData).to.deep.eq({
         'journeyType': 'aip',
         'appellantInUk': 'undefined',
         'gwfReferenceNumber': null,
         'isHearingLoopNeeded': null,
         'isHearingRoomNeeded': null,
+        'isLateRemissionRequest': 'No',
+        'asylumSupportRefNumber': null,
+        'decisionHearingFeeOption': null,
+        'feeSupportPersisted': 'No',
+        'helpWithFeesOption': null,
+        'helpWithFeesRefNumber': null,
+        'localAuthorityLetters': null,
+        'paAppealTypeAipPaymentOption': null,
+        'pcqId': null,
+        'refundConfirmationApplied': 'No',
+        'refundRequested': 'No',
+        'remissionDecision': null,
+        'remissionOption': null,
+        'rpDcAppealHearingOption': null,
+        'lateAsylumSupportRefNumber': null,
+        'lateHelpWithFeesOption': null,
+        'lateHelpWithFeesRefNumber': null,
+        'lateLocalAuthorityLetters': null,
+        'lateRemissionOption': null,
         'uploadTheNoticeOfDecisionDocs': [
           {
             'id': 'fileId',
@@ -1221,6 +1353,61 @@ describe('update-appeal-service', () => {
       });
     });
 
+    describe('previousRemissionDetails', () => {
+      const caseData: Partial<CaseData> = {
+        previousRemissionDetails:
+        [{
+          id: '1',
+          value: {
+            feeAmount: '2000',
+            amountRemitted: '1000',
+            amountLeftToPay: '1000',
+            feeRemissionType: 'type1',
+            remissionDecision: 'decission1',
+            asylumSupportReference: 'refNumber1',
+            remissionDecisionReason: 'decission',
+            helpWithFeesReferenceNumber: 'refNumber2',
+            helpWithFeesOption: 'helpOption',
+            localAuthorityLetters: [
+              {
+                id: 'fa35dcae-ae4c-462d-9cce-6878326875b0',
+                value: {
+                  tag: 'additionalEvidence',
+                  document: {
+                    document_url: 'http://dm-store:4506/documents/02f4b97c-0dfa-49b1-9262-a6cbd399a7c4',
+                    document_filename: '1135444116_9abd250e95f14a43b5c42d9f72547779-280823-1412-88.pdf',
+                    document_binary_url: 'http://dm-store:4506/documents/02f4b97c-0dfa-49b1-9262-a6cbd399a7c4/binary'
+                  },
+                  dateUploaded: ''
+                }
+              }
+            ]
+          } as RemissionDetailsData
+        }] as RemissionDetailsCollection[]
+      };
+
+      const appeal: Partial<CcdCaseDetails> = {
+        case_data: caseData as CaseData
+      };
+      it('should map previousRemissionDetails', () => {
+        const mappedAppeal = updateAppealService.mapCcdCaseToAppeal(appeal as CcdCaseDetails);
+        expect(mappedAppeal.application.previousRemissionDetails[0].id).to.be.equals('1');
+        expect(mappedAppeal.application.previousRemissionDetails[0].feeAmount).to.be.equals('2000');
+        expect(mappedAppeal.application.previousRemissionDetails[0].amountRemitted).to.be.equals('1000');
+        expect(mappedAppeal.application.previousRemissionDetails[0].amountLeftToPay).to.be.equals('1000');
+        expect(mappedAppeal.application.previousRemissionDetails[0].feeRemissionType).to.be.equals('type1');
+        expect(mappedAppeal.application.previousRemissionDetails[0].remissionDecision).to.be.equals('decission1');
+        expect(mappedAppeal.application.previousRemissionDetails[0].asylumSupportReference).to.be.equals('refNumber1');
+        expect(mappedAppeal.application.previousRemissionDetails[0].remissionDecisionReason).to.be.equals('decission');
+        expect(mappedAppeal.application.previousRemissionDetails[0].helpWithFeesReferenceNumber).to.be.equals('refNumber2');
+        expect(mappedAppeal.application.previousRemissionDetails[0].helpWithFeesOption).to.be.equals('helpOption');
+        expect(mappedAppeal.application.previousRemissionDetails[0].localAuthorityLetters[0].id).to.be.equals('fa35dcae-ae4c-462d-9cce-6878326875b0');
+        expect(mappedAppeal.application.previousRemissionDetails[0].localAuthorityLetters[0].name).to.be.equals('1135444116_9abd250e95f14a43b5c42d9f72547779-280823-1412-88.pdf');
+        expect(mappedAppeal.application.previousRemissionDetails[0].localAuthorityLetters[0].tag).to.be.equals('additionalEvidence');
+
+      });
+    });
+
     describe('ftpaApplicationRespondentDocument', () => {
       const caseData: Partial<CaseData> = {
         'ftpaApplicationRespondentDocument':
@@ -1419,6 +1606,55 @@ describe('update-appeal-service', () => {
     });
   });
 
+  describe('map the refundConfirmationApplied from Yes value', () => {
+    const testData = [
+      {
+        value: 'Yes',
+        expectation: true
+      },
+      {
+        value: 'No',
+        expectation: false
+      },
+      {
+        value: null,
+        expectation: undefined
+      }
+    ];
+
+    testData.forEach(({ value, expectation }) => {
+      it(`mapped value should be ${expectation}`, () => {
+        const caseData: Partial<CaseData> = {
+          'refundConfirmationApplied': value
+        };
+
+        const appeal: Partial<CcdCaseDetails> = {
+          case_data: caseData as CaseData
+        };
+        const mappedAppeal = updateAppealService.mapCcdCaseToAppeal(appeal as CcdCaseDetails);
+        expect(mappedAppeal.application.refundConfirmationApplied).to.be.eq(expectation);
+      });
+    });
+  });
+
+  describe('remissionRejectedDatePlus14days and amountLeftToPay mappings', () => {
+    const caseData: Partial<CaseData> = {
+      'remissionRejectedDatePlus14days': '2022-01-26',
+      'amountLeftToPay': '4000'
+    };
+
+    const appeal: Partial<CcdCaseDetails> = {
+      case_data: caseData as CaseData
+    };
+
+    it('should map remissionRejectedDatePlus14days and amountLeftToPay', () => {
+      const mappedAppeal = updateAppealService.mapCcdCaseToAppeal(appeal as CcdCaseDetails);
+
+      expect(mappedAppeal.application.amountLeftToPay).eq('4000');
+      expect(mappedAppeal.application.remissionRejectedDatePlus14days).eq('2022-01-26');
+    });
+  });
+
   describe('submitEvent', () => {
     let expectedCaseData: Partial<CaseData>;
     let ccdService2: Partial<CcdService>;
@@ -1512,7 +1748,19 @@ describe('update-appeal-service', () => {
                 dateUploaded: '2020-01-01',
                 'description': 'Some evidence 1',
                 'tag': 'additionalEvidence'
-              }]
+              }],
+              lateRemissionOption: 'test',
+              lateAsylumSupportRefNumber: 'test',
+              lateHelpWithFeesOption: 'test',
+              lateHelpWithFeesRefNumber: 'HWF-123',
+              lateLocalAuthorityLetters: [{
+                name: 'somefile.png',
+                fileId: '00000000-0000-0000-0000-000000000000',
+                dateUploaded: '2020-01-01',
+                'description': 'Some evidence 1',
+                'tag': 'additionalEvidence'
+              }],
+              remissionDecision: 'approved'
             } as AppealApplication,
             reasonsForAppeal: {
               applicationReason: 'I\'ve decided to appeal because ...',
@@ -1639,7 +1887,6 @@ describe('update-appeal-service', () => {
         'sponsorGivenNames': 'ABC XYZ',
         'sponsorFamilyName': 'ABC XYZ',
         'sponsorNameForDisplay': 'ABC XYZ',
-        'sponsorAuthorisation': 'ABC XYZ',
         'reasonsForAppealDecision': 'I\'ve decided to appeal because ...',
         'reasonsForAppealDocuments': [
           {

--- a/test/unit/utils/payment-utils.test.ts
+++ b/test/unit/utils/payment-utils.test.ts
@@ -1,6 +1,11 @@
 import { expect } from 'chai';
 import { Request } from 'express';
-import { getFee, payLaterForApplicationNeeded, payNowForApplicationNeeded } from '../../../app/utils/payments-utils';
+import {
+  convertToAmountOfMoneyDividedBy100,
+  getFee,
+  payLaterForApplicationNeeded,
+  payNowForApplicationNeeded
+} from '../../../app/utils/payments-utils';
 import { sinon } from '../../utils/testUtils';
 
 describe('payment-utils', () => {
@@ -113,6 +118,16 @@ describe('payment-utils', () => {
       });
 
       expect(payLater).to.eql(false);
+    });
+  });
+
+  describe('convertToAmountOfMoneyDividedBy100', () => {
+    it('should return correct converted amount of money', () => {
+      expect(convertToAmountOfMoneyDividedBy100('4000')).to.eql('40');
+    });
+
+    it('should throw an error for invalid input', () => {
+      expect(() => convertToAmountOfMoneyDividedBy100('invalid')).to.throw('Amount value is not available');
     });
   });
 });

--- a/test/unit/utils/remission-utils.test.ts
+++ b/test/unit/utils/remission-utils.test.ts
@@ -1,11 +1,21 @@
 import { Request } from 'express';
 import Logger from '../../../app/utils/logger';
-import { appealHasNoRemissionOption, appealHasRemissionOption } from '../../../app/utils/remission-utils';
+import {
+  appealHasNoRemissionOption,
+  appealHasRemissionOption,
+  getDecisionReasonRowForAppealDetails,
+  getFeeSupportStatusForAppealDetails,
+  getPaymentStatusRow,
+  hasFeeRemissionDecision,
+  paymentForAppealHasBeenMade
+} from '../../../app/utils/remission-utils';
+import { addSummaryRow } from '../../../app/utils/summary-list';
+import i18n from '../../../locale/en.json';
 import { expect, sinon } from '../../utils/testUtils';
 
 describe('Remission fields utils', () => {
   let sandbox: sinon.SinonSandbox;
-  let req: Partial<Request>;
+  let req: Request;
   const logger: Logger = new Logger();
 
   beforeEach(() => {
@@ -27,7 +37,7 @@ describe('Remission fields utils', () => {
           logger
         }
       } as any
-    } as Partial<Request>;
+    } as Request;
   });
 
   afterEach(() => {
@@ -98,7 +108,13 @@ describe('Remission fields utils', () => {
       }
     ];
 
-    remissionOptiondata.forEach(({ remissionOption, helpWithFeesOption, helpWithFeesRefNumber, expectedResponse, description }) => {
+    remissionOptiondata.forEach(({
+                                   remissionOption,
+                                   helpWithFeesOption,
+                                   helpWithFeesRefNumber,
+                                   expectedResponse,
+                                   description
+                                 }) => {
       it(`should be ${description}`, () => {
         appeal.application.remissionOption = remissionOption;
         appeal.application.helpWithFeesOption = helpWithFeesOption;
@@ -117,4 +133,310 @@ describe('Remission fields utils', () => {
     expect(appealHasNoRemissionOption(appeal.application)).to.be.deep.equal(true);
   });
 
+  it('check appeal has or has not remission decision', () => {
+    const { appeal } = req.session;
+    const remissionOptiondata = [
+      {
+        remissionDecision: 'approved',
+        expectedResponse: true,
+        description: 'Decision approved'
+      },
+      {
+        remissionDecision: undefined,
+        expectedResponse: false,
+        description: 'Decision does not exists'
+      },
+      {
+        remissionDecision: null,
+        expectedResponse: false,
+        description: 'Decision does not exists'
+      },
+      {
+        remissionDecision: '',
+        expectedResponse: false,
+        description: 'Decision does not exists'
+      }];
+
+    remissionOptiondata.forEach(({
+                                   remissionDecision,
+                                   expectedResponse,
+                                   description
+                                 }) => {
+      it(`should be ${description}`, () => {
+        appeal.application.remissionDecision = remissionDecision;
+        expect(hasFeeRemissionDecision(req)).to.be.deep.equal(expectedResponse);
+      });
+    });
+  });
+
+  it('appeal has no remission option', () => {
+    const { appeal } = req.session;
+    appeal.application.appealType = 'protection';
+    appeal.application.remissionOption = 'noneOfTheseStatements';
+    appeal.application.helpWithFeesOption = 'willPayForAppeal';
+
+    expect(appealHasNoRemissionOption(appeal.application)).to.be.deep.equal(true);
+  });
+
+  it('should return proper fee support status for appeal details', () => {
+    const { appeal } = req.session;
+    const testData = [
+      {
+        remissionDecision: 'approved',
+        expectedResponse: i18n.pages.overviewPage.doThisNext.remissionDecided.feeSupportStatusApproved,
+        description: 'Decision approved'
+      },
+      {
+        remissionDecision: 'partiallyApproved',
+        expectedResponse: i18n.pages.overviewPage.doThisNext.remissionDecided.feeSupportStatusPartiallyApproved,
+        description: 'Decision partiallyApproved'
+      },
+      {
+        remissionDecision: 'rejected',
+        expectedResponse: i18n.pages.overviewPage.doThisNext.remissionDecided.feeSupportStatusRefused,
+        description: 'Decision rejected'
+      },
+      {
+        remissionDecision: undefined,
+        expectedResponse: i18n.pages.overviewPage.doThisNext.remissionDecided.feeSupportStatusRefused,
+        description: 'Decision does not exists'
+      }
+    ];
+
+    testData.forEach(({
+                        remissionDecision,
+                        expectedResponse,
+                        description
+                      }) => {
+      it(`should be ${description}`, () => {
+        appeal.application.remissionDecision = remissionDecision;
+        expect(getFeeSupportStatusForAppealDetails(req)).to.be.deep.equal(expectedResponse);
+      });
+    });
+  });
+
+  it('should return proper decision reason row for appeal details', () => {
+    const { appeal } = req.session;
+    appeal.application.amountLeftToPay = '4000';
+    appeal.application.remissionDecisionReason = 'Test reason';
+    const testData = [
+      {
+        remissionDecision: 'approved',
+        expectedResponse: [],
+        description: 'Decision approved'
+      },
+      {
+        remissionDecision: 'partiallyApproved',
+        expectedResponse: [
+          addSummaryRow(i18n.pages.checkYourAnswers.rowTitles.reasonForDecision,
+            ['Test reason'], null),
+          addSummaryRow(i18n.pages.checkYourAnswers.rowTitles.feeToPay, ['£' + '40'], null)
+        ],
+        description: 'Decision partiallyApproved'
+      },
+      {
+        remissionDecision: 'rejected',
+        expectedResponse: [
+          addSummaryRow(i18n.pages.checkYourAnswers.rowTitles.reasonForDecision,
+            ['Test reason'], null)
+        ],
+        description: 'Decision rejected'
+      }
+    ];
+
+    testData.forEach(({
+                        remissionDecision,
+                        expectedResponse,
+                        description
+                      }) => {
+      it(`should be ${description}`, () => {
+        appeal.application.remissionDecision = remissionDecision;
+        expect(getDecisionReasonRowForAppealDetails(req)).to.be.deep.equal(expectedResponse);
+      });
+    });
+  });
+
+  it('paymentForAppealHasBeenMade', () => {
+    const { appeal } = req.session;
+    appeal.history = [
+      {
+        'id': 'recordRemissionDecision',
+        'createdDate': '2024-03-07T15:36:26.099'
+      },
+      {
+        'id': 'recordRemissionDecision',
+        'createdDate': '2024-04-07T15:36:26.099'
+      },
+      {
+        'id': 'updateTribunalDecision',
+        'createdDate': '2024-03-07T15:36:26.099'
+      }
+    ] as HistoryEvent[];
+
+    const testData = [
+      {
+        history: [
+          {
+            'id': 'recordRemissionDecision',
+            'createdDate': '2024-03-07T15:36:26.099'
+          },
+          {
+            'id': 'recordRemissionDecision',
+            'createdDate': '2024-04-07T15:36:26.099'
+          },
+          {
+            'id': 'updateTribunalDecision',
+            'createdDate': '2024-03-07T15:36:26.099'
+          }
+        ] as HistoryEvent[],
+        expectedResponse: false,
+        description: 'False'
+      },
+      {
+        history: [
+          {
+            'id': 'paymentAppeal',
+            'createdDate': '2024-03-07T15:36:26.099'
+          }
+        ] as HistoryEvent[],
+        expectedResponse: true,
+        description: 'True'
+      }];
+
+    testData.forEach(({
+                        history,
+                        expectedResponse,
+                        description
+                      }) => {
+      it(`should be ${description}`, () => {
+        expect(paymentForAppealHasBeenMade(req)).to.be.deep.equal(expectedResponse);
+      });
+    });
+  });
+
+  it('getPaymentStatusRow', () => {
+    const { appeal } = req.session;
+    appeal.paymentStatus = 'Paid';
+    const testData = [
+      {
+        isLateRemissionRequest: false,
+        remissionDecision: 'approved',
+        history: [
+          {
+            'id': 'recordRemissionDecision',
+            'createdDate': '2024-04-07T15:36:26.099'
+          }
+        ] as HistoryEvent[],
+        response: 'No payment needed',
+        description: 'No payment needed'
+      },
+      {
+        isLateRemissionRequest: false,
+        remissionDecision: 'partiallyApproved',
+        history: [
+          {
+            'id': 'recordRemissionDecision',
+            'createdDate': '2024-04-07T15:36:26.099'
+          }
+        ] as HistoryEvent[],
+        response: 'Not paid',
+        description: 'Not paid'
+      },
+      {
+        isLateRemissionRequest: false,
+        remissionDecision: 'partiallyApproved',
+        history: [
+          {
+            'id': 'rejected',
+            'createdDate': '2024-04-07T15:36:26.099'
+          }
+        ] as HistoryEvent[],
+        response: 'Not paid',
+        description: 'Not paid'
+      },
+      {
+        remissionDecision: null,
+        history: null,
+        response: 'Paid',
+        description: 'Paid'
+      },
+      {
+        isLateRemissionRequest: true,
+        remissionDecision: 'partiallyApproved',
+        history: [
+          {
+            'id': 'recordRemissionDecision',
+            'createdDate': '2024-04-07T15:36:26.099'
+          },
+          {
+            'id': 'paymentAppeal',
+            'createdDate': '2024-04-07T15:32:26.099'
+          }
+        ] as HistoryEvent[],
+        response: 'To be refunded',
+        description: 'To be refunded'
+      },
+      {
+        isLateRemissionRequest: true,
+        remissionDecision: 'approved',
+        history: [
+          {
+            'id': 'recordRemissionDecision',
+            'createdDate': '2024-04-07T15:36:26.099'
+          },
+          {
+            'id': 'paymentAppeal',
+            'createdDate': '2024-04-07T15:32:26.099'
+          }
+        ] as HistoryEvent[],
+        response: 'To be refunded',
+        description: 'To be refunded'
+      },
+      {
+        isLateRemissionRequest: true,
+        remissionDecision: 'rejected',
+        history: [
+          {
+            'id': 'recordRemissionDecision',
+            'createdDate': '2024-04-07T15:36:26.099'
+          },
+          {
+            'id': 'paymentAppeal',
+            'createdDate': '2024-04-07T15:32:26.099'
+          }
+        ] as HistoryEvent[],
+        response: 'Paid',
+        description: 'Paid'
+      },
+      {
+        isLateRemissionRequest: false,
+        remissionDecision: 'rejected',
+        history: [
+          {
+            'id': 'recordRemissionDecision',
+            'createdDate': '2024-04-07T15:36:26.099'
+          },
+          {
+            'id': 'markAppealPaid',
+            'createdDate': '2024-04-07T15:32:26.099'
+          }
+        ] as HistoryEvent[],
+        response: 'Paid',
+        description: 'Paid'
+      }
+    ];
+
+    testData.forEach(({
+                        remissionDecision,
+                        history,
+                        response,
+                        description,
+                        isLateRemissionRequest
+                      }) => {
+      appeal.application.remissionDecision = remissionDecision;
+      appeal.application.isLateRemissionRequest = isLateRemissionRequest;
+      appeal.history = history;
+      expect(getPaymentStatusRow(req)).to.be.deep.equal(response);
+    });
+  });
 });

--- a/test/unit/utils/utils.test.ts
+++ b/test/unit/utils/utils.test.ts
@@ -8,8 +8,10 @@ import {
   formatWitnessName,
   getApplicationType,
   getFtpaApplicantType,
+  getLatestUpdateRemissionDecionsEventHistory,
   getLatestUpdateTribunalDecisionHistory,
   hasPendingTimeExtension,
+  isRemissionDecisionDecided,
   isUpdateTribunalDecide,
   isUpdateTribunalDecideWithRule31,
   isUpdateTribunalDecideWithRule32,
@@ -220,7 +222,10 @@ describe('utils', () => {
 
   describe('getApplicationType', () => {
     it('Valid type', () => {
-      expect(getApplicationType('Judge\'s review of application decision')).to.include({ code: 'askJudgeReview', type: 'Judge\'s review of application decision' });
+      expect(getApplicationType('Judge\'s review of application decision')).to.include({
+        code: 'askJudgeReview',
+        type: 'Judge\'s review of application decision'
+      });
       expect(getApplicationType('Other')).to.include({ code: 'askSomethingElse', type: 'Other' });
     });
 
@@ -379,6 +384,84 @@ describe('utils', () => {
         }
       ] as HistoryEvent[];
       expect(getLatestUpdateTribunalDecisionHistory(req as Request, true)).to.eq(null);
+    });
+  });
+
+  describe('Remission decision utils', () => {
+    it('isRemissionDecisionDecided', () => {
+      const { appeal } = req.session;
+      const testData = [
+        {
+          history: undefined,
+          remissionDecision: 'approved',
+          expectedResponse: false,
+          description: 'False'
+        },
+        {
+          history: undefined,
+          remissionDecision: undefined,
+          expectedResponse: false,
+          description: 'False'
+        },
+        {
+          history: [
+            {
+              'id': 'recordRemissionDecision',
+              'createdDate': '2024-03-07T15:36:26.099'
+            }
+          ] as HistoryEvent[],
+          remissionDecision: undefined,
+          expectedResponse: false,
+          description: 'False'
+        },
+        {
+          history: [
+            {
+              'id': 'recordRemissionDecision',
+              'createdDate': '2024-03-07T15:36:26.099'
+            }
+          ] as HistoryEvent[],
+          remissionDecision: 'approved',
+          expectedResponse: true,
+          description: 'True'
+        }
+      ];
+
+      testData.forEach(({
+                          history,
+                          remissionDecision,
+                          expectedResponse,
+                          description
+                        }) => {
+        it(`should be ${description}`, () => {
+          appeal.application.remissionDecision = remissionDecision;
+          appeal.history = history;
+          expect(isRemissionDecisionDecided(req as Request, true)).to.be.deep.equal(expectedResponse);
+        });
+      });
+    });
+
+    it('getLatestUpdateRemissionDecionsEventHistory', () => {
+      const { appeal } = req.session;
+      appeal.application.remissionDecision = 'approved';
+      appeal.history = [
+        {
+          'id': 'recordRemissionDecision',
+          'createdDate': '2024-03-07T15:36:26.099'
+        },
+        {
+          'id': 'recordRemissionDecision',
+          'createdDate': '2024-04-07T15:36:26.099'
+        },
+        {
+          'id': 'updateTribunalDecision',
+          'createdDate': '2024-03-07T15:36:26.099'
+        }
+      ] as HistoryEvent[];
+
+      const latesHistoryEvent = getLatestUpdateRemissionDecionsEventHistory(req as Request, true);
+      expect(latesHistoryEvent.id).to.be.deep.equal('recordRemissionDecision');
+      expect(latesHistoryEvent.createdDate).to.be.deep.equal('2024-04-07T15:36:26.099');
     });
   });
 

--- a/types/caseData.d.ts
+++ b/types/caseData.d.ts
@@ -41,6 +41,7 @@ interface CaseData {
   appealType: string;
   homeOfficeReferenceNumber: string;
   appealReferenceNumber: string;
+  ccdReferenceNumberForDisplay: string;
   removeAppealFromOnlineReason: string;
   removeAppealFromOnlineDate: string;
   homeOfficeDecisionDate: string;
@@ -136,6 +137,8 @@ interface CaseData {
   feeDescription?: string;
   feeVersion?: string;
   feeAmountGbp?: string;
+  newFeeAmount?: string;
+  previousFeeAmountGbp?: string;
   pcqId?: string;
   isWitnessesAttending?: 'Yes' | 'No';
   isEvidenceFromOutsideUkInCountry?: 'Yes' | 'No';
@@ -245,8 +248,29 @@ interface CaseData {
   helpWithFeesRefNumber?: string;
   localAuthorityLetters?: Collection<DocumentWithMetaData>[];
   correctedDecisionAndReasons: Collection<CcdDecisionAndReasons>[];
+
+  //Late remission(refund) values:
+  lateRemissionOption?: string;
+  lateAsylumSupportRefNumber?: string;
+  lateHelpWithFeesOption?: string;
+  lateHelpWithFeesRefNumber?: string;
+  lateLocalAuthorityLetters?: Collection<DocumentWithMetaData>[];
+
+  refundRequested?: string;
+  remissionDecision?: string;
+  previousRemissionDetails?: RemissionDetailsCollection[];
+  remissionRejectedDatePlus14days?: string;
+  amountLeftToPay?: string;
+  remissionDecisionReason?: string;
+  isLateRemissionRequest?: string;
+  feeUpdateTribunalAction?: string;
+  feeUpdateReason?: string;
+  manageFeeRefundedAmount?: string;
+  manageFeeRequestedAmount?: string;
+  paidAmount?: string;
   sourceOfRemittal?: string;
   remittalDocuments: Collection<CcdRemittalDetails>[];
+  refundConfirmationApplied?: string;
 }
 
 interface Application<T> {
@@ -397,6 +421,24 @@ interface CcdRemittalDetails {
 interface DynamicList {
   value?: Value;
   list_items?: Value[];
+}
+
+interface RemissionDetailsCollection {
+  id?: number | string;
+  value?: RemissionDetailsData;
+}
+
+interface RemissionDetailsData {
+  feeAmount?: string;
+  amountRemitted?: string;
+  amountLeftToPay?: string;
+  feeRemissionType?: string;
+  remissionDecision?: string;
+  asylumSupportReference?: string;
+  remissionDecisionReason?: string;
+  helpWithFeesReferenceNumber?: string;
+  helpWithFeesOption?: string;
+  localAuthorityLetters?: Collection<DocumentWithDescription | DocumentWithMetaData>[];
 }
 
 interface InterpreterLanguageRefData {

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -111,6 +111,7 @@ interface Appeal {
   appealCreatedDate?: string;
   appealLastModified?: string;
   appealReferenceNumber?: string;
+  ccdReferenceNumber?: string;
   removeAppealFromOnlineReason?: string;
   removeAppealFromOnlineDate?: string;
   application: AppealApplication;
@@ -157,6 +158,8 @@ interface Appeal {
   feeDescription?: string;
   feeVersion?: string;
   feeAmountGbp?: string;
+  newFeeAmount?: string;
+  previousFeeAmountGbp?: string;
   additionalEvidenceDocuments?: Evidence[];
   addendumEvidenceDocuments?: Evidence[];
   additionalEvidence?: AdditionalEvidenceDocument[];
@@ -317,6 +320,26 @@ interface AppealApplication {
   helpWithFeesOption?: string;
   helpWithFeesRefNumber?: string;
   localAuthorityLetters?: Evidence[];
+
+  lateRemissionOption?: string;
+  lateAsylumSupportRefNumber?: string;
+  lateHelpWithFeesOption?: string;
+  lateHelpWithFeesRefNumber?: string;
+  lateLocalAuthorityLetters?: Evidence[];
+
+  refundRequested?: boolean;
+  remissionDecision?: string;
+  amountLeftToPay?: string;
+  remissionDecisionReason?: string;
+  previousRemissionDetails?: RemissionDetails[];
+  remissionRejectedDatePlus14days?: string;
+  isLateRemissionRequest?: boolean;
+  feeUpdateTribunalAction?: string;
+  feeUpdateReason?: string;
+  manageFeeRefundedAmount?: string;
+  manageFeeRequestedAmount?: string;
+  paidAmount?: string;
+  refundConfirmationApplied?: boolean;
 }
 
 interface CmaRequirements {
@@ -532,6 +555,20 @@ interface DecisionAndReasons {
   dateDocumentAndReasonsDocumentUploaded?: string;
   documentAndReasonsDocument?: Evidence;
   summariseChanges?: string;
+}
+
+interface RemissionDetails {
+  id?: string;
+  feeAmount?: string;
+  amountRemitted?: string;
+  amountLeftToPay?: string;
+  feeRemissionType?: string;
+  remissionDecision?: string;
+  asylumSupportReference?: string;
+  remissionDecisionReason?: string;
+  helpWithFeesReferenceNumber?: string;
+  helpWithFeesOption?: string;
+  localAuthorityLetters?: Evidence[];
 }
 
 interface RemittalDetails {

--- a/views/appeal-application/check-and-send.njk
+++ b/views/appeal-application/check-and-send.njk
@@ -20,6 +20,8 @@
     {% set buttonCopy = i18n.common.buttons.submit  %}
   {% elif payNow %}
     {% set buttonCopy = i18n.common.buttons.payNow  %}
+  {% elif dlrmFeeRemissionFlag %}
+    {% set buttonCopy = i18n.common.buttons.submit  %}
   {% else %}
     {% set buttonCopy = i18n.common.buttons.submitYourAppeal  %}
   {% endif %}

--- a/views/appeal-application/fee-support/asylum-support.njk
+++ b/views/appeal-application/fee-support/asylum-support.njk
@@ -12,7 +12,8 @@
             errorList: errorList
         }) }}
     {% endif %}
-    <form action="{{ paths.appealStarted.asylumSupport }}" method="post">
+
+    <form action="{{ formAction }}" method="post">
         <input type="hidden" name="_csrf" value="{{ csrfToken }}">
         {% call govukFieldset({
             legend: {
@@ -44,8 +45,12 @@
                     text:  errors['asylumSupportRefNumber'].text
                 } if errors['asylumSupportRefNumber']
             }) }}
-
-            {{ saveButtons() }}
+            {% if refundJourney %}
+                {{ continueButton() }}
+                {{ canelButton() }}
+            {% else %}
+                {{ saveButtons() }}
+            {% endif %}
         {% endcall %}
     </form>
     {{ contactUs() }}

--- a/views/appeal-application/fee-support/fee-waiver.njk
+++ b/views/appeal-application/fee-support/fee-waiver.njk
@@ -9,12 +9,18 @@
             errorList: errorList
         }) }}
     {% endif %}
-    <form method="post" action={{ paths.awaitingReasonsForAppeal.feeWaiver }}>
+    <form method="post" action={{ formAction }}>
         <input type="hidden" name="_csrf" value="{{ csrfToken }}">
         <h1 class="govuk-heading-xl">{{ i18n.pages.feeWaiverPage.title }}</h1>
         <p>{{ i18n.pages.feeWaiverPage.legend1 }}</p>
-        <p>{{ i18n.pages.feeWaiverPage.legend2 }}</p>
-        {{ continueButton() }}
+        {% if refundJourney %}
+            <p>{{ i18n.pages.feeWaiverPage.legendForRefund }}</p>
+            {{ continueButton() }}
+            {{ canelButton() }}
+        {% else %}
+            <p>{{ i18n.pages.feeWaiverPage.legend2 }}</p>
+            {{ continueButton() }}
+        {% endif %}
     </form>
     {{ contactUs() }}
 {% endblock %}

--- a/views/appeal-application/fee-support/help-with-fees-reference-number.njk
+++ b/views/appeal-application/fee-support/help-with-fees-reference-number.njk
@@ -12,7 +12,7 @@
             errorList: errorList
         }) }}
     {% endif %}
-    <form action="{{ paths.appealStarted.helpWithFeesReferenceNumber }}" method="post">
+    <form action="{{ formAction }}" method="post">
         <input type="hidden" name="_csrf" value="{{ csrfToken }}">
         {% call govukFieldset({
             legend: {
@@ -38,8 +38,12 @@
                     text:  errors['helpWithFeesRefNumber'].text
                 } if errors['helpWithFeesRefNumber']
             }) }}
-
-            {{ saveButtons() }}
+            {% if refundJourney %}
+                {{ continueButton() }}
+                {{ cancelButtonWithAttributes(previousPage, errors) }}
+            {% else %}
+                {{ saveButtons() }}
+            {% endif %}
         {% endcall %}
     </form>
     {{ contactUs() }}

--- a/views/appeal-application/fee-support/help-with-fees.njk
+++ b/views/appeal-application/fee-support/help-with-fees.njk
@@ -14,7 +14,13 @@
   <form action="{{ formAction }}" method="post">
     <input type="hidden" name="_csrf" value="{{ csrfToken }}">
     <h1 class="govuk-heading-xl">{{ i18n.pages.helpWithFees.title }}</h1>
-    <p>{{ i18n.pages.helpWithFees.tips }}</p>
+
+    {% if refundJourney %}
+      <p>{{ question.helpWithFeesHint }}</p>
+    {% else %}
+      <p>{{ i18n.pages.helpWithFees.tips }}</p>
+    {% endif %}
+
 
     <ul class="govuk-list govuk-list--bullet">
       <li>{{ i18n.pages.helpWithFees.tipsBullet1 }}</li>
@@ -37,6 +43,9 @@
 
     {% if saveAndContinueOnly %}
       {{ saveAndContinueButton() }}
+    {% elif continueCancelButtons %}
+      {{ continueButton() }}
+      {{ canelButton() }}
     {% else %}
       {% if saveAndContinue %}
         {{ saveButtons() }}

--- a/views/appeal-application/fee-support/steps-to-help-with-fees.njk
+++ b/views/appeal-application/fee-support/steps-to-help-with-fees.njk
@@ -10,11 +10,16 @@
             errorList: errorList
         }) }}
     {% endif %}
-    <form method="post" action={{ paths.awaitingReasonsForAppeal.stepsToApplyForHelpWithFees }}>
+    <form method="post" action={{ formAction }}>
         <input type="hidden" name="_csrf" value="{{ csrfToken }}">
         <h1 class="govuk-heading-xl">{{ i18n.pages.stepsToHelpWithFees.title }}</h1>
         <div>
-            <p>{{ i18n.pages.stepsToHelpWithFees.tips }}</p>
+            {% if refundJourney %}
+                <p>{{ i18n.pages.stepsToHelpWithFees.tipsRefund }}</p>
+            {% else %}
+                <p>{{ i18n.pages.stepsToHelpWithFees.tips }}</p>
+            {% endif %}
+
             <ol class="govuk-list govuk-list--number">
                 <li> {{ i18n.pages.stepsToHelpWithFees.bullet1 | safe }} </li>
                 <li> {{ i18n.pages.stepsToHelpWithFees.bullet2 }} </li>
@@ -24,20 +29,18 @@
             </ol>
         </div>
 
-        <div class="save-buttons__container">
-            {{ govukButton({
-                name: 'continue',
-                text: i18n.common.buttons.continue,
-                classes: "govuk-!-margin-right-1"
-            }) }}
-
+        {% if refundJourney %}
+            {{ continueButton() }}
+            {{ canelButton() }}
+        {% else %}
+            {{ continueButton() }}
             {{ govukButton({
                 text: i18n.common.buttons.saveForLater,
                 name: "saveForLater",
                 value: "saveForLater",
                 classes: "govuk-button--secondary"
             }) }}
-        </div>
+        {% endif %}
     </form>
     {{ contactUs() }}
 {% endblock %}

--- a/views/application-overview.njk
+++ b/views/application-overview.njk
@@ -147,6 +147,9 @@
               {% if showAppealRequests and not isPostDecisionState %}
                 <p><a class="govuk-link" href='{{ paths.makeApplication.withdraw }}'>{{ i18n.pages.overviewPage.withdrawAppeal }}</a></p>
               {% endif %}
+              {% if showAskForFeeRemission %}
+                    <p><a class="govuk-link" href='{{ paths.appealSubmitted.feeSupportRefund }}'>{{ i18n.pages.overviewPage.askForFeeRemission }}</a></p>
+              {% endif %}
             </div>
           {% endif %}
           {% if showAppealRequests or showAppealRequestsInAppealEndedStatus %}
@@ -163,6 +166,9 @@
                        {% elif showAppealRequestsInAppealEndedStatus %}
                           <p><a class="govuk-link" href='{{ paths.makeApplication.reinstate }}'>{{ i18n.pages.overviewPage.appealRequests.askReinstateAppeal }}</a></p>
                           <p><a class="govuk-link" href='{{ paths.makeApplication.judgesReview }}'>{{ i18n.pages.overviewPage.appealRequests.askJudgeToReview}}</a></p>
+                          {% if showAskForSomethingInEndedState %}
+                            <p><a class="govuk-link" href='{{ paths.makeApplication.other }}'>{{ i18n.pages.overviewPage.appealRequests.askForSomethingElse }}</a></p>
+                          {% endif %}
                       {% endif %}
               </div>
           {% endif %}

--- a/views/ask-for-fee-remission/check-and-send.njk
+++ b/views/ask-for-fee-remission/check-and-send.njk
@@ -1,0 +1,35 @@
+{% set pageTitleName = i18n.pages.checkYourAnswers.title %}
+{% extends "layout.njk" %}
+{% from "govuk/components/button/macro.njk" import govukButton %}
+{% from "govuk/components/tag/macro.njk" import govukTag %}
+{% from "govuk/components/checkboxes/macro.njk" import govukCheckboxes %}
+{% from "components/summary-list.njk" import govukSummaryList %}
+{% import "components/text-components.njk" as text with context %}
+
+{% block content %}
+
+  {% if errorList %}
+    {{ govukErrorSummary({
+      titleText: i18n.validationErrors.errorSummary,
+      errorList: errorList
+    }) }}
+  {% endif %}
+
+  <h1 class="govuk-heading-xl">{{ i18n.pages.checkYourAnswers.header }}</h1>
+
+  {{ govukSummaryList({
+    rows: summaryRows
+  }) }}
+
+  <form method="post" action={{ paths.appealSubmitted.checkYourAnswersRefund }}>
+    <input type="hidden" name="_csrf" value="{{ csrfToken }}">
+    <div class="save-buttons__container">
+      {{ govukButton({
+        text: "Submit",
+        classes: "govuk-!-margin-right-1",
+        preventDoubleClick: true
+      }) }}
+    </div>
+  </form>
+  {{ contactUs() }}
+{% endblock %}

--- a/views/ask-for-fee-remission/confirmation-page.njk
+++ b/views/ask-for-fee-remission/confirmation-page.njk
@@ -1,0 +1,26 @@
+{% block beforeContent %}
+{% endblock %}
+{% set pageTitleName = i18n.pages.feeSupportConfirmationPage.title %}
+
+{% extends "layout.njk" %}
+
+{% block content %}
+  {% from "govuk/components/panel/macro.njk" import govukPanel %}
+  {{ govukPanel({
+    titleText: i18n.pages.feeSupportConfirmationPage.title,
+    classes: mainClasses
+  }) }}
+  <h2 class="govuk-heading-m">{{ i18n.pages.feeSupportConfirmationPage.whatHappensNext }}</h2>
+  <div>
+    <ul class="govuk-list govuk-list--bullet govuk-!-padding-left-4">
+      <li>{{ i18n.pages.feeSupportConfirmationPage.bullet1 | safe }}</li>
+      <li>{{ i18n.pages.feeSupportConfirmationPage.bullet2 | eval | safe }}</li>
+    </ul>
+  </div>
+
+  {{ govukButton({
+    text: i18n.common.buttons.seeProgress,
+    href: paths.common.overview
+  }) }}
+  {{ contactUs() }}
+{% endblock %}

--- a/views/ask-for-fee-remission/fee-support-refund.njk
+++ b/views/ask-for-fee-remission/fee-support-refund.njk
@@ -1,0 +1,35 @@
+{% set pageTitleName = pageTitle %}
+{% from "components/radio-button-question.njk" import radioButtonQuestion %}
+
+{% extends "layout.njk" %}
+
+{% block content %}
+    {% if errorList %}
+        {{ govukErrorSummary({
+            titleText: i18n.error.summary.title,
+            descriptionText: i18n.error.summary.descriptionText,
+            errorList: errorList
+        }) }}
+    {% endif %}
+    <form action="{{ formAction }}" method="post">
+        <input type="hidden" name="_csrf" value="{{ csrfToken }}">
+        <h1 class="govuk-heading-xl">{{ i18n.pages.remissionOptionPage.refundTitle }}</h1>
+
+        <p>{{ i18n.pages.remissionOptionPage.refundParagraph1 }}</p>
+        <p>{{ i18n.pages.remissionOptionPage.refundParagraph2 }}</p>
+        <p>{{ i18n.pages.remissionOptionPage.refundParagraph3 }}</p>
+
+        {{ radioButtonQuestion(
+            question.name or 'answer',
+            question.options,
+            "",
+            question.titleIsheading or true,
+            question.hint | eval | safe if question.hint,
+            error[question.name].text,
+            question.inline
+        ) }}
+        {{ continueButton() }}
+        {{ canelButton() }}
+    </form>
+    {{ contactUs() }}
+{% endblock %}

--- a/views/components/overview-timeline.njk
+++ b/views/components/overview-timeline.njk
@@ -24,7 +24,7 @@
       </div>
     {% endif %}
 
-    {% if history.appealArgumentSection | length > 0  %}
+    {% if history.appealArgumentSection | length > 0  and not history.appealRemissionSection | length > 0 %}
       <div class="govuk-!-margin-bottom-3">
         <h3 class="govuk-heading-s govuk-!-margin-bottom-0">{{ i18n.pages.overviewPage.timeline.sections.appealArgumentSection }}</h3>
         <div class="timeline-section">
@@ -39,6 +39,18 @@
       <div class="govuk-!-margin-bottom-3">
         <h3 class="govuk-heading-s govuk-!-margin-bottom-0">{{ i18n.pages.overviewPage.timeline.sections.appealDetailsSection }}</h3>
         <div class="timeline-section">
+          {% if history.appealRemissionDecisionSection | length > 0 %}
+            {% for event in history.appealRemissionDecisionSection %}
+              {% include "components/event-in-timeline.njk" %}
+            {% endfor %}
+          {% endif %}
+
+          {% if history.appealRemissionSection | length > 0 and not history.appealRemissionDecisionSection | length > 0 %}
+            {% for event in history.appealRemissionSection %}
+              {% include "components/event-in-timeline.njk" %}
+            {% endfor %}
+          {% endif %}
+
           {% for event in history.appealDetailsSection %}
             {% include "components/event-in-timeline.njk" %}
           {% endfor %}

--- a/views/layout.njk
+++ b/views/layout.njk
@@ -110,6 +110,19 @@
   <a class="cancel-button" href="{{ previousPage }}">{{ i18n.common.buttons.cancel }}</a>
 {% endmacro %}
 
+{% macro cancelButtonWithAttributes(previousPage, errors=None) %}
+  {# Check if errors is present #}
+  {% if error or errors %}
+    <a class="cancel-button" href="javascript:void(0);" onclick="history.go(-1); return false;">
+      {{ i18n.common.buttons.cancel }}
+    </a>
+  {% else %}
+    <a class="cancel-button" href="#" onclick="{{ previousPage.attributes.onclick }}">
+      {{ i18n.common.buttons.cancel }}
+    </a>
+  {% endif %}
+{% endmacro %}
+
 {% macro saveAndContinueButton() %}
   {{ govukButton({
     text: "Save and continue"

--- a/views/templates/details-with-fees-viewer.njk
+++ b/views/templates/details-with-fees-viewer.njk
@@ -18,5 +18,22 @@
             rows: data.feeDetailsRows
         }) }}
     {% endif %}
+
+    {% if data.feeHistoryRows | length %}
+        {% for feeHistoryRow in data.feeHistoryRows %}
+            <div class="govuk-summary-history">
+                <div class ="govuk-summary-history-header">
+                    <div class="govuk-summary-list__key">Fee remission application {{data.feeHistoryRows.length + 1 -
+                    loop
+                    .index}}</div>
+                </div>
+                <div class="govuk-summary-history-body">
+                      {{ govukSummaryList({
+                        rows: feeHistoryRow
+                      }) }}
+                </div>
+            </div>
+        {% endfor %}
+    {% endif %}
   {{ contactUs() }}
 {% endblock %}


### PR DESCRIPTION
* ia-aip-frontend-drlm: base branch for DLRM

* RIA-8047 content_update (#1036)

* RIA-8047: Edit decisionTypePage hints

* RIA-8047: Add feature toggler to new hint texts for the DLRM set aside journey

* RIA-8019 create new fee support section (#1039)

* RIA-8019 create new fee support section

* RIA-8019 add tests and fix functionality

* Empty-Commit

* RIA-8019 remove only test

* RIA-8019 add known issues suppression

* RIA-8019 rename fee support dlrm flag

* RIA-8019 Fix tests

* RIA-8019 Add unit test for sonar coverage (#1045)

* RIA-8019 Add fee type option with dlrm flag (#1046)

* RIA-8199 Added R35 document for appellant FTPA application (#1047)

* RIA-8199 Added R35 document for appellant FTPA application

* RIA-8199 Fix lint

* RIA-8199 Fix lint

* RIA-8199 revert changes

* RIA-8200 FTPA decided Rule 35 - Respondent timeline update + doc (#1049)

* RIA-8200 FTPA decided Rule 35 - Respondent timeline update

* RIA-8200 Putting line separator back as LF

* RIA-8200 Fixing unit test detail-viewers-test

* RIA-8200 Unit test fix

* RIA-8200 Additional logic added and separated R35 document fields

* RIA-8208 timeline changes for rule 31 and rule 32 (#1050)

* RIA-8208 timeline changes for rule 31 and rule 32

* RIA-8208 Added suppression 1096525 and 1096519

* RIA-8207 HO timeline changes for rule 31 and rule 32 (#1054)

* RIA-8207 Audit known issues (#1058)

* RIA-8633 Refactoring for Decide FTPA decision document fields (#1057)

* RIA-8633 Refactoring for Decide FTPA decision document fields

* RIA-8633 Logic change after Rule31+32 rebased

* RIA-8633 Refactoring for Decide FTPA decision document fields

* RIA-8633 Logic change after Rule31+32 rebased

* RIA-8633 rebase changes after respondent Rule 31+32 changes

* RIA-8052 Modify check and send file uploader (#1055)

* RIA-8052 Modify check and send file uploader

* RIA-8052 Fix security check

* RIA-8052 Rename feature flag

* RIA-8048 fee_support_screens (#1048)

* RIA-8048: Add fee-support page, and asylum support page routes, translations, view

* RIA-8048: Add fee-support page, and asylum support page routes, translations, view

* RIA-8048: Add FeeSupport changes, FeeWaiver, UploadLocalAuthority  pages,  routes, translations, views

* RIA-8048: Add FeeSupport changes, FeeWaiver, UploadLocalAuthority  pages,  routes, translations, views

* RIA-8048: Add HelpWithReferenceNUmber, FeeWaiver, StepToHelpFees  pages,  routes, translations, views, validations. Editions on AsylumSupport, caseData, UploadLocalAuthorityLetter pages

* RIA-8048: Edit validation for help with fee ref number

* RIA-8048: Add Free support label to be saved if the journey in this section is over, save this value to db. Save all pages values to db. UpdateAppealService modification. Populate caseData and index.dt with mapping values

* RIA-8048: Add CYA page values for new journeys, adapt to edit mode implemented components, reset section if 1 and 2 sections are reseted/modified

* RIA-8048: Remove unused variables and functions, added tests for validations functions

* RIA-8048: Update update-appea-service.test

* RIA-8048: Update fee-support.ts and asylum-support.ts and add junit tests for these components

* RIA-8048: Add fee-waiver tests

* RIA-8048: Add help with fees tests

* RIA-8048: Add help-with-fees-reference-number tests

* RIA-8048: Add steps-to-help-with-fees tests

* RIA-8048: Small path naming refactor

* RIA-8048: Add task utils test

* RIA-8048: Add local authority letter tests

* RIA-8048: Add suppressions

* RIA-8048: restore package.json

* RIA-8048: help-with-fees-reference-number and help-with-fees.ts feeSupportPersisted save logic fix

* RIA-8048: test fix

* RIA-8048: Changes for all Components - drlmFeeRemissionFlag variables renamed consistently to match the journey, flags logic in Post functions moved in the very beginning of the functions

* RIA-8048: removed comment

* RIA-8048: Fix tests

* RIA-8050 Add fee remission submit message (#1051)

* RIA-8050 Add fee remission submit message

* RIA-8050 Rename feature flag and integrate with helpWithFeesOption

* RIA-8050 Fix showing condition

* RIA-8050 Add out of country extra days (#1062)

* RIA-8048: Fix QA comments (#1063)

* Update en.json

Added space on line 3632 between (opens in a new tab)

* RIA-8679 confirmation_page (#1065)

* RIA-8679: Add Conditions for confirmation page with and without remission. Change translations for Confirmation page.

* RIA-8679: Add updates for webpack to resolve Pipeline

* Revert "RIA-8679: Add updates for webpack to resolve Pipeline"

This reverts commit 36e55b8022c19bacbf06169ad92b069f81556c78.

* RIA-8679: Add updates for webpack to resolve Pipeline

* RIA-8048 qa-fixes_2 (#1067)

* RIA-8048: Fix QA comments

* RIA-8048: Fix QA comments - hidden text on feesupport, value in check and send and fee state appearance when it is deleted

* RIA-8048: test fix

* RIA-8679 confirmation_page (#1068)

* RIA-8679: Add Conditions for confirmation page with and without remission. Change translations for Confirmation page.

* RIA-8679: Add updates for webpack to resolve Pipeline

* Revert "RIA-8679: Add updates for webpack to resolve Pipeline"

This reverts commit 36e55b8022c19bacbf06169ad92b069f81556c78.

* RIA-8679: Add updates for webpack to resolve Pipeline

* RIA-8679: Add flag to confirmation page, edit existing tests

* RIA-8679 fixing_qa_comments (#1071)

* RIA-8679: Add Conditions for confirmation page with and without remission. Change translations for Confirmation page.

* RIA-8679: Add updates for webpack to resolve Pipeline

* Revert "RIA-8679: Add updates for webpack to resolve Pipeline"

This reverts commit 36e55b8022c19bacbf06169ad92b069f81556c78.

* RIA-8679: Add updates for webpack to resolve Pipeline

* RIA-8679: Add flag to confirmation page, edit existing tests

* RIA-8679: Fix QA comments, remove flag add condition to links for NoRemissionOption

* RIA-8679: Fix QA comments, remove flag add condition to links for NoRemissionOption

* RIA-8679: Fix QA comments, remove flag add condition to links for NoRemissionOption

* RIA-8679: Fix QA comments, remove flag add condition to links for NoRemissionOption

* RIA-8050 Fix typos (#1072)

* RIA-8211 update tribunal decision rule 31 AIP timeline (#1070)

* RIA-8211 update tribunal decision rule 31 AIP timeline

* update the calculate of due date from the date of triggering updateTribunalDecision event

* remove unnecessary semicolon

* add the test for the function getDueDateForAppellantToRespondToJudgeDecision

* update logic from Thomas feedback

* Revert "RIA-8052 Modify check and send file uploader (#1055)" (#1061)

* Revert "RIA-8052 Modify check and send file uploader (#1055)"

This reverts commit 1b1f51abf9bbfb1716274ac8fa03807de5f86d11.

* RIA-8052 add featureFlag

* RIA-8052 Move late appeal to the bottom of the summary

* RIA-8679 qa_comments_fix (#1074)

* RIA-8679: Add Conditions for confirmation page with and without remission. Change translations for Confirmation page.

* RIA-8679: Add updates for webpack to resolve Pipeline

* Revert "RIA-8679: Add updates for webpack to resolve Pipeline"

This reverts commit 36e55b8022c19bacbf06169ad92b069f81556c78.

* RIA-8679: Add updates for webpack to resolve Pipeline

* RIA-8679: Add flag to confirmation page, edit existing tests

* RIA-8679: Fix QA comments, remove flag add condition to links for NoRemissionOption

* RIA-8679: Fix QA comments, remove flag add condition to links for NoRemissionOption

* RIA-8679: Fix QA comments, remove flag add condition to links for NoRemissionOption

* RIA-8679: Fix QA comments, remove flag add condition to links for NoRemissionOption

* RIA-8679: Fix QA comments, remove flag add condition to links for NoRemissionOption

* RIA-8679 yarn_audit_known_issues (#1075)

* RIA-8679: Add Conditions for confirmation page with and without remission. Change translations for Confirmation page.

* RIA-8679: Add updates for webpack to resolve Pipeline

* Revert "RIA-8679: Add updates for webpack to resolve Pipeline"

This reverts commit 36e55b8022c19bacbf06169ad92b069f81556c78.

* RIA-8679: Add updates for webpack to resolve Pipeline

* RIA-8679: Add flag to confirmation page, edit existing tests

* RIA-8679: Fix QA comments, remove flag add condition to links for NoRemissionOption

* RIA-8679: Fix QA comments, remove flag add condition to links for NoRemissionOption

* RIA-8679: Fix QA comments, remove flag add condition to links for NoRemissionOption

* RIA-8679: Fix QA comments, remove flag add condition to links for NoRemissionOption

* RIA-8679: Fix QA comments, remove flag add condition to links for NoRemissionOption

* RIA-8679: yarn-audit-known-issues

* RIA-8239 Added rule 31 corrected list AIP (#1073)

* RIA-8239 Added complex type corrected decisions to AIP

* RIA-8239 Added view page for updated decisions

* RIA-8239 Added tests for updated decisions and reasons page

* RIA-8239 Added link on timeline to updated decision page

* RIA-8239 fixed checkstyle

* RIA-8239 Added set aside feature flag check to new page

* RIA-8679: remove noRemission condition from confirmation page (#1077)

* RIA-8227 update tribunal decision rule 32 AIP timeline (#1078)

* RIA-8227 update tribunal decision rule 32 aip timeline

* remove useless the space

* RIA-8211 update tribunal decision rule 31 aip timeline v2 (#1079)

* RIA-8051 Create new details viewer screen (#1076)

* RIA-8051 Create new details viewer screen

* RIA-8051 Add detail viewer tests

* RIA-8051 fix vulnerabilities

* RIA-8048_fix: Removed condition in help-with-fees-reference-number to null values (#1082)

* RIA-8051 Fix details screen for RP and DC appeal types (#1084)

* RIA-8051 Fix details screen for RP and DC appeal types

* RIA-8051 Fix linting

* RIA-8747 Modify confirmation page when appeal is late. (#1083)

* RIA-8747 Fix vulnerabilities (#1086)

* RIA-8747 Fix header title (#1087)

* RIA-8729 set button title for dlrm fee remission cases (#1088)

* RIA-8729 set button title for dlrm fee remission cases

* RIA-8729 fix space

* ia-ccd-definitions-dlrm-refund: added yarn fix

* RIA-8069_RIA-8070 ask_for_fee_remission (#1081)

* RIA-8069_RIA-8070: Add link to overview page, flag for refund, modify Fee-support,asylum support components for new journey with refund

* RIA-8069_RIA-8070: Cherry pick 1

* RIA-8069_RIA-8070: Fix reset to help with fees reference number

* RIA-8069_RIA-8070: Add CYA page and view for it, update routes, directory where controllers and views

* RIA-8069: Add CYA and confirmation pages, translations, edit journey POST paths

* RIA-8069: Revert auth service

* RIA-8069: Editing the pages for Ask for a fee remission

* RIA-8069: Add new values for Fee refund journey and mapping for them

* RIA-8069: Add remissionutils changes

* RIA-8069: Edit resetting values in refund journey

* RIA-8069: Edit application overview condition

* RIA-8069: Add tests app-overview, asylum-support-refund, fee-support-refund, help-with-fee-ref-number, update-appeal-service test

* RIA-8069: Add fee-waiver tests also add more checks into previously implemented

* RIA-8069: Add steps-to-help-with-fees-refund tests

* RIA-8069: Add help-with-fees-refund test

* RIA-8069: Add help-with-fees-reference-number test

* RIA-8069: Add upload-local-authority-letter-refund test

* RIA-8069: Add confirmation-page-refund test

* RIA-8069: Add cya-page-refund test

* RIA-8069: Add audit fixes

* RIA-8069 fix issues with styyles and mappings (#1091)

* RIA-8069 add_flag_for_link (#1096)

* RIA-8069: Add condition to the link 'ask for fee refund'

* RIA-8069: Security checks

* RIA-8070: Fixing translations and title (#1097)

* RIA-8764 Modify timeline information when appeal has remission (#1099)

* RIA-8764 Modify timeline information when appeal has remission

* RIA-8764 Fix audit issues

* RIA-8764 Fix overview error

* RIA-8764 Fix lint

* RIA-8764 Update nodeJs chart version

* Bumping chart version/ fixing aliases

---------



* RIA-8764 Add missing title (#1104)

* RIA-8764 Fix later remission option helpWithFees check (#1106)

* RIA-8762 aip_timeline_update_on_decision (#1105)

* RIA-8762: Add updates to the timeline and notifications banners when the fee remission is approved, partially approved or rejected

* RIA-8762: Update remissionUtils functions(remove flags)

* RIA-8762: Add tests for paymentUtils, remissionUtils, update-appeal-service

* RIA-8762: Add tests for timeline-utils and utils

* RIA-8762: Add tests for application state utils, detail-viewer test fixes and remission utils fixes

* RIA-8762: Merge conflict solving

* RIA-8762: Tests fix and event-deadline-date-finder

* RIA-8762: security issues fix

* RIA-8762: security issues fix

* RIA-8762: security issues fix

* RIA-8667 show 'Ask for something' in ended state (#1110)

* RIA-8762 timeline_fee_remission_fixes (#1115)

* RIA-8762: Add updates to the timeline and notifications banners when the fee remission is approved, partially approved or rejected

* RIA-8762: Update remissionUtils functions(remove flags)

* RIA-8762: Add tests for paymentUtils, remissionUtils, update-appeal-service

* RIA-8762: Add tests for timeline-utils and utils

* RIA-8762: Add tests for application state utils, detail-viewer test fixes and remission utils fixes

* RIA-8762: Merge conflict solving

* RIA-8762: Tests fix and event-deadline-date-finder

* RIA-8762: security issues fix

* RIA-8762: security issues fix

* RIA-8762: security issues fix

* RIA-8762: Update the time line utils and detail viewer

* RIA-8762 qa_issues_fix (#1118)

* RIA-8762: Add updates to the timeline and notifications banners when the fee remission is approved, partially approved or rejected

* RIA-8762: Update remissionUtils functions(remove flags)

* RIA-8762: Add tests for paymentUtils, remissionUtils, update-appeal-service

* RIA-8762: Add tests for timeline-utils and utils

* RIA-8762: Add tests for application state utils, detail-viewer test fixes and remission utils fixes

* RIA-8762: Merge conflict solving

* RIA-8762: Tests fix and event-deadline-date-finder

* RIA-8762: security issues fix

* RIA-8762: security issues fix

* RIA-8762: security issues fix

* RIA-8762: Update the time line utils and detail viewer

* RIA-8762: Edit translations and application-state utils along with the test

* RIA-8086 Create remission decission details (#1108)

* RIA-8086 Create remission decission details

* RIA-8086 Create remission decission details historical screen

* RIA-8086 Add update appeal service tests

* RIA-8086 Add remission util tests

* RIA-8086 fix detail viewers test and add functionality

* RIA-8086 Remove only word in tests

* RIA-8086 Update extra comma

* RIA-8086 Add tests for detail-viewers

* RIA-8086 Add tests for detail-viewers

* RIA-8086 fix linting

* RIA-8086 Modify Fee support status (#1122)

* RIA-8245 Create  manage a fee update details and timeline (#1121)

* RIA-8245 Create  manage a fee update details and timeline

* RIA-8245 Create detail viewers when manage a fee update is done

* RIA-8245 Move manage a refund event to remissionDetails section

* RIA-8245 Add fee update remission section for appeals without remission (#1130)

* RIA-8245 Add fee update remission section for appeals without remission

* Bumping chart version/ fixing aliases

---------



* Bumping chart version/ fixing aliases

* ia-aip-frontend-dlrm-refund: know issues add

* RIA-1111 Triggering biuld (#1154)

* RIA-9198 fix_decision_reason (#1158)

* RIA-9198: Fix remission decision appealDetails line

* Bumping chart version/ fixing aliases

* RIA-9198: Add chart upgrade

---------



* RIA-9197: Add mark as paid event and update remissiont utils (#1160)

* ia-aip-frontend-dlrm-refund: Security issues update

* Trigger Build

* RIA-9221 Fix pendingPayment with record decission screen (#1164)

* RIA: empty commit to rerun pipelines

* RIA-task merge with master: Imports fix

* RIA-task merge with master: Fix tests

* RIA-9331 Remove payment link when remission is approved or partiallyapproved (#1169)

* RIA-9331 Remove payment link when remission is approved or partially approved

* Bumping chart version/ fixing aliases

---------



* RIA-task merge with master: Fix merge conflicts

* RIA-TASK - Rebase master ia-aip-frontend (#1170)

* RIA-2222 add_test_changes_for_nightly (#1146)

* RIA-2222: Add test changes for nightly pipelines

* RIA-2222: Add security checks

* RIA-9158 fix_fee_support (#1149)

* RIA-9158: Fix the fee-support checked option

* RIA-9158: Known issues

* Update braces, socks and ws. (#1151)

* DTSSE-5078 Add stale bot (#1144)



* DIAC-456 Update postcode search validation (#1152)

* DIAC-456-Update postcode search validation

* DIAC-456 Update postcode search validation unit tests

* DIAC-456 Update postcode search validation unit tests

* DIAC-456 Update postcode search validation unit tests

* DIAC-456 - update nodejs chart to 3.1.1

* Bumping chart version/ fixing aliases

---------




* DIAC-515 nightly fix (#1156)

* DIAC-515 nightly fix

* DIAC-515 nightly fix

* DIAC-515 nightly fix

* fix

* upgrading node chart

* Bumping chart version/ fixing aliases

---------




* DIAC-475 enabling payments and hidden links in postDecision states (#1150)

* DIAC-475 enabling payments and hidden links in postDecision states

* DIAC-475 linting fix

* DIAC-475 njk anti if statement fix

* DIAC-475 fixing addendum evidence upload

* DIAC-475 - udpate chart version to 3.1.1

* Bumping chart version/ fixing aliases

---------





* DIAC-523 Allow space in middle of postcode (regex) (#1161)

* RIA-7875 Merge SNL -> Master (DO NOT MERGE) (#972)

* RIA-7415 Split witness names to capture first and last names in AiP journey (#969)

* RIA-7415: Update witness details to include given names and family name fields

* RIA-7415: Update Controllers and views to use the updated witness details

---------



* RIA-7565 refactor the capture of witnessess in AIP (#973)

* RIA-7565 refactor the capture of witnessess in aip

* add the missing semicolon

* suppress the cve problems

* RIA-7638 ref-data-service and ref-data-api (#975)

* RIA-7638 ref-data-service and ref-data-api

* RIA-7638 Vulnerabilities

* RIA-7638 Add refData url to config (test)

* RIA-7638 Add aat env var for payments api and ref data api

* Bumping chart version/ fixing aliases

---------



* RIA-7304 AIP with no witnesses can state interpreter requirement (#976)

* RIA-7304-aip-with-no-witnesses-can-state-interpreter-requirement

* Fix the check style problem

* retreive the spoken language and sign language from common reference data, also set show the answer in summary page

* add the new pages

* update the error message and unit test

* add and update the unit test

* add/update the unit test

* Revert "add/update the unit test"

This reverts commit 0403b65286707a4806d23578f20f95038709f51f.

* add the unit test for spoken language and sign language in access-needs page

* remove useless comment

* check the data of spoken and sign language to determine whether show them in summary page

* Add the function to clear cached data

* Suppress the CVE problem

* RIA-7506 AIP with witnesses can state appellant interpreter req (Review and merge the PR of RIA-7304 first) (#977)

* RIA-7304-aip-with-no-witnesses-can-state-interpreter-requirement

* Fix the check style problem

* retreive the spoken language and sign language from common reference data, also set show the answer in summary page

* add the new pages

* update the error message and unit test

* add and update the unit test

* add/update the unit test

* Revert "add/update the unit test"

This reverts commit 0403b65286707a4806d23578f20f95038709f51f.

* add the unit test for spoken language and sign language in access-needs page

* remove useless comment

* check the data of spoken and sign language to determine whether show them in summary page

* RIA-7506 AIP with witnesses can state appellant interpreter req

* Add the function to clear cached data

* Add the new question to summary page and unit test

* Add the new question to summary page and unit test

* Suppress the CVE problem

* update the check condition for appellantInterpreterLanguageCategoryList and remove unnecessary comment

* add the additional condition for checking the old field of language and languageDialect

* RIA-7508 AIP with witnesses can state witness interpreter req (#980)

* RIA-7508 AIP with witnesses can state witness interpreter req

* add the unit test for validation rule

* Add the feature for witness selection language category / spoken language and sign language page

* -Add the unit test for witness selection language category / spoken language and sign language page -Enhance the code structure

* -Show the question in summary page -Add the unit test for summary page
-Add the function to utils
-clear the cached the witnesses data

* -skip the page of which witness need interpreter support if there is only witness with required interpreter -fix checkstyle problem
-clear the cached the witness data when remove witness from the list

* -suppress the CVE problem

* -add the missing value for the CCD field  (witness1 to witness 10)

* -update the logic after removing witness from the list

* -update the logic after removing witness from the list

* -add the function for reusable

* -remove unnecessary line

* RIA-7752 party ID generation AIP journey (#999)

* RIA-7752 party ID generation AIP journey

* Fix the problem of node.js upgrade

* Bumping chart version/ fixing aliases

* fix checkstyle problem

* fix the security checks problem

* update the package.json

* Updates to fix merge conflicts

* Updates to fix merge conflicts

* Updates to fix merge conflicts

* updates to suppress vulnerabilities

---------





* RIA-7875 fix the sonar problem for the bug and code coverage (#1002)

* RIA-7875 fix the sonar problem for the bug and code coverage

* RIA-7875 fix the unit test problem after adding empty hearingRequirements object to emptyApplication

* Add more unit test to increase code coverage

* remove the duplicated checking for the getWitnessComponent method

* fix the problem of duplication

* Update saucelabs.config.js

* Update saucelabs.config.js

* Update saucelabs.config.js

* Updates to suppress the new cve

* Update saucelabs.config.js

* Update default.json

* Update saucelabs.config.js

* RIA-7967 Submit hearing requirement failing in AIP demo Env (#1009)

* RIA-7967 Submit hearing requirement failing in AIP demo Env

* update the unit test

* update the chart.yaml

* Update saucelabs.config.js

* Updates to suppress cves

* Bumping chart version/ fixing aliases

* Update Chart.yaml

* Update saucelabs.config.js

* Update saucelabs.config.js

* Update saucelabs.config.js

* RIA-7781: New Application type - Change hearing type Missing for AIP (#1021)

* RIA-8393 - Fix What Happens Next text missing and supporting document still appears after selected no in provide doc page (#1022)

* RIA-7781: New Application type - Change hearing type Missing for AIP

* RIA-8393 - Fix What Happens Next text missing and supporting document still appears after selected no in provide doc page

* RIA-8392 - Removed space

* Suppressed vul

* RIA-8416 Notice of Adjourned Hearing on AIP (#1025)

* RIA-8416 Show Notice of Adjourned Hearing when available

* RIA-8416 Update document's name in unit test

* RIA-8416 Fix unit test

* Update saucelabs.config.js

* Bumping chart version/ fixing aliases

* Update saucelabs.config.js

* Temporarily address dependency vulnerabilities

* VUL-5808: Get rid of hard-coded secrets from source code (#1085)

- Remove hard-coded ssl certificate and private key from code
- Add a script to generate certificate and key for dev environment

* Update saucelabs.config.js

* Updates to suppress vulnerabilities

* RIA-8827 Fix issue with events timeline for 'recordAdjournmentDetail… (#1127)

* RIA-8827: Fix issue with events timeline for 'recordAdjournmentDetails' event

* RIA-8827: Address dependency vulnerability

* Update saucelabs.config.js

* RIA-8918 Appeals AIP Naba Rebasing (#1136)

* DIAC-366 CVEs (#1113)

* ip version 2.0.1 added, fixing CVE-2023-42282

* remove CVE-2023-45857 from yarn-audit-known-issues

* Revert change to ip and add  "tar": "^6.2.1" fixing CVE-2024-28863

* Revert change to ip and add  "tar": "^6.2.1" fixing CVE-2024-28863

* Suppress CVE-2023-42282

* DIAC-226 added if statement to check for + or digit at start of string (#1040)

* DIAC-226 added if statement to check for + or digit at start of string

* Adding check at end of checks to fix other tests

* removed check to view tests

* Adding fix back in

* Updated known errors to try and fix tests

* Updated known errors messages

* Updated known errors messages

* Tring different validator method

* Reverting older changes

* Trying previous validator method

* Trying previous validator method

* Trying different method

* Refactoring expression

* changing regex pattern to be more strict to test

* updating package

* reverting dependency

* Trying different regex pattern

* Refactoring regex check

* Refactoring regex check more

* DIAC-226 adding regex to check start and end of number and updating phone code to work for international mobile numbers

* DIAC-226 test fix ?

* DIAC-226 test fix ?

* DIAC-226 test fix ?

* DIAC-226 test fix ?

* DIAC-226 test fix ?

* DIAC-226 test fix ?

* DIAC-226 test fix ?

* DIAC-226 test fix ?

* DIAC-226 updating checks for sponsor phonenumber to be UK only

* DIAC-226 updating error message content for sponsor contact phone number

* DIAC-226 fix

* DIAC-226 test fix

* DIAC-226 stopping a +44 number without the + as a sponsor contact preference to match case data validation

* DIAC-226 stopping a 0044 number as a sponsor contact preference to match case data validation

* DIAC-226 making sure only one + is allowed at start of number

---------





* RIA-TASK - NABA -> Master : DO NOT MERGE (#948)

* RIA-6132 AIP FTPA application (in time) (#911)

* RIA-6132: Appellant Submits FTPA Application - In Time

- Update the content of 'Do this next' section in 'decided' state according to spec
- Update the 'Do this next' section in 'decided' state to include link to ftpa appeal
- Add the event 'applyForFTPAAppellant' to the list of supported events
- Create controller, path/route, content and view for ftpa reason for appeal screen
- Create controller, path/route, content and view for ftpa grounds for appeal screen
- Create controllers, paths/routes, content and views for ftpa supporting evidence screens
- Create controller, path/route, content and view for ftpa check your answer screen
- Create controller, path/route, content and view for ftpa confirmation screen
- Update Overview page (timeline and 'Do this next' section) for 'ftpaSubmitted' state

* RIA-6132: Unit tests

* RIA-6132 Suppress vulnerabilities

* RIA-6132 Update test

* RIA-6132 Add application-state-utils test

* RIA-6132 Enable ftpa-applications test

* RIA-6132 Use feature flag for AIP FTPA

* RIA-6132 Style

* RIA-6132 Unwrap flag spy before restubbing it

* RIA-6132 Add functional test

* RIA-6132 Try to initialize LD for feature tests

* RIA-6132 Streamline feature test

---------



* RIA-6111: Appellant Submits FTPA Application - Out of Time (#914)

* RIA-6111: Appellant Submits FTPA Application - Out of Time

* RIA-6111: update smoke test config

* RIA-6111: persist ftpa application reasons in a new case field 'ftpaAppellantGrounds'

* RIA-6111: Implement a details viewer for ftpa appellant application

* RIA-6111: Fix issue with failing functional test

* RIA-611: Fix issue with failing unit test

* RIA-6111: 'ftpaAppellantGroundsDocuments' field is not available in Citizen's journey

* RIA-6971: Update timeline content post-decision (#915)

* RIA-6971: Update timeline content post-decision

* RIA-6971: Wrap feature under Launch darkly flag

* RIA-6111: Some formatting changes for CYA page (#921)

* RIA-6904: Appellant's view when a Judge makes decision on FTPA - HO (#920)

* RIA-6114 changes to the overview page (#918)

* RIA-6114 changes to the overview page

* suppressed vulnerabilities

* Changed content format and added tests

* Changed content format and added tests

* Suppressions

* Changed tests

* Appellant's view when a Judge makes decision on FTPA - Completed Section (#922)

* RIA-7037: Appellant's view when a Judge makes decision on FTPA - Completed Section

* RIA-7037: Updates for Resident judge ftpa decision

* RIA-6959: HO Makes An Application - Updates to Appellants Completed S… (#923)

* RIA-6959: HO Makes An Application - Updates to Appellants Completed Section & The Home Office Request Page

* RIA-6959: Fix the 'no-unnecessary-type-assertion' linting errors

* Tech Improvement: Upgrade to yarn 3

* Tech Improvement: Bump jsonwebtoken to version 9.0.0 and nunjucks to version 3.2.4

* RIA-7058 Enable FTPA Application in FTPA Submitted & Decided state for Appellant (#924)

* RIA-7058: Enable FTPA Application in FTPA Submitted & Decided state for Appellant

* RIA-7058: Clear local ftpa data at the start of a new application

* RIA-6998 Tribunal sends Non Standard Direction to the Appellant/HO - Update to Timeline Page (#928)

* RIA-6998 Tribunal sends Non Standard Direction to the Appellant/HO - Update to Timeline Page

* -fix the checkstyle problem

* -update the logic for more efficiency

* RIA-6516 Copy of PR for supplementary data (#926)

* RIA-7037: Fix issue with missing late FTPA application documents (#929)

* RIA-7058: Some updates on when to show/hide ftpa application link on side menu (#930)

* RIA-6999 Tribunal sends Non Standard Direction to the Appellant/HO - New Details Page (#931)

* RIA-6999 Tribunal sends Non Standard Direction to the Appellant/HO - New Details Page

* -update the logic from suggestion

* -Add the page of direction-history-view.njk (#932)

* RIA-6114 link to FTPA docs overview page (#935)

* RIA-6114 Link to FTPA docs when FTPA decided

* RIA-6114 Update unit test

* RIA-6959 Updates to Home Office Make application event timeline and details (#933)

* RIA-6959: HO application decision event should not appear on timeline

* RIA-6959: Hearing center email address should correspond to appeal's hearing center

* RIA-6959 Fix issues with application types and hearing centre emails (#938)

* RIA-6959: Fix issue with application type

* RIA-6959: Fix issue with 'Glasgow hearing centre email'

* RIA-7145: Appellant's view when HO Application has been decided (#936)

* RIA-7145: Appellant's view when HO Application has been decided

* RIA-7145: Sort history events based on created date

* RIA-7145: Update functional tests

* RIA-7151: Appellant's View when Home Office makes an FTPA Application (#937)

* RIA-7151 Appellant's View when Home Office makes an FTPA Application (issues fixes) (#942)

* RIA-7151: Best effort to determine applicant type in 'ftpaSubmitted' state

* RIA-7151: Get rid of the sorting for timeline events

* RIA-7188: Disable non FTPA features (For FTPA release preparation) (#943)

* RIA-7188: Disable non standard direction to AIP

* RIA-7188: Disable readonly application

* RIA-7056 Transfer to UT overview page toDoNext and timeline sections (#946)

* RIA-7056
* Added transferToUt content for toDoNext section of overview page
* Dynamically returned correct dict for doThisNext for ended state depending on if utAppealReferenceNumber is present
* Added utility to check if appeal ended state reached via transferToUT event
* Added transferToUT event for timeline
* Added markAsReadyForUtTransfer event
* Added markAsReadyForUtTransfer event to appealArgument section
* Added utAppealReferenceNumber to appeal interface
* Added utAppealReferenceNumber to service class so that it can be read from case data
* Updated tests

* RIA-7056 - Fixed test

---------



* RIA-7056 (#953)

* Content changes

* RIA-7056 (#954)

* Separating 2 pieces of text with a new line

* RIA-TASK - Merge master changes to NABA - ia-aip-frontend (#1031)

* To merge AIP FTPA changes to master (#944)

* RIA-6132 AIP FTPA application (in time) (#911)

* RIA-6132: Appellant Submits FTPA Application - In Time

- Update the content of 'Do this next' section in 'decided' state according to spec
- Update the 'Do this next' section in 'decided' state to include link to ftpa appeal
- Add the event 'applyForFTPAAppellant' to the list of supported events
- Create controller, path/route, content and view for ftpa reason for appeal screen
- Create controller, path/route, content and view for ftpa grounds for appeal screen
- Create controllers, paths/routes, content and views for ftpa supporting evidence screens
- Create controller, path/route, content and view for ftpa check your answer screen
- Create controller, path/route, content and view for ftpa confirmation screen
- Update Overview page (timeline and 'Do this next' section) for 'ftpaSubmitted' state

* RIA-6132: Unit tests

* RIA-6132 Suppress vulnerabilities

* RIA-6132 Update test

* RIA-6132 Add application-state-utils test

* RIA-6132 Enable ftpa-applications test

* RIA-6132 Use feature flag for AIP FTPA

* RIA-6132 Style

* RIA-6132 Unwrap flag spy before restubbing it

* RIA-6132 Add functional test

* RIA-6132 Try to initialize LD for feature tests

* RIA-6132 Streamline feature test

---------



* RIA-6111: Appellant Submits FTPA Application - Out of Time (#914)

* RIA-6111: Appellant Submits FTPA Application - Out of Time

* RIA-6111: update smoke test config

* RIA-6111: persist ftpa application reasons in a new case field 'ftpaAppellantGrounds'

* RIA-6111: Implement a details viewer for ftpa appellant application

* RIA-6111: Fix issue with failing functional test

* RIA-611: Fix issue with failing unit test

* RIA-6111: 'ftpaAppellantGroundsDocuments' field is not available in Citizen's journey

* RIA-6971: Update timeline content post-decision (#915)

* RIA-6971: Update timeline content post-decision

* RIA-6971: Wrap feature under Launch darkly flag

* RIA-6111: Some formatting changes for CYA page (#921)

* RIA-6904: Appellant's view when a Judge makes decision on FTPA - HO (#920)

* RIA-6114 changes to the overview page (#918)

* RIA-6114 changes to the overview page

* suppressed vulnerabilities

* Changed content format and added tests

* Changed content format and added tests

* Suppressions

* Changed tests

* Appellant's view when a Judge makes decision on FTPA - Completed Section (#922)

* RIA-7037: Appellant's view when a Judge makes decision on FTPA - Completed Section

* RIA-7037: Updates for Resident judge ftpa decision

* RIA-6959: HO Makes An Application - Updates to Appellants Completed S… (#923)

* RIA-6959: HO Makes An Application - Updates to Appellants Completed Section & The Home Office Request Page

* RIA-6959: Fix the 'no-unnecessary-type-assertion' linting errors

* Tech Improvement: Upgrade to yarn 3

* Tech Improvement: Bump jsonwebtoken to version 9.0.0 and nunjucks to version 3.2.4

* RIA-7058 Enable FTPA Application in FTPA Submitted & Decided state for Appellant (#924)

* RIA-7058: Enable FTPA Application in FTPA Submitted & Decided state for Appellant

* RIA-7058: Clear local ftpa data at the start of a new application

* RIA-6998 Tribunal sends Non Standard Direction to the Appellant/HO - Update to Timeline Page (#928)

* RIA-6998 Tribunal sends Non Standard Direction to the Appellant/HO - Update to Timeline Page

* -fix the checkstyle problem

* -update the logic for more efficiency

* RIA-6516 Copy of PR for supplementary data (#926)

* RIA-7037: Fix issue with missing late FTPA application documents (#929)

* RIA-7058: Some updates on when to show/hide ftpa application link on side menu (#930)

* RIA-6999 Tribunal sends Non Standard Direction to the Appellant/HO - New Details Page (#931)

* RIA-6999 Tribunal sends Non Standard Direction to the Appellant/HO - New Details Page

* -update the logic from suggestion

* -Add the page of direction-history-view.njk (#932)

* RIA-6114 link to FTPA docs overview page (#935)

* RIA-6114 Link to FTPA docs when FTPA decided

* RIA-6114 Update unit test

* RIA-6959 Updates to Home Office Make application event timeline and details (#933)

* RIA-6959: HO application decision event should not appear on timeline

* RIA-6959: Hearing center email address should correspond to appeal's hearing center

* RIA-6959 Fix issues with application types and hearing centre emails (#938)

* RIA-6959: Fix issue with application type

* RIA-6959: Fix issue with 'Glasgow hearing centre email'

* RIA-7145: Appellant's view when HO Application has been decided (#936)

* RIA-7145: Appellant's view when HO Application has been decided

* RIA-7145: Sort history events based on created date

* RIA-7145: Update functional tests

* RIA-7151: Appellant's View when Home Office makes an FTPA Application (#937)

* RIA-7151 Appellant's View when Home Office makes an FTPA Application (issues fixes) (#942)

* RIA-7151: Best effort to determine applicant type in 'ftpaSubmitted' state

* RIA-7151: Get rid of the sorting for timeline events

* RIA-7188: Disable non FTPA features (For FTPA release preparation) (#943)

* RIA-7188: Disable non standard direction to AIP

* RIA-7188: Disable readonly application

---------






* Merge decision without hearing changes to master (#949)

* RIA-6132 AIP FTPA application (in time) (#911)

* RIA-6132: Appellant Submits FTPA Application - In Time

- Update the content of 'Do this next' section in 'decided' state according to spec
- Update the 'Do this next' section in 'decided' state to include link to ftpa appeal
- Add the event 'applyForFTPAAppellant' to the list of supported events
- Create controller, path/route, content and view for ftpa reason for appeal screen
- Create controller, path/route, content and view for ftpa grounds for appeal screen
- Create controllers, paths/routes, content and views for ftpa supporting evidence screens
- Create controller, path/route, content and view for ftpa check your answer screen
- Create controller, path/route, content and view for ftpa confirmation screen
- Update Overview page (timeline and 'Do this next' section) for 'ftpaSubmitted' state

* RIA-6132: Unit tests

* RIA-6132 Suppress vulnerabilities

* RIA-6132 Update test

* RIA-6132 Add application-state-utils test

* RIA-6132 Enable ftpa-applications test

* RIA-6132 Use feature flag for AIP FTPA

* RIA-6132 Style

* RIA-6132 Unwrap flag spy before restubbing it

* RIA-6132 Add functional test

* RIA-6132 Try to initialize LD for feature tests

* RIA-6132 Streamline feature test

---------



* RIA-6111: Appellant Submits FTPA Application - Out of Time (#914)

* RIA-6111: Appellant Submits FTPA Application - Out of Time

* RIA-6111: update smoke test config

* RIA-6111: persist ftpa application reasons in a new case field 'ftpaAppellantGrounds'

* RIA-6111: Implement a details viewer for ftpa appellant application

* RIA-6111: Fix issue with failing functional test

* RIA-611: Fix issue with failing unit test

* RIA-6111: 'ftpaAppellantGroundsDocuments' field is not available in Citizen's journey

* RIA-6971: Update timeline content post-decision (#915)

* RIA-6971: Update timeline content post-decision

* RIA-6971: Wrap feature under Launch darkly flag

* RIA-6111: Some formatting changes for CYA page (#921)

* RIA-6904: Appellant's view when a Judge makes decision on FTPA - HO (#920)

* RIA-6114 changes to the overview page (#918)

* RIA-6114 changes to the overview page

* suppressed vulnerabilities

* Changed content format and added tests

* Changed content format and added tests

* Suppressions

* Changed tests

* Appellant's view when a Judge makes decision on FTPA - Completed Section (#922)

* RIA-7037: Appellant's view when a Judge makes decision on FTPA - Completed Section

* RIA-7037: Updates for Resident judge ftpa decision

* RIA-6959: HO Makes An Application - Updates to Appellants Completed S… (#923)

* RIA-6959: HO Makes An Application - Updates to Appellants Completed Section & The Home Office Request Page

* RIA-6959: Fix the 'no-unnecessary-type-assertion' linting errors

* Tech Improvement: Upgrade to yarn 3

* Tech Improvement: Bump jsonwebtoken to version 9.0.0 and nunjucks to version 3.2.4

* RIA-7058 Enable FTPA Application in FTPA Submitted & Decided state for Appellant (#924)

* RIA-7058: Enable FTPA Application in FTPA Submitted & Decided state for Appellant

* RIA-7058: Clear local ftpa data at the start of a new application

* RIA-6998 Tribunal sends Non Standard Direction to the Appellant/HO - Update to Timeline Page (#928)

* RIA-6998 Tribunal sends Non Standard Direction to the Appellant/HO - Update to Timeline Page

* -fix the checkstyle problem

* -update the logic for more efficiency

* RIA-6516 Copy of PR for supplementary data (#926)

* RIA-7037: Fix issue with missing late FTPA application documents (#929)

* RIA-7058: Some updates on when to show/hide ftpa application link on side menu (#930)

* RIA-6999 Tribunal sends Non Standard Direction to the Appellant/HO - New Details Page (#931)

* RIA-6999 Tribunal sends Non Standard Direction to the Appellant/HO - New Details Page

* -update the logic from suggestion

* -Add the page of direction-history-view.njk (#932)

* RIA-6114 link to FTPA docs overview page (#935)

* RIA-6114 Link to FTPA docs when FTPA decided

* RIA-6114 Update unit test

* RIA-6959 Updates to Home Office Make application event timeline and details (#933)

* RIA-6959: HO application decision event should not appear on timeline

* RIA-6959: Hearing center email address should correspond to appeal's hearing center

* RIA-6959 Fix issues with application types and hearing centre emails (#938)

* RIA-6959: Fix issue with application type

* RIA-6959: Fix issue with 'Glasgow hearing centre email'

* RIA-7145: Appellant's view when HO Application has been decided (#936)

* RIA-7145: Appellant's view when HO Application has been decided

* RIA-7145: Sort history events based on created date

* RIA-7145: Update functional tests

* RIA-7151: Appellant's View when Home Office makes an FTPA Application (#937)

* RIA-7151 Appellant's View when Home Office makes an FTPA Application (issues fixes) (#942)

* RIA-7151: Best effort to determine applicant type in 'ftpaSubmitted' state

* RIA-7151: Get rid of the sorting for timeline events

* RIA-6248: Update to Appellant's Timeline Page when LO triggers DWH event

* Update timeline-utils.ts

* Update timeline-utils.test.ts

* Update timeline-utils.ts

* Update application-state-utils.ts

---------






* RIA-6401 patching critical vulns (#860)






* AIP FTPA Read Only -> Master (#951)

* RIA-6132 AIP FTPA application (in time) (#911)

* RIA-6132: Appellant Submits FTPA Application - In Time

- Update the content of 'Do this next' section in 'decided' state according to spec
- Update the 'Do this next' section in 'decided' state to include link to ftpa appeal
- Add the event 'applyForFTPAAppellant' to the list of supported events
- Create controller, path/route, content and view for ftpa reason for appeal screen
- Create controller, path/route, content and view for ftpa grounds for appeal screen
- Create controllers, paths/routes, content and views for ftpa supporting evidence screens
- Create controller, path/route, content and view for ftpa check your answer screen
- Create controller, path/route, content and view for ftpa confirmation screen
- Update Overview page (timeline and 'Do this next' section) for 'ftpaSubmitted' state

* RIA-6132: Unit tests

* RIA-6132 Suppress vulnerabilities

* RIA-6132 Update test

* RIA-6132 Add application-state-utils test

* RIA-6132 Enable ftpa-applications test

* RIA-6132 Use feature flag for AIP FTPA

* RIA-6132 Style

* RIA-6132 Unwrap flag spy before restubbing it

* RIA-6132 Add functional test

* RIA-6132 Try to initialize LD for feature tests

* RIA-6132 Streamline feature test

---------



* RIA-6111: Appellant Submits FTPA Application - Out of Time (#914)

* RIA-6111: Appellant Submits FTPA Application - Out of Time

* RIA-6111: update smoke test config

* RIA-6111: persist ftpa application reasons in a new case field 'ftpaAppellantGrounds'

* RIA-6111: Implement a details viewer for ftpa appellant application

* RIA-6111: Fix issue with failing functional test

* RIA-611: Fix issue with failing unit test

* RIA-6111: 'ftpaAppellantGroundsDocuments' field is not available in Citizen's journey

* RIA-6971: Update timeline content post-decision (#915)

* RIA-6971: Update timeline content post-decision

* RIA-6971: Wrap feature under Launch darkly flag

* RIA-6111: Some formatting changes for CYA page (#921)

* RIA-6904: Appellant's view when a Judge makes decision on FTPA - HO (#920)

* RIA-6114 changes to the overview page (#918)

* RIA-6114 changes to the overview page

* suppressed vulnerabilities

* Changed content format and added tests

* Changed content format and added tests

* Suppressions

* Changed tests

* Appellant's view when a Judge makes decision on FTPA - Completed Section (#922)

* RIA-7037: Appellant's view when a Judge makes decision on FTPA - Completed Section

* RIA-7037: Updates for Resident judge ftpa decision

* RIA-6959: HO Makes An Application - Updates to Appellants Completed S… (#923)

* RIA-6959: HO Makes An Application - Updates to Appellants Completed Section & The Home Office Request Page

* RIA-6959: Fix the 'no-unnecessary-type-assertion' linting errors

* Tech Improvement: Upgrade to yarn 3

* Tech Improvement: Bump jsonwebtoken to version 9.0.0 and nunjucks to version 3.2.4

* RIA-7058 Enable FTPA Application in FTPA Submitted & Decided state for Appellant (#924)

* RIA-7058: Enable FTPA Application in FTPA Submitted & Decided state for Appellant

* RIA-7058: Clear local ftpa data at the start of a new application

* RIA-6998 Tribunal sends Non Standard Direction to the Appellant/HO - Update to Timeline Page (#928)

* RIA-6998 Tribunal sends Non Standard Direction to the Appellant/HO - Update to Timeline Page

* -fix the checkstyle problem

* -update the logic for more efficiency

* RIA-6516 Copy of PR for supplementary data (#926)

* RIA-7037: Fix issue with missing late FTPA application documents (#929)

* RIA-7058: Some updates on when to show/hide ftpa application link on side menu (#930)

* RIA-6999 Tribunal sends Non Standard Direction to the Appellant/HO - New Details Page (#931)

* RIA-6999 Tribunal sends Non Standard Direction to the Appellant/HO - New Details Page

* -update the logic from suggestion

* -Add the page of direction-history-view.njk (#932)

* RIA-6114 link to FTPA docs overview page (#935)

* RIA-6114 Link to FTPA docs when FTPA decided

* RIA-6114 Update unit test

* RIA-6959 Updates to Home Office Make application event timeline and details (#933)

* RIA-6959: HO application decision event should not appear on timeline

* RIA-6959: Hearing center email address should correspond to appeal's hearing center

* RIA-6959 Fix issues with application types and hearing centre emails (#938)

* RIA-6959: Fix issue with application type

* RIA-6959: Fix issue with 'Glasgow hearing centre email'

* RIA-7145: Appellant's view when HO Application has been decided (#936)

* RIA-7145: Appellant's view when HO Application has been decided

* RIA-7145: Sort history events based on created date

* RIA-7145: Update functional tests

* RIA-7151: Appellant's View when Home Office makes an FTPA Application (#937)

* RIA-7151 Appellant's View when Home Office makes an FTPA Application (issues fixes) (#942)

* RIA-7151: Best effort to determine applicant type in 'ftpaSubmitted' state

* RIA-7151: Get rid of the sorting for timeline events

* RIA-6248: Update to Appellant's Timeline Page when LO triggers DWH event (#947)

* updates to enable read only application

---------






* AIP FTPA -> Master (DO NOT MERGE) (#925)

* RIA-6132 AIP FTPA application (in time) (#911)

* RIA-6132: Appellant Submits FTPA Application - In Time

- Update the content of 'Do this next' section in 'decided' state according to spec
- Update the 'Do this next' section in 'decided' state to include link to ftpa appeal
- Add the event 'applyForFTPAAppellant' to the list of supported events
- Create controller, path/route, content and view for ftpa reason for appeal screen
- Create controller, path/route, content and view for ftpa grounds for appeal screen
- Create controllers, paths/routes, content and views for ftpa supporting evidence screens
- Create controller, path/route, content and view for ftpa check your answer screen
- Create controller, path/route, content and view for ftpa confirmation screen
- Update Overview page (timeline and 'Do this next' section) for 'ftpaSubmitted' state

* RIA-6132: Unit tests

* RIA-6132 Suppress vulnerabilities

* RIA-6132 Update test

* RIA-6132 Add application-state-utils test

* RIA-6132 Enable ftpa-applications test

* RIA-6132 Use feature flag for AIP FTPA

* RIA-6132 Style

* RIA-6132 Unwrap flag spy before restubbing it

* RIA-6132 Add functional test

* RIA-6132 Try to initialize LD for feature tests

* RIA-6132 Streamline feature test

---------



* RIA-6111: Appellant Submits FTPA Application - Out of Time (#914)

* RIA-6111: Appellant Submits FTPA Application - Out of Time

* RIA-6111: update smoke test config

* RIA-6111: persist ftpa application reasons in a new case field 'ftpaAppellantGrounds'

* RIA-6111: Implement a details viewer for ftpa appellant application

* RIA-6111: Fix issue with failing functional test

* RIA-611: Fix issue with failing unit test

* RIA-6111: 'ftpaAppellantGroundsDocuments' field is not available in Citizen's journey

* RIA-6971: Update timeline content post-decision (#915)

* RIA-6971: Update timeline content post-decision

* RIA-6971: Wrap feature under Launch darkly flag

* RIA-6111: Some formatting changes for CYA page (#921)

* RIA-6904: Appellant's view when a Judge makes decision on FTPA - HO (#920)

* RIA-6114 changes to the overview page (#918)

* RIA-6114 changes to the overview page

* suppressed vulnerabilities

* Changed content format and added tests

* Changed content format and added tests

* Suppressions

* Changed tests

* Appellant's view when a Judge makes decision on FTPA - Completed Section (#922)

* RIA-7037: Appellant's view when a Judge makes decision on FTPA - Completed Section

* RIA-7037: Updates for Resident judge ftpa decision

* RIA-6959: HO Makes An Application - Updates to Appellants Completed S… (#923)

* RIA-6959: HO Makes An Application - Updates to Appellants Completed Section & The Home Office Request Page

* RIA-6959: Fix the 'no-unnecessary-type-assertion' linting errors

* Tech Improvement: Upgrade to yarn 3

* Tech Improvement: Bump jsonwebtoken to version 9.0.0 and nunjucks to version 3.2.4

* RIA-7058 Enable FTPA Application in FTPA Submitted & Decided state for Appellant (#924)

* RIA-7058: Enable FTPA Application in FTPA Submitted & Decided state for Appellant

* RIA-7058: Clear local ftpa data at the start of a new application

* RIA-6998 Tribunal sends Non Standard Direction to the Appellant/HO - Update to Timeline Page (#928)

* RIA-6998 Tribunal sends Non Standard Direction to the Appellant/HO - Update to Timeline Page

* -fix the checkstyle problem

* -update the logic for more efficiency

* RIA-6516 Copy of PR for supplementary data (#926)

* RIA-7037: Fix issue with missing late FTPA application documents (#929)

* RIA-7058: Some updates on when to show/hide ftpa application link on side menu (#930)

* RIA-6999 Tribunal sends Non Standard Direction to the Appellant/HO - New Details Page (#931)

* RIA-6999 Tribunal sends Non Standard Direction to the Appellant/HO - New Details Page

* -update the logic from suggestion

* -Add the page of direction-history-view.njk (#932)

* RIA-6114 link to FTPA docs overview page (#935)

* RIA-6114 Link to FTPA docs when FTPA decided

* RIA-6114 Update unit test

* RIA-6959 Updates to Home Office Make application event timeline and details (#933)

* RIA-6959: HO application decision event should not appear on timeline

* RIA-6959: Hearing center email address should correspond to appeal's hearing center

* RIA-6959 Fix issues with application types and hearing centre emails (#938)

* RIA-6959: Fix issue with application type

* RIA-6959: Fix issue with 'Glasgow hearing centre email'

* RIA-7145: Appellant's view when HO Application has been decided (#936)

* RIA-7145: Appellant's view when HO Application has been decided

* RIA-7145: Sort history events based on created date

* RIA-7145: Update functional tests

* RIA-7151: Appellant's View when Home Office makes an FTPA Application (#937)

* RIA-7151 Appellant's View when Home Office makes an FTPA Application (issues fixes) (#942)

* RIA-7151: Best effort to determine applicant type in 'ftpaSubmitted' state

* RIA-7151: Get rid of the sorting for timeline events

* RIA-6248: Update to Appellant's Timeline Page when LO triggers DWH event (#947)

* Updates to enable non standard direction

---------






* RIA-6860 - Duplicate IDs on about-appeal page (#934)



* RIA-7344 upgrade to redis v6 (#955)



* Revert "RIA-7344 upgrade to redis v6" (#956)

* update to fix yarn issue (#957)

* update to fix yarn issue

* update to fix yarn issue

* Yarn recursive fix

* Yarn recursive fix

---------



* Redis cache name change (#958)

* Redis upgrade (again) (#959)

* Removing redis from terraform config (#960)

* Removing redis secrets (#961)



* Allowing deletion of cache (#962)

* Allowing deletion of cache

* Reverting multiple commits to re-instate Redis 6 (#963)

* RIA-7384 Enforce conventions on commit messages and branches (#965)

* RIA-0000 - INC5521937 - Corrective action (#964)

* RIA-5804 CDAM changes with feature flag (#966)



* RIA-TASK (RIA-5804) Temporarily suppressing vulnerabilities

* RIA-6817 - added fortify scan + required gradle project components (#995)

* RIA-6817 - added fortify scan + required gradle project components

* RIA-6817 - update suppressions

* RIA-6817 - update suppressions

* RIA-6817 - update suppressions

* RIA-7834 Accessibility fix mass deployment (#996)

* RIA-7858 upgrade node and dependencies (#997)

* upgrading node version and dependencies, adding required .nvmrc and renovate.json files and tests

* pr-build

* fixing suppressions

* Update nodejs chart version to 3.0.0

* Bumping chart version/ fixing aliases

* pr-build

* Yarn audit

---------




* DIAC-000 - Update memory limits (#1015)

* Update memory limits

* Bumping chart version/ fixing aliases

* Add DIAC pr-validation

* Add yarn suppressions

---------



* RIA-7643 Updated appeal submitted page with feedback (#979)

* RIA-7643 audit update

* RIA-7643 Updated appeal submitted page with feedback box and link

* RIA-7643 adding blue border around new feedback box

* RIA-7643 - suppression update

* RIA-7643 update and fix

* RIA-7643 update content and box resized

* RIA-7643 fixes

* suppression update

* Add renovate.json

* Add nvmrc file with node version

* Upgrade nodejs version to 18.16.0

---------




* RIA-7682 removing previous exit survey link (#978)

* RIA-7682 Removing instances of the previous exit survey link and titles

* RIA-7682 audit update

* RIA-7682 - suppression update

---------



* RIA-7772-Fixing-Dynatrace-Monitoring (#992)



* DIAC-48 nightly fixes (#1016)

* DIAC-96 get rid of timezone offset in dateuploaded for reasons for appeal additional evidence (#1006)

* DIAC-123 small nightly parameter fix (#1017)

* DIAC-002 fixing renovate JSON (#1018)

* DIAC-105 turning fortify on (#1024)

* DIAC-105 turning fortify on

* DIAC-105 dependency suppression

* DIAC-105 dependency suppression

* DIAC-105 setting up fortify

* DIAC-105 setting up fortify

* DIAC-71 adding pa11y in properly and fixing some flakiness (#1028)

* DIAC-220 await request stuff to fix s2s issues in aat (#1029)

* await request stuff to fix s2s issues in aat

* test ?

* test ?

* test ?

* test ?

* test ?

---------



* RIA-TASK - Merge master changes to NABA - ia-aip-frontend

* Update README.md

---------





















* RIA-8609 - Cherry picked from commit af0707a8 09/02/2024 to f2895a23 22/02/2024 (#1059)

* RIA-8609 - Cherry picked from commit af0707a8 09/02/2024 to f2895a23 22/02/2024

* Suppress vul 1096571

* Cherry picked commits from b4cf4db8 27/02/24 to 1be32aa4 01/03/24

* Suppress CVE

* Suppress cve (#1109)

* Cherry picked from ec875b17 03/04/2024 to 5b946bfa 11/04/2024 (#1120)

* DIAC-226 added if statement to check for + or digit at start of string (#1040)

* DIAC-226 added if statement to check for + or digit at start of string

* Adding check at end of checks to fix other tests

* removed check to view tests

* Adding fix back in

* Updated known errors to try and fix tests

* Updated known errors messages

* Updated known errors messages

* Tring different validator method

* Reverting older changes

* Trying previous validator method

* Trying previous validator method

* Trying different method

* Refactoring expression

* changing regex pattern to be more strict to test

* updating package

* reverting dependency

* Trying different regex pattern

* Refactoring regex check

* Refactoring regex check more

* DIAC-226 adding regex to check start and end of number and updating phone code to work for international mobile numbers

* DIAC-226 test fix ?

* DIAC-226 test fix ?

* DIAC-226 test fix ?

* DIAC-226 test fix ?

* DIAC-226 test fix ?

* DIAC-226 test fix ?

* DIAC-226 test fix ?

* DIAC-226 test fix ?

* DIAC-226 updat…

### Jira link

<!-- 
Replace PROJ-XXXXXX with your Jira key
Remove this section if its not applicable, or replace it with another reference link
-->
See [PROJ-XXXXXX](https://tools.hmcts.net/jira/browse/PROJ-XXXXXX)

### Change description

<!--
Provide a description of what change you are proposing.
A short summary here and then you can add comments in your pull request explaining your change to others.
-->

### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is not always complete, so a successful pull request build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [ ] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
