### PR TITLE
DIAC-0000 - removed repeated line of text and added test directory to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ public
 dump.rdb
 build
 test/coverage
+mochawesome-report/
 functional-output
 .env
 output

--- a/locale/en.json
+++ b/locale/en.json
@@ -2177,7 +2177,6 @@
             "title": "What a Tribunal Caseworker can’t do",
             "content": [
               "A Tribunal Caseworker cannot:",
-              "A Tribunal Caseworker cannot:",
               "<ul class='govuk-list govuk-list--bullet'><li>offer legal advice</li><li>go to a hearing with you</li><li>decide the outcome of your appeal</li></ul>"
             ]
           }


### PR DESCRIPTION
This change corrects a mistake in the text on the [tribunal case-worker page](https://immigration-appeal.aat.platform.hmcts.net/tribunal-caseworker), where there is a repeated line of text:

**What a Tribunal Caseworker can’t do**

A Tribunal Caseworker cannot:

A Tribunal Caseworker cannot:

It also adds the `mochawesome-report/` directory to `.gitignore`.